### PR TITLE
fix(ui): derive now-playing summary and fix artwork duplication

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -176,9 +176,11 @@ fun MainScreen(
     val isPlaying by viewModel.isPlaying.collectAsStateWithLifecycle()
     val isBuffering by viewModel.isBuffering.collectAsStateWithLifecycle()
     val currentTrackTitle by viewModel.currentTrackTitle.collectAsStateWithLifecycle()
+    val currentTrackArtist by viewModel.currentTrackArtist.collectAsStateWithLifecycle()
     val currentTrackArtworkData by viewModel.currentTrackArtworkData.collectAsStateWithLifecycle()
     val currentTrackArtworkUrl by viewModel.currentTrackArtworkUrl.collectAsStateWithLifecycle()
     val nowPlayingInfo by viewModel.nowPlayingInfo.collectAsStateWithLifecycle()
+    val nowPlayingDisplay by viewModel.nowPlayingDisplay.collectAsStateWithLifecycle()
     val sleepTimer by viewModel.sleepTimer.collectAsStateWithLifecycle()
     val playbackError by viewModel.playbackError.collectAsStateWithLifecycle()
     val recentlyAddedStationId by viewModel.recentlyAddedStationId.collectAsStateWithLifecycle()
@@ -337,24 +339,9 @@ fun MainScreen(
                 .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 32.dp),
         ) {
             currentStation?.let { station ->
-                val hasSong = activeNowPlayingInfo?.track != null
-                val miniPlayerTitle = if (hasSong) {
-                    activeNowPlayingInfo!!.track!!.artist.takeIf { it.isNotBlank() }
-                        ?: activeNowPlayingInfo.programmeTitle
-                        ?: station.name
-                } else {
-                    station.name
-                }
+                val miniPlayerTitle = nowPlayingDisplay.title.ifBlank { station.name }
                 val miniPlayerSubtitle = playbackError
-                    ?: if (isBuffering) "Buffering…"
-                    else if (hasSong) {
-                        activeNowPlayingInfo?.track?.title?.takeIf { it != miniPlayerTitle }
-                            ?: currentTrackTitle?.takeIf { it != miniPlayerTitle }
-                            ?: if (isPlaying) "Playing" else "Paused"
-                    } else {
-                        activeNowPlayingInfo?.programmeTitle?.takeIf { it != station.name }
-                            ?: if (isPlaying) "Playing" else "Paused"
-                    }
+                    ?: if (isBuffering) "Buffering…" else nowPlayingDisplay.subtitle
                 BoxWithConstraints {
                     val isActive = isPlaying || isBuffering
                     val playPauseCorner by animateDpAsState(
@@ -488,6 +475,7 @@ fun MainScreen(
                     isBuffering = isBuffering,
                     nowPlayingInfo = activeNowPlayingInfo,
                     currentTrackTitle = currentTrackTitle,
+                    currentTrackArtist = currentTrackArtist,
                     currentTrackArtworkData = currentTrackArtworkData,
                     currentTrackArtworkUrl = currentTrackArtworkUrl,
                     sleepTimer = sleepTimer,

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -151,6 +151,9 @@ class MainViewModel(
     private val _currentTrackTitle = MutableStateFlow<String?>(null)
     val currentTrackTitle: StateFlow<String?> = _currentTrackTitle.asStateFlow()
 
+    private val _currentTrackArtist = MutableStateFlow<String?>(null)
+    val currentTrackArtist: StateFlow<String?> = _currentTrackArtist.asStateFlow()
+
     private val _currentTrackArtworkUrl = MutableStateFlow<String?>(null)
     val currentTrackArtworkUrl: StateFlow<String?> = _currentTrackArtworkUrl.asStateFlow()
 
@@ -162,6 +165,19 @@ class MainViewModel(
 
     val nowPlayingInfo: StateFlow<NowPlayingInfo?> = NowPlayingStore.state
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+
+    // Single derived "what's playing" summary. Recomputes whenever any source flow emits
+    // (enricher info, ICY media metadata, or the current station change) so the UI never has
+    // to reconcile the sources itself.
+    val nowPlayingDisplay: StateFlow<NowPlayingDisplay> = combine(
+        currentStation,
+        nowPlayingInfo,
+        _currentTrackTitle,
+        _currentTrackArtist,
+    ) { station, info, icyTitle, icyArtist ->
+        val activeInfo = info?.takeIf { it.stationId == station?.id }
+        computeNowPlayingDisplay(station?.name.orEmpty(), activeInfo, icyTitle, icyArtist)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), NowPlayingDisplay("", ""))
 
     val sleepTimer: StateFlow<SleepTimerState?> = SleepTimerStore.state
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
@@ -429,6 +445,7 @@ class MainViewModel(
                 !title.isNullOrEmpty() && title != "Live Radio" -> _currentTrackTitle.value = title
                 !artist.isNullOrEmpty() && artist != "Live Radio" -> _currentTrackTitle.value = artist
             }
+            _currentTrackArtist.value = artist?.takeIf { it.isNotEmpty() && it != "Live Radio" }
             _currentTrackArtworkData.value = artworkData
             _currentTrackArtworkUrl.value = if (artworkData == null && !artwork.isNullOrEmpty()) {
                 artwork
@@ -447,6 +464,7 @@ class MainViewModel(
             _currentStationId.value = station.id
         }
         _currentTrackTitle.value = null
+        _currentTrackArtist.value = null
         _currentTrackArtworkUrl.value = null
         _currentTrackArtworkData.value = null
         _playbackError.value = null
@@ -604,6 +622,51 @@ class MainViewModel(
             prepare()
             pause()
         }
+    }
+}
+
+/** Two-line "what's playing" summary for the mini player / notifications. */
+data class NowPlayingDisplay(val title: String, val subtitle: String)
+
+private const val LIVE_RADIO = "Live Radio"
+
+/**
+ * Derives the display summary from the available metadata sources, in priority order:
+ * track (song) → programme → ICY title → nothing. Pure and side-effect free so it can be
+ * unit tested and reused; the ViewModel drives it from the event-fed flows.
+ */
+fun computeNowPlayingDisplay(
+    stationName: String,
+    info: NowPlayingInfo?,
+    icyTitle: String?,
+    icyArtist: String? = null,
+): NowPlayingDisplay {
+    val track = info?.track
+    return when {
+        track != null -> artistTitleDisplay(track.artist, track.title, stationName)
+        info?.programmeTitle != null -> NowPlayingDisplay(
+            title = info.programmeTitle,
+            subtitle = info.programmeSubtitle?.takeIf { it.isNotBlank() } ?: stationName,
+        )
+        // No enricher active but the stream carries ICY/ID3 track text. ICY commonly parses to
+        // "Artist - Title"; show both, the same as an enriched song.
+        info == null && !icyTitle.isNullOrBlank() -> artistTitleDisplay(icyArtist.orEmpty(), icyTitle, stationName)
+        else -> NowPlayingDisplay(stationName, LIVE_RADIO)
+    }
+}
+
+// Artist on the top line, title below; falls back to the station name when one side is missing,
+// ignoring an "artist" that is really just the station name (ICY with no separator).
+private fun artistTitleDisplay(rawArtist: String, rawTitle: String, stationName: String): NowPlayingDisplay {
+    val artist = rawArtist.takeIf { it.isNotBlank() && it != stationName }
+    // Ignore a "title" that is really just the station name: with no track metadata the media
+    // item's title is the station name, which would otherwise show as "Station - Station".
+    val title = rawTitle.takeIf { it.isNotBlank() && it != stationName }
+    return when {
+        artist != null && title != null -> NowPlayingDisplay(artist, title)
+        artist != null -> NowPlayingDisplay(artist, stationName)
+        title != null -> NowPlayingDisplay(title, stationName)
+        else -> NowPlayingDisplay(stationName, LIVE_RADIO)
     }
 }
 

--- a/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
@@ -90,6 +90,7 @@ fun NowPlayingScreen(
     isBuffering: Boolean,
     nowPlayingInfo: NowPlayingInfo? = null,
     currentTrackTitle: String?,
+    currentTrackArtist: String? = null,
     currentTrackArtworkData: ByteArray? = null,
     currentTrackArtworkUrl: String? = null,
     sleepTimer: SleepTimerState? = null,
@@ -119,6 +120,8 @@ fun NowPlayingScreen(
         else -> currentTrackTitle
     }
     val trackArtist = track?.artist?.takeIf { it.isNotBlank() }
+        // No enricher: use the ICY artist (ignoring one that's just the station name).
+        ?: currentTrackArtist?.takeIf { nowPlayingInfo == null && it.isNotBlank() && it != station.name }
     val mainArtworkModel = when {
         nowPlayingInfo?.artworkData != null -> nowPlayingInfo.artworkData
         !nowPlayingInfo?.artworkUrl.isNullOrBlank() -> nowPlayingInfo.artworkUrl
@@ -132,6 +135,10 @@ fun NowPlayingScreen(
         nowPlayingInfo == null && !currentTrackArtworkUrl.isNullOrBlank() -> currentTrackArtworkUrl
         else -> null
     }
+    // The main image is distinct programme/context artwork (not the station's own logo) only
+    // when the enricher supplied its own artwork. Otherwise the main image already is the
+    // station logo, so the small logo badge would just duplicate it.
+    val mainArtworkIsDistinct = nowPlayingInfo?.artworkData != null || !nowPlayingInfo?.artworkUrl.isNullOrBlank()
     val trackArtworkModel = when {
         track?.artworkData != null -> track.artworkData
         track?.artworkUrl?.isNotBlank() == true -> track.artworkUrl
@@ -216,7 +223,9 @@ fun NowPlayingScreen(
                             AsyncImage(
                                 model = mainArtworkModel,
                                 contentDescription = null,
-                                contentScale = ContentScale.Crop,
+                                // Fit (not Crop) so non-square artwork isn't cropped; the
+                                // surface colour fills the letterbox space.
+                                contentScale = ContentScale.Fit,
                                 onError = { mainArtworkFailed = true },
                                 modifier = Modifier.fillMaxSize(),
                             )
@@ -230,7 +239,7 @@ fun NowPlayingScreen(
                         }
                     }
                 }
-                if (mainArtworkModel != null && !mainArtworkFailed) {
+                if (mainArtworkModel != null && !mainArtworkFailed && mainArtworkIsDistinct) {
                     Surface(
                         shape = CircleShape,
                         color = MaterialTheme.colorScheme.surface,

--- a/app/src/test/java/com/shapeshed/aerial/ui/NowPlayingDisplayTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/ui/NowPlayingDisplayTest.kt
@@ -1,0 +1,79 @@
+package com.shapeshed.aerial.ui
+
+import com.shapeshed.aerial.data.NowPlayingInfo
+import com.shapeshed.aerial.data.TrackInfo
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NowPlayingDisplayTest {
+
+    @Test
+    fun noMetadataShowsStationNameAndLiveRadio() {
+        val display = computeNowPlayingDisplay("Radio X", info = null, icyTitle = null)
+        assertEquals(NowPlayingDisplay("Radio X", "Live Radio"), display)
+    }
+
+    @Test
+    fun trackShowsArtistThenTitle() {
+        val info = NowPlayingInfo(stationId = 1, track = TrackInfo(artist = "Aphex Twin", title = "Xtal"))
+        val display = computeNowPlayingDisplay("Radio X", info, icyTitle = null)
+        assertEquals(NowPlayingDisplay("Aphex Twin", "Xtal"), display)
+    }
+
+    @Test
+    fun trackWithoutArtistFallsBackToStationNameAsSubtitle() {
+        val info = NowPlayingInfo(stationId = 1, track = TrackInfo(artist = "", title = "Some Track"))
+        val display = computeNowPlayingDisplay("Radio X", info, icyTitle = null)
+        assertEquals(NowPlayingDisplay("Some Track", "Radio X"), display)
+    }
+
+    @Test
+    fun programmeShownWhenNoTrack() {
+        val info = NowPlayingInfo(stationId = 1, programmeTitle = "Breakfast", programmeSubtitle = "with Zoe Ball")
+        val display = computeNowPlayingDisplay("Radio X", info, icyTitle = null)
+        assertEquals(NowPlayingDisplay("Breakfast", "with Zoe Ball"), display)
+    }
+
+    @Test
+    fun programmeWithoutSubtitleFallsBackToStationName() {
+        val info = NowPlayingInfo(stationId = 1, programmeTitle = "The News")
+        val display = computeNowPlayingDisplay("Radio X", info, icyTitle = null)
+        assertEquals(NowPlayingDisplay("The News", "Radio X"), display)
+    }
+
+    @Test
+    fun icyArtistAndTitleShownWhenNoEnricher() {
+        val display = computeNowPlayingDisplay(
+            "KISS Dance", info = null, icyTitle = "Slow Burner", icyArtist = "Interplanetary Criminal",
+        )
+        assertEquals(NowPlayingDisplay("Interplanetary Criminal", "Slow Burner"), display)
+    }
+
+    @Test
+    fun icyTitleOnlyFallsBackToStationName() {
+        val display = computeNowPlayingDisplay("Radio X", info = null, icyTitle = "Some Show", icyArtist = null)
+        assertEquals(NowPlayingDisplay("Some Show", "Radio X"), display)
+    }
+
+    @Test
+    fun icyTitleEqualToStationNameFallsBackToLiveRadio() {
+        // No track metadata: the media item title is the station name — must not show twice.
+        val display = computeNowPlayingDisplay("Radio X", info = null, icyTitle = "Radio X", icyArtist = null)
+        assertEquals(NowPlayingDisplay("Radio X", "Live Radio"), display)
+    }
+
+    @Test
+    fun icyArtistEqualToStationNameIsIgnored() {
+        // ICY with no "artist - title" separator: PlayerService sets artist = station name.
+        val display = computeNowPlayingDisplay("Radio X", info = null, icyTitle = "Some Show", icyArtist = "Radio X")
+        assertEquals(NowPlayingDisplay("Some Show", "Radio X"), display)
+    }
+
+    @Test
+    fun icyTitleIgnoredWhenEnricherActiveButHasNoTrackOrProgramme() {
+        // Enricher is running (info != null) but produced nothing — don't fall back to ICY.
+        val info = NowPlayingInfo(stationId = 1)
+        val display = computeNowPlayingDisplay("Radio X", info, icyTitle = "Stale ICY")
+        assertEquals(NowPlayingDisplay("Radio X", "Live Radio"), display)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes several Now Playing / mini-player issues and replaces the fragile display logic with a single derived, testable state.

## Mini-player metadata (single derived state)

The mini player's two-line summary was computed with a deep if/else in the composable and had bugs. It's now a single `NowPlayingDisplay(title, subtitle)` derived in the ViewModel by `combine()`-ing the event-fed flows through a pure, unit-tested `computeNowPlayingDisplay()`. The composable just renders it.

Priority: **track → programme → ICY → station name / "Live Radio"**.

Bugs fixed along the way:
- **ICY stations showed only the title** — the ViewModel dropped the ICY artist. It now exposes `currentTrackArtist`, so non-enriched streams show "Artist / Title" (matching the quick-settings player) in both the mini player and the Now Playing screen.
- **"Station / Station" duplication** — with no track metadata the media item's title is the station name; a title/artist equal to the station name is now ignored, so it shows "Station / Live Radio".

## Now Playing artwork

- **Duplicate station-logo badge** — the small logo badge over the main artwork now only shows when the main image is distinct programme artwork. When the main image already is the station logo (no enrichment), the badge is suppressed.
- **Non-square artwork was cropped** — the main image now uses `ContentScale.Fit` so it isn't cropped; the surface colour fills the letterbox space.

## Tests

- New `NowPlayingDisplayTest` covering no-metadata, track, programme, ICY (artist+title, title-only, station-name dedup), and the enricher-active-but-empty case.
- `assembleDebug` and `testDebugUnitTest` pass.
- Verified on-device across enriched (BBC/MusicBrainz), ICY (KISS Dance), and metadata-less stations.