### PR TITLE
feat: show A-Z stations before searching

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryDao.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryDao.kt
@@ -47,4 +47,7 @@ abstract class RegistryDao {
 
     @Query("SELECT * FROM registry_stations ORDER BY name")
     abstract suspend fun all(): List<RegistryStation>
+
+    @Query("SELECT * FROM registry_stations ORDER BY name LIMIT :limit")
+    abstract suspend fun browse(limit: Int): List<RegistryStation>
 }

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
@@ -132,6 +132,10 @@ class RegistryRepository(private val dao: RegistryDao, private val httpClient: O
         }
     }
 
+    // A-Z subsection shown as browse suggestions before the user has typed anything.
+    // Capped to match the search query limit.
+    suspend fun defaultStations(limit: Int = 200): List<RegistryStation> = dao.browse(limit)
+
     private fun parseRegistry(json: String): List<RegistryStation> {
         return try {
             val arr = JSONArray(json)

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -190,6 +190,7 @@ fun MainScreen(
     val recentSearches by viewModel.recentSearches.collectAsStateWithLifecycle()
     val allTags by viewModel.allTags.collectAsStateWithLifecycle()
     val featuredStations by viewModel.featuredStations.collectAsStateWithLifecycle()
+    val defaultStations by viewModel.defaultStations.collectAsStateWithLifecycle()
     val selectedCountries: Set<String> by viewModel.selectedCountries.collectAsStateWithLifecycle()
     val selectedTags: Set<String> by viewModel.selectedTags.collectAsStateWithLifecycle()
     val availableCountries: List<String> by viewModel.availableCountries.collectAsStateWithLifecycle()
@@ -519,14 +520,30 @@ fun MainScreen(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
                 if (searchQueryText.isBlank() && !hasFilters) {
-                    RecentSearches(
-                        searches = recentSearches,
-                        onSelect = { query ->
-                            textFieldState.edit { replace(0, length, query) }
-                            viewModel.searchRegistry(query)
-                        },
-                        onRemove = { viewModel.removeRecentSearch(it) },
-                    )
+                    if (recentSearches.isNotEmpty()) {
+                        RecentSearches(
+                            searches = recentSearches,
+                            onSelect = { query ->
+                                textFieldState.edit { replace(0, length, query) }
+                                viewModel.searchRegistry(query)
+                            },
+                            onRemove = { viewModel.removeRecentSearch(it) },
+                        )
+                    } else {
+                        // Cold start with no history: show an A-Z browse list so the view
+                        // isn't empty before the user has typed anything.
+                        DefaultSearchResults(
+                            stations = defaultStations,
+                            savedStreamUrls = savedStreamUrls,
+                            onPlay = { station ->
+                                viewModel.playFromRegistry(station)
+                                textFieldState.edit { replace(0, length, "") }
+                                scope.launch { searchBarState.animateToCollapsed() }
+                            },
+                            onAdd = { viewModel.addFromRegistry(it) },
+                            onRemove = { viewModel.removeFromRegistry(it) },
+                        )
+                    }
                 } else {
                     RegistrySearchResults(
                         results = registrySearchResults,
@@ -635,6 +652,34 @@ fun MainScreen(
 
 }
 
+
+// Pre-search browse list (A-Z subsection of the registry) shown on a cold start when there
+// are no recent searches, so the search view isn't empty before the user types.
+@Composable
+private fun DefaultSearchResults(
+    stations: List<RegistryStation>,
+    savedStreamUrls: Set<String>,
+    onPlay: (RegistryStation) -> Unit,
+    onAdd: (RegistryStation) -> Unit,
+    onRemove: (RegistryStation) -> Unit,
+) {
+    if (stations.isEmpty()) return
+    LazyColumn {
+        items(
+            items = stations,
+            key = { it.id },
+            contentType = { "registry-result" },
+        ) { station ->
+            RegistryResultItem(
+                station = station,
+                alreadySaved = station.streamUrl in savedStreamUrls,
+                onTap = { onPlay(station) },
+                onAdd = { onAdd(station) },
+                onRemove = { onRemove(station) },
+            )
+        }
+    }
+}
 
 @Composable
 private fun RecentSearches(

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -88,6 +88,9 @@ class MainViewModel(
     private val _featuredStations = MutableStateFlow<List<RegistryStation>>(emptyList())
     val featuredStations: StateFlow<List<RegistryStation>> = _featuredStations.asStateFlow()
 
+    private val _defaultStations = MutableStateFlow<List<RegistryStation>>(emptyList())
+    val defaultStations: StateFlow<List<RegistryStation>> = _defaultStations.asStateFlow()
+
     init {
         viewModelScope.launch {
             repository.getAll().first()
@@ -102,6 +105,7 @@ class MainViewModel(
                 .distinctUntilChanged()
                 .collect {
                     _featuredStations.value = registryRepository.featuredStations()
+                    _defaultStations.value = registryRepository.defaultStations()
                     _availableCountries.value = registryRepository.availableCountryCodes()
                     _allTags.value = registryRepository.availableTags()
                 }


### PR DESCRIPTION
## Summary

On a cold start the expanded search view was empty until the user typed something. This shows an **A-Z browse list** of registry stations in the pre-search state so it doesn't look empty.

## What's included

- **`RegistryDao.browse(limit)`** — `SELECT * FROM registry_stations ORDER BY name LIMIT :limit`.
- **`RegistryRepository.defaultStations(limit = 200)`** — the first 200 stations A-Z, capped to match the existing `search` query limit.
- **MainViewModel** — a `defaultStations` flow, loaded once the registry is ready (alongside featured stations / tags).
- **Search overlay** — in the pre-search state (blank query, no filters): shows **recent searches if any**, otherwise the browse list. Reuses the existing `RegistryResultItem` rows (play / add / already-saved); tapping a station plays it and collapses search.

## Behaviour notes

- Browse list appears only when there are no recent searches; once the user has search history, that takes precedence (unchanged).
- Renders nothing (not a misleading "No stations found") during the brief moment before the registry finishes loading.
- No title header — just the list.

## Testing

- `assembleDebug` and `testDebugUnitTest` pass.
- Verified on-device: cold-start browse list appears, recent searches take precedence once present, tapping plays and collapses.