### PR TITLE
feat: add sleep timer

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
+++ b/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
@@ -4,6 +4,7 @@ import android.app.PendingIntent
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.os.SystemClock
 import android.util.Log
 import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
@@ -26,20 +27,28 @@ import androidx.media3.session.SessionError
 import androidx.media3.session.SessionResult
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
+import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_CANCEL
+import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_SET
 import com.shapeshed.aerial.data.Provider
 import com.shapeshed.aerial.data.NowPlayingInfo
 import com.shapeshed.aerial.data.NowPlayingStore
+import com.shapeshed.aerial.data.SLEEP_TIMER_DURATION_MS
+import com.shapeshed.aerial.data.SleepTimerState
+import com.shapeshed.aerial.data.SleepTimerStore
 import com.shapeshed.aerial.data.Station
 import com.shapeshed.aerial.data.StationRepository
 import com.shapeshed.aerial.data.parseIcyTitle
 import com.shapeshed.aerial.ENRICH_METADATA_KEY
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -48,6 +57,9 @@ class PlayerService : MediaSessionService() {
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val favoriteCommand = SessionCommand(ACTION_TOGGLE_FAVORITE, Bundle.EMPTY)
+    private val sleepTimerSetCommand = SessionCommand(ACTION_SLEEP_TIMER_SET, Bundle.EMPTY)
+    private val sleepTimerCancelCommand = SessionCommand(ACTION_SLEEP_TIMER_CANCEL, Bundle.EMPTY)
+    private var sleepTimerJob: Job? = null
 
     private lateinit var player: ExoPlayer
     private lateinit var mediaSession: MediaSession
@@ -226,6 +238,8 @@ class PlayerService : MediaSessionService() {
                     MediaSession.ConnectionResult.DEFAULT_SESSION_COMMANDS
                         .buildUpon()
                         .add(favoriteCommand)
+                        .add(sleepTimerSetCommand)
+                        .add(sleepTimerCancelCommand)
                         .build()
                 )
                 .build()
@@ -237,20 +251,30 @@ class PlayerService : MediaSessionService() {
             customCommand: SessionCommand,
             args: Bundle,
         ): ListenableFuture<SessionResult> {
-            if (customCommand.customAction != ACTION_TOGGLE_FAVORITE) {
-                return super.onCustomCommand(session, controller, customCommand, args)
-            }
-            val station = currentStation()
-                ?: return Futures.immediateFuture(SessionResult(SessionError.ERROR_INVALID_STATE))
-            serviceScope.launch {
-                val updatedStation = station.copy(isFavorite = !station.isFavorite)
-                withContext(Dispatchers.IO) {
-                    repository.update(updatedStation)
+            when (customCommand.customAction) {
+                ACTION_SLEEP_TIMER_SET -> {
+                    startSleepTimer(args.getLong(SLEEP_TIMER_DURATION_MS, 0L))
+                    return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
                 }
-                stations = stations.map { if (it.id == updatedStation.id) updatedStation else it }
-                updateFavoriteButton()
+                ACTION_SLEEP_TIMER_CANCEL -> {
+                    cancelSleepTimer()
+                    return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
+                }
+                ACTION_TOGGLE_FAVORITE -> {
+                    val station = currentStation()
+                        ?: return Futures.immediateFuture(SessionResult(SessionError.ERROR_INVALID_STATE))
+                    serviceScope.launch {
+                        val updatedStation = station.copy(isFavorite = !station.isFavorite)
+                        withContext(Dispatchers.IO) {
+                            repository.update(updatedStation)
+                        }
+                        stations = stations.map { if (it.id == updatedStation.id) updatedStation else it }
+                        updateFavoriteButton()
+                    }
+                    return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
+                }
+                else -> return super.onCustomCommand(session, controller, customCommand, args)
             }
-            return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
         }
     }
 
@@ -269,6 +293,48 @@ class PlayerService : MediaSessionService() {
             .setEnabled(station != null)
             .setSessionCommand(favoriteCommand)
             .build()
+    }
+
+    private fun startSleepTimer(durationMs: Long) {
+        sleepTimerJob?.cancel()
+        if (durationMs <= 0L) {
+            cancelSleepTimer()
+            return
+        }
+        player.volume = 1f // clear any leftover fade from a previous timer
+        val endAt = SystemClock.elapsedRealtime() + durationMs
+        sleepTimerJob = serviceScope.launch {
+            while (isActive) {
+                val remaining = endAt - SystemClock.elapsedRealtime()
+                if (remaining <= 0L) break
+                SleepTimerStore.set(SleepTimerState(totalMs = durationMs, remainingMs = remaining))
+                delay(remaining.coerceAtMost(1_000L))
+            }
+            fadeOutAndPause()
+        }
+    }
+
+    private fun cancelSleepTimer() {
+        sleepTimerJob?.cancel()
+        sleepTimerJob = null
+        player.volume = 1f // undo any in-progress fade
+        SleepTimerStore.set(null)
+    }
+
+    // Ease the volume down over ~4s so the timer doesn't cut playback off abruptly, then pause.
+    // Volume is restored so the next play() isn't silent. Cancellation mid-fade is handled by
+    // cancelSleepTimer(), which resets the volume.
+    private suspend fun fadeOutAndPause() {
+        val startVolume = player.volume
+        val steps = 20
+        for (i in 1..steps) {
+            player.volume = startVolume * (1f - i / steps.toFloat())
+            delay(FADE_STEP_MS)
+        }
+        player.pause()
+        player.volume = 1f
+        sleepTimerJob = null
+        SleepTimerStore.set(null)
     }
 
     private fun currentStation(): Station? = stationForMediaItem(player.currentMediaItem)
@@ -368,6 +434,7 @@ class PlayerService : MediaSessionService() {
 
     override fun onDestroy() {
         serviceScope.cancel()
+        SleepTimerStore.set(null)
         activeEnricher?.stop()
         activeEnricher = null
         player.removeListener(icyListener)
@@ -391,5 +458,6 @@ class PlayerService : MediaSessionService() {
     private companion object {
         const val TAG = "AerialPlayerService"
         const val ACTION_TOGGLE_FAVORITE = "com.shapeshed.aerial.action.TOGGLE_FAVORITE"
+        const val FADE_STEP_MS = 200L
     }
 }

--- a/app/src/main/java/com/shapeshed/aerial/data/SleepTimer.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/SleepTimer.kt
@@ -1,0 +1,27 @@
+package com.shapeshed.aerial.data
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+// Session command actions for the sleep timer. Defined here (rather than on PlayerService's
+// private companion) so both the service and the MediaController side can share them.
+const val ACTION_SLEEP_TIMER_SET = "com.shapeshed.aerial.action.SLEEP_TIMER_SET"
+const val ACTION_SLEEP_TIMER_CANCEL = "com.shapeshed.aerial.action.SLEEP_TIMER_CANCEL"
+const val SLEEP_TIMER_DURATION_MS = "durationMs"
+
+/** Snapshot of a running sleep timer. Null in the store means no timer is active. */
+data class SleepTimerState(
+    val totalMs: Long,
+    val remainingMs: Long,
+)
+
+/**
+ * Process-wide holder for the active sleep-timer countdown, mirroring [NowPlayingStore].
+ * PlayerService owns the countdown and publishes ticks here; the UI collects them.
+ */
+object SleepTimerStore {
+    private val _state = MutableStateFlow<SleepTimerState?>(null)
+    val state: StateFlow<SleepTimerState?> = _state.asStateFlow()
+    fun set(state: SleepTimerState?) { _state.value = state }
+}

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -179,6 +179,7 @@ fun MainScreen(
     val currentTrackArtworkData by viewModel.currentTrackArtworkData.collectAsStateWithLifecycle()
     val currentTrackArtworkUrl by viewModel.currentTrackArtworkUrl.collectAsStateWithLifecycle()
     val nowPlayingInfo by viewModel.nowPlayingInfo.collectAsStateWithLifecycle()
+    val sleepTimer by viewModel.sleepTimer.collectAsStateWithLifecycle()
     val playbackError by viewModel.playbackError.collectAsStateWithLifecycle()
     val recentlyAddedStationId by viewModel.recentlyAddedStationId.collectAsStateWithLifecycle()
     val isOnline by viewModel.isOnline.collectAsStateWithLifecycle()
@@ -488,8 +489,11 @@ fun MainScreen(
                     currentTrackTitle = currentTrackTitle,
                     currentTrackArtworkData = currentTrackArtworkData,
                     currentTrackArtworkUrl = currentTrackArtworkUrl,
+                    sleepTimer = sleepTimer,
                     onToggle = { viewModel.togglePlayback() },
                     onToggleFavorite = { viewModel.toggleFavorite(station) },
+                    onSetSleepTimer = { viewModel.setSleepTimer(it) },
+                    onCancelSleepTimer = { viewModel.cancelSleepTimer() },
                     onDismiss = { viewModel.setShowNowPlaying(false) },
                 )
             } else {

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -22,14 +22,20 @@ import androidx.media3.common.MediaMetadata
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.session.MediaController
+import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionToken
 import androidx.core.content.ContextCompat
 import com.shapeshed.aerial.AerialApp
 import com.shapeshed.aerial.PlayerService
+import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_CANCEL
+import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_SET
 import com.shapeshed.aerial.data.NowPlayingInfo
 import com.shapeshed.aerial.data.NowPlayingStore
 import com.shapeshed.aerial.data.RegistryRepository
 import com.shapeshed.aerial.data.RegistryStation
+import com.shapeshed.aerial.data.SLEEP_TIMER_DURATION_MS
+import com.shapeshed.aerial.data.SleepTimerState
+import com.shapeshed.aerial.data.SleepTimerStore
 import com.shapeshed.aerial.data.Station
 import com.shapeshed.aerial.data.StationRepository
 import com.shapeshed.aerial.data.bauerStreamUrl
@@ -152,6 +158,22 @@ class MainViewModel(
 
     val nowPlayingInfo: StateFlow<NowPlayingInfo?> = NowPlayingStore.state
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+
+    val sleepTimer: StateFlow<SleepTimerState?> = SleepTimerStore.state
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+
+    fun setSleepTimer(durationMs: Long) {
+        val ctrl = controller ?: return
+        ctrl.sendCustomCommand(
+            SessionCommand(ACTION_SLEEP_TIMER_SET, Bundle.EMPTY),
+            Bundle().apply { putLong(SLEEP_TIMER_DURATION_MS, durationMs) },
+        )
+    }
+
+    fun cancelSleepTimer() {
+        val ctrl = controller ?: return
+        ctrl.sendCustomCommand(SessionCommand(ACTION_SLEEP_TIMER_CANCEL, Bundle.EMPTY), Bundle.EMPTY)
+    }
 
     val showNowPlaying: StateFlow<Boolean> = savedStateHandle.getStateFlow("showNowPlaying", false)
     fun setShowNowPlaying(value: Boolean) {

--- a/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
@@ -79,6 +79,7 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import kotlinx.coroutines.delay
 import com.shapeshed.aerial.data.NowPlayingInfo
+import com.shapeshed.aerial.data.SleepTimerState
 import com.shapeshed.aerial.data.Station
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -91,14 +92,18 @@ fun NowPlayingScreen(
     currentTrackTitle: String?,
     currentTrackArtworkData: ByteArray? = null,
     currentTrackArtworkUrl: String? = null,
+    sleepTimer: SleepTimerState? = null,
     onToggle: () -> Unit,
     onToggleFavorite: () -> Unit,
+    onSetSleepTimer: (Long) -> Unit = {},
+    onCancelSleepTimer: () -> Unit = {},
     onDismiss: () -> Unit,
 ) {
     val context = LocalContext.current
     val dismissThresholdPx = with(LocalDensity.current) { 96.dp.toPx() }
     var dragOffsetY by remember { mutableFloatStateOf(0f) }
     var showTrackDetail by remember { mutableStateOf(false) }
+    var showSleepTimer by remember { mutableStateOf(false) }
     val artworkShape = RoundedCornerShape(
         topStart = 28.dp,
         topEnd = 28.dp,
@@ -138,6 +143,9 @@ fun NowPlayingScreen(
     var trackArtworkFailed by remember(trackArtworkModel) { mutableStateOf(false) }
     val showTrackBlock = !trackTitle.isNullOrBlank() && trackTitle != programmeTitle
     LaunchedEffect(showTrackBlock) { if (!showTrackBlock) showTrackDetail = false }
+    // When the timer clears (it expired, or was cancelled), close the picker too. Keyed on the
+    // active->inactive transition so a picker opened with no timer running stays open.
+    LaunchedEffect(sleepTimer == null) { if (sleepTimer == null) showSleepTimer = false }
 
     Scaffold(
         modifier = Modifier
@@ -175,6 +183,9 @@ fun NowPlayingScreen(
                     ) {
                         Icon(Icons.Rounded.KeyboardArrowDown, contentDescription = "Close player")
                     }
+                },
+                actions = {
+                    SleepTimerAction(active = sleepTimer, onClick = { showSleepTimer = true })
                 },
             )
         },
@@ -437,6 +448,15 @@ fun NowPlayingScreen(
                 }
             }
         }
+    }
+
+    if (showSleepTimer) {
+        SleepTimerSheet(
+            active = sleepTimer,
+            onSet = onSetSleepTimer,
+            onCancel = onCancelSleepTimer,
+            onDismiss = { showSleepTimer = false },
+        )
     }
 
     if (showTrackDetail) {

--- a/app/src/main/java/com/shapeshed/aerial/ui/SleepTimerSheet.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/SleepTimerSheet.kt
@@ -1,0 +1,228 @@
+package com.shapeshed.aerial.ui
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Bedtime
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.ToggleButton
+import androidx.compose.material3.ToggleButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.IconButtonShapes
+import androidx.compose.material3.LinearWavyProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.WavyProgressIndicatorDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.shapeshed.aerial.data.SleepTimerState
+
+private const val MINUTE_MS = 60_000L
+
+val SLEEP_TIMER_PRESETS_MS: List<Long> = listOf(
+    30_000L,
+    15 * MINUTE_MS,
+    30 * MINUTE_MS,
+    45 * MINUTE_MS,
+    60 * MINUTE_MS,
+    90 * MINUTE_MS,
+)
+
+/** Formats remaining milliseconds as H:MM:SS (or M:SS under an hour), rounding seconds up. */
+fun formatSleepRemaining(ms: Long): String {
+    val totalSec = ((ms + 999) / 1000).coerceAtLeast(0)
+    val h = totalSec / 3600
+    val m = (totalSec % 3600) / 60
+    val s = totalSec % 60
+    return if (h > 0) "%d:%02d:%02d".format(h, m, s) else "%d:%02d".format(m, s)
+}
+
+private fun presetLabel(ms: Long): String {
+    if (ms < MINUTE_MS) return "${ms / 1000} sec"
+    val min = ms / MINUTE_MS
+    return when {
+        min < 60 -> "$min min"
+        min % 60 == 0L -> "${min / 60} hr"
+        else -> "${min / 60}h ${min % 60}m"
+    }
+}
+
+/** Now Playing top-bar action: a plain icon when idle, a tonal icon with countdown when active. */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun SleepTimerAction(active: SleepTimerState?, onClick: () -> Unit) {
+    if (active != null) {
+        // Active state: a filled Material You accent pill (primaryContainer) holding the icon
+        // and live countdown. The whole pill opens the picker, and it's inset to sit at the
+        // 16.dp margin used by the mini-player lozenge.
+        Surface(
+            onClick = onClick,
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            // End inset so the pill's right edge lines up with the 24.dp content margin of the
+            // main artwork below it.
+            modifier = Modifier.padding(end = 20.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(start = 12.dp, end = 14.dp, top = 8.dp, bottom = 8.dp),
+            ) {
+                Icon(
+                    Icons.Rounded.Bedtime,
+                    contentDescription = "Sleep timer",
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = formatSleepRemaining(active.remainingMs),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Medium,
+                )
+            }
+        }
+    } else {
+        // Match the active pill's inset so the idle icon isn't flush against the edge and
+        // lines up with the 24.dp artwork margin.
+        IconButton(
+            onClick = onClick,
+            shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
+            modifier = Modifier.padding(end = 8.dp),
+        ) {
+            Icon(Icons.Rounded.Bedtime, contentDescription = "Sleep timer")
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class, ExperimentalLayoutApi::class)
+@Composable
+fun SleepTimerSheet(
+    active: SleepTimerState?,
+    onSet: (Long) -> Unit,
+    onCancel: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 48.dp),
+        ) {
+            Text(
+                text = "Sleep timer",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+            )
+
+            if (active != null) {
+                Spacer(Modifier.height(20.dp))
+                Text(
+                    text = formatSleepRemaining(active.remainingMs),
+                    style = MaterialTheme.typography.displaySmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(Modifier.height(16.dp))
+                // Elapsed fraction so the bar fills left-to-right as the timer counts down
+                // (empty at the start, full when it's about to fire).
+                val fraction = if (active.totalMs > 0) {
+                    (1f - active.remainingMs.toFloat() / active.totalMs.toFloat()).coerceIn(0f, 1f)
+                } else 0f
+                val animatedFraction by animateFloatAsState(
+                    targetValue = fraction,
+                    animationSpec = tween(500),
+                    label = "sleepProgress",
+                )
+                LinearWavyProgressIndicator(
+                    progress = { animatedFraction },
+                    // Keep it wavy throughout — the default amplitude flattens the wave near
+                    // progress 0 and 1, which looked like an intermittent bug.
+                    amplitude = { 1f },
+                    color = MaterialTheme.colorScheme.primary,
+                    trackColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(WavyProgressIndicatorDefaults.LinearContainerHeight),
+                )
+                Spacer(Modifier.height(20.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    OutlinedButton(
+                        onClick = { onCancel(); onDismiss() },
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Text("Cancel")
+                    }
+                    FilledTonalButton(
+                        onClick = { onSet(active.remainingMs + 15 * MINUTE_MS) },
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Text("+15 min")
+                    }
+                }
+                Spacer(Modifier.height(28.dp))
+                Text(
+                    text = "Set a new duration",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+            // M3 Expressive single-select: toggle buttons that morph round -> square and fill
+            // with the primary (Material You) colour when selected. FlowRow wraps so every
+            // preset stays visible rather than collapsing into an overflow menu.
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                SLEEP_TIMER_PRESETS_MS.forEach { ms ->
+                    ToggleButton(
+                        checked = active?.totalMs == ms,
+                        onCheckedChange = { onSet(ms); onDismiss() },
+                        // Visual hierarchy per applying-m-3-expressive: unselected siblings are
+                        // squarer and the selected one rounds out to stand apart.
+                        shapes = ToggleButtonDefaults.shapes(
+                            shape = ToggleButtonDefaults.squareShape,
+                            pressedShape = ToggleButtonDefaults.pressedShape,
+                            checkedShape = ToggleButtonDefaults.roundShape,
+                        ),
+                        // Larger touch target — these are primary actions.
+                        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
+                    ) {
+                        Text(presetLabel(ms), style = MaterialTheme.typography.titleMedium)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a sleep timer that pauses playback after a chosen duration. The timer is owned by `PlayerService` (not the ViewModel) so it keeps counting when the app is swiped away while playback continues in the background.

## What's included

- **PlayerService** — `SLEEP_TIMER_SET`/`CANCEL` session commands (following the existing favorite-button pattern), a per-second countdown on `serviceScope`, and a ~4s volume fade before pausing on expiry. Volume is restored afterwards so the next `play()` isn't silent; cancelling mid-fade resets it.
- **`SleepTimerStore`** — a process-wide `StateFlow` of the countdown, mirroring `NowPlayingStore`. The service publishes ticks; the UI collects them.
- **MainViewModel** — `setSleepTimer()` / `cancelSleepTimer()` send the commands via the `MediaController` and expose the countdown state.
- **Now Playing UI (Material 3 Expressive)**
  - Top-bar action that becomes a filled `primaryContainer` pill with a live countdown when active (tapping anywhere on it opens the picker); a plain icon when idle.
  - Bottom-sheet picker with **30s / 15 / 30 / 45 / 60 / 90 min** presets as `ToggleButton`s that morph (selected rounds out vs. squarer siblings) and fill with `primary`.
  - `LinearWavyProgressIndicator` tracking elapsed time (fills left→right; amplitude pinned so it stays wavy across the whole range).
  - Picker auto-closes when the timer clears (expiry or cancel), while a picker opened with no timer running stays open.

## Behaviour notes

- On expiry playback is **paused** (with fade), not stopped — the user can resume.
- The timer **survives station changes**; replacing the duration (a new preset or +15 min) resets it.
- No new permissions; no DB or schema changes.

## Testing

- `./gradlew assembleDebug` and `testDebugUnitTest` pass.
- Verified on-device: setting/reopening the picker, active-state pill + countdown, selection morph, wavy progress, expiry fade→pause, cancel, and background persistence.