### PR TITLE
feat(i18n): internationalise the app with per-app language support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,18 @@
         android:fullBackupContent="@xml/full_backup_rules"
         android:supportsRtl="true"
         android:networkSecurityConfig="@xml/network_security_config"
+        android:localeConfig="@xml/locales_config"
         android:theme="@style/Theme.Aerial">
+
+        <!-- Persists the per-app locale on pre-Android-13 via AppCompat. -->
+        <service
+            android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
+            android:enabled="false"
+            android:exported="false">
+            <meta-data
+                android:name="autoStoreLocales"
+                android:value="true" />
+        </service>
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/shapeshed/aerial/MainActivity.kt
+++ b/app/src/main/java/com/shapeshed/aerial/MainActivity.kt
@@ -1,7 +1,7 @@
 package com.shapeshed.aerial
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
+import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
@@ -40,7 +40,7 @@ object Routes {
     fun stationEdit(id: Long) = "station/$id"
 }
 
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
 
     private val mainViewModel: MainViewModel by viewModels {
         val app = application as AerialApp

--- a/app/src/main/java/com/shapeshed/aerial/ui/LanguagePicker.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/LanguagePicker.kt
@@ -1,0 +1,117 @@
+package com.shapeshed.aerial.ui
+
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Language
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.os.LocaleListCompat
+import com.shapeshed.aerial.R
+
+/** A supported UI language; [autonym] is the language's own name and is intentionally not translated. */
+data class AppLanguage(val tag: String, val autonym: String)
+
+// Must stay in sync with res/xml/locales_config.xml and the values-* resource dirs.
+val APP_LANGUAGES: List<AppLanguage> = listOf(
+    AppLanguage("en", "English (US)"),
+    AppLanguage("en-GB", "English (UK)"),
+    AppLanguage("es", "Español"),
+    AppLanguage("fr", "Français"),
+    AppLanguage("de", "Deutsch"),
+    AppLanguage("it", "Italiano"),
+    AppLanguage("pt", "Português"),
+    AppLanguage("nl", "Nederlands"),
+    AppLanguage("zh-CN", "简体中文"),
+    AppLanguage("ja", "日本語"),
+    AppLanguage("ko", "한국어"),
+)
+
+private fun setAppLanguage(tag: String) {
+    val locales = if (tag.isBlank()) LocaleListCompat.getEmptyLocaleList()
+    else LocaleListCompat.forLanguageTags(tag)
+    AppCompatDelegate.setApplicationLocales(locales)
+}
+
+/**
+ * Settings row + dialog for choosing the app language. Only shown on API < 33; on Android 13+
+ * the system per-app language picker (Settings → Apps → Aerial → Language) is used instead.
+ */
+@Composable
+fun LanguageSettingRow() {
+    var showDialog by remember { mutableStateOf(false) }
+    val currentTag = AppCompatDelegate.getApplicationLocales().toLanguageTags()
+    val currentLabel = APP_LANGUAGES.firstOrNull { it.tag.equals(currentTag, ignoreCase = true) }?.autonym
+        ?: stringResource(R.string.language_system_default)
+
+    ListItem(
+        modifier = Modifier.fillMaxWidth().clickable { showDialog = true },
+        leadingContent = { Icon(Icons.Rounded.Language, contentDescription = null) },
+        headlineContent = { Text(stringResource(R.string.language)) },
+        supportingContent = { Text(currentLabel) },
+    )
+
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text(stringResource(R.string.language)) },
+            text = {
+                Column(modifier = Modifier.verticalScroll(rememberScrollState()).heightIn(max = 420.dp)) {
+                    LanguageOption(
+                        label = stringResource(R.string.language_system_default),
+                        selected = currentTag.isBlank(),
+                        onClick = { setAppLanguage(""); showDialog = false },
+                    )
+                    APP_LANGUAGES.forEach { lang ->
+                        LanguageOption(
+                            label = lang.autonym,
+                            selected = currentTag.equals(lang.tag, ignoreCase = true),
+                            onClick = { setAppLanguage(lang.tag); showDialog = false },
+                        )
+                    }
+                }
+            },
+            confirmButton = {},
+            dismissButton = {
+                TextButton(onClick = { showDialog = false }) {
+                    Text(stringResource(R.string.action_cancel))
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun LanguageOption(label: String, selected: Boolean, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RadioButton(selected = selected, onClick = onClick)
+        Spacer(Modifier.width(8.dp))
+        Text(label, style = MaterialTheme.typography.bodyLarge)
+    }
+}

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -121,6 +121,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -135,18 +136,37 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
+import androidx.compose.ui.res.stringResource
+import com.shapeshed.aerial.R
 import com.shapeshed.aerial.data.RegistryStation
 import com.shapeshed.aerial.data.Station
 import java.io.File
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-// Lazily memoised so Locale.Builder is not called on every LazyColumn row recomposition.
+// Localized country name from the stored ISO code via ICU, in the app's current locale.
+// Cached per (code, language) so Locale.Builder isn't called on every row recomposition.
 private val countryNameCache = mutableMapOf<String, String>()
-private fun countryName(code: String): String =
-    countryNameCache.getOrPut(code) {
-        java.util.Locale.Builder().setRegion(code).build().getDisplayCountry().ifBlank { code }
+private fun countryName(code: String, locale: java.util.Locale): String =
+    countryNameCache.getOrPut("$code|${locale.language}") {
+        java.util.Locale.Builder().setRegion(code).build().getDisplayCountry(locale).ifBlank { code }
     }
+
+// The curated genre tags are a fixed set, so their display is localized while the English tag
+// stays the matching key. Unknown tags fall back to their raw value.
+@Composable
+private fun rememberTagLabels(): Map<String, String> = mapOf(
+    "News" to stringResource(R.string.tag_news),
+    "Sport" to stringResource(R.string.tag_sport),
+    "Pop" to stringResource(R.string.tag_pop),
+    "Rock" to stringResource(R.string.tag_rock),
+    "Jazz" to stringResource(R.string.tag_jazz),
+    "Classical" to stringResource(R.string.tag_classical),
+    "Dance" to stringResource(R.string.tag_dance),
+    "Soul" to stringResource(R.string.tag_soul),
+    "Country" to stringResource(R.string.tag_country),
+    "Electronic" to stringResource(R.string.tag_electronic),
+)
 
 // Fixed tag→icon map — hoisted to avoid allocating a new Map on every CategoryGrid recomposition.
 private val CATEGORY_ICONS = mapOf(
@@ -196,6 +216,8 @@ fun MainScreen(
     val selectedCountries: Set<String> by viewModel.selectedCountries.collectAsStateWithLifecycle()
     val selectedTags: Set<String> by viewModel.selectedTags.collectAsStateWithLifecycle()
     val availableCountries: List<String> by viewModel.availableCountries.collectAsStateWithLifecycle()
+    val appLocale = LocalConfiguration.current.locales[0]
+    val tagLabels = rememberTagLabels()
 
     val textFieldState = rememberTextFieldState()
     val searchBarState = rememberContainedSearchBarState()
@@ -245,7 +267,7 @@ fun MainScreen(
             textFieldState = textFieldState,
             searchBarState = searchBarState,
             onSearch = { viewModel.saveRecentSearch(it) },
-            placeholder = { Text("Search stations") },
+            placeholder = { Text(stringResource(R.string.search_hint)) },
             leadingIcon = {
                 if (isSearchExpanded) {
                     IconButton(
@@ -255,7 +277,7 @@ fun MainScreen(
                         },
                         shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
                     ) {
-                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 } else {
                     Icon(Icons.Rounded.Search, contentDescription = null)
@@ -268,7 +290,7 @@ fun MainScreen(
                             onClick = { textFieldState.edit { replace(0, length, "") } },
                             shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
                         ) {
-                            Icon(Icons.Rounded.Close, contentDescription = "Clear search")
+                            Icon(Icons.Rounded.Close, contentDescription = stringResource(R.string.clear_search))
                         }
                     }
                     !isSearchExpanded -> {
@@ -276,7 +298,7 @@ fun MainScreen(
                             onClick = onSettings,
                             shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
                         ) {
-                            Icon(Icons.Rounded.Settings, contentDescription = "Settings")
+                            Icon(Icons.Rounded.Settings, contentDescription = stringResource(R.string.settings))
                         }
                     }
                 }
@@ -341,7 +363,7 @@ fun MainScreen(
             currentStation?.let { station ->
                 val miniPlayerTitle = nowPlayingDisplay.title.ifBlank { station.name }
                 val miniPlayerSubtitle = playbackError
-                    ?: if (isBuffering) "Buffering…" else nowPlayingDisplay.subtitle
+                    ?: if (isBuffering) stringResource(R.string.buffering) else nowPlayingDisplay.subtitle
                 BoxWithConstraints {
                     val isActive = isPlaying || isBuffering
                     val playPauseCorner by animateDpAsState(
@@ -424,7 +446,7 @@ fun MainScreen(
                                         } else {
                                             Icon(
                                                 imageVector = if (playing) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-                                                contentDescription = if (playing) "Pause" else "Play",
+                                                contentDescription = stringResource(if (playing) R.string.pause else R.string.play),
                                                 tint = MaterialTheme.colorScheme.onPrimary,
                                                 modifier = Modifier.size(30.dp),
                                             )
@@ -563,13 +585,13 @@ fun MainScreen(
                 sheetState = countrySheetState,
             ) {
                 FilterPickerSheetContent(
-                    title = "Country",
-                    searchLabel = "Search countries",
+                    title = stringResource(R.string.filter_country),
+                    searchLabel = stringResource(R.string.search_countries),
                     query = countryFilterQuery,
                     onQueryChange = { countryFilterQuery = it },
                     items = availableCountries,
                     selectedItems = selectedCountries,
-                    displayName = ::countryName,
+                    displayName = { countryName(it, appLocale) },
                     onToggle = { viewModel.toggleCountryFilter(it) },
                     onClear = { viewModel.clearCountryFilter() },
                 )
@@ -585,13 +607,13 @@ fun MainScreen(
                 sheetState = genreSheetState,
             ) {
                 FilterPickerSheetContent(
-                    title = "Genre",
-                    searchLabel = "Search genres",
+                    title = stringResource(R.string.filter_genre),
+                    searchLabel = stringResource(R.string.search_genres),
                     query = genreFilterQuery,
                     onQueryChange = { genreFilterQuery = it },
                     items = allTags,
                     selectedItems = selectedTags,
-                    displayName = { it },
+                    displayName = { tagLabels[it] ?: it },
                     onToggle = { viewModel.toggleTagFilter(it) },
                     onClear = { viewModel.clearTagFilter() },
                 )
@@ -621,18 +643,18 @@ fun MainScreen(
         stationToDelete?.let { station ->
             AlertDialog(
                 onDismissRequest = { stationToDelete = null },
-                title = { Text("Remove station?") },
-                text = { Text("\"${station.name}\" will be removed from your favorites.") },
+                title = { Text(stringResource(R.string.remove_station_title)) },
+                text = { Text(stringResource(R.string.remove_station_message, station.name)) },
                 confirmButton = {
                     TextButton(onClick = {
                         viewModel.deleteStation(station)
                         stationToDelete = null
                     }) {
-                        Text("Remove", color = MaterialTheme.colorScheme.error)
+                        Text(stringResource(R.string.action_remove), color = MaterialTheme.colorScheme.error)
                     }
                 },
                 dismissButton = {
-                    TextButton(onClick = { stationToDelete = null }) { Text("Cancel") }
+                    TextButton(onClick = { stationToDelete = null }) { Text(stringResource(R.string.action_cancel)) }
                 },
             )
         }
@@ -695,7 +717,7 @@ private fun RecentSearches(
                         onClick = { onRemove(query) },
                         shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
                     ) {
-                        Icon(Icons.Rounded.Close, contentDescription = "Remove", modifier = Modifier.size(18.dp))
+                        Icon(Icons.Rounded.Close, contentDescription = stringResource(R.string.action_remove), modifier = Modifier.size(18.dp))
                     }
                 },
             )
@@ -737,13 +759,13 @@ private fun RegistrySearchResults(
                     }
                 }
                 Text(
-                    text = "No stations found",
+                    text = stringResource(R.string.no_stations_found),
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                     textAlign = TextAlign.Center,
                 )
                 Text(
-                    text = "Try a different search, or add a station using its stream URL.",
+                    text = stringResource(R.string.no_stations_found_desc),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center,
@@ -757,7 +779,7 @@ private fun RegistrySearchResults(
                             modifier = androidx.compose.ui.Modifier.size(18.dp),
                         )
                         Spacer(androidx.compose.ui.Modifier.width(8.dp))
-                        Text("Add your own station")
+                        Text(stringResource(R.string.add_your_own_station))
                     }
                 }
             }
@@ -837,7 +859,7 @@ private fun RegistryResultItem(
             ) {
                 Icon(
                     imageVector = if (alreadySaved) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
-                    contentDescription = if (alreadySaved) "Remove from favorites" else "Save to favorites",
+                    contentDescription = stringResource(if (alreadySaved) R.string.remove_from_favorites else R.string.save_to_favorites),
                     tint = if (alreadySaved) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.size(20.dp),
                 )
@@ -874,13 +896,13 @@ private fun NoNetworkState() {
                 }
             }
             Text(
-                text = "No internet connection",
+                text = stringResource(R.string.no_internet_title),
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onSurface,
                 textAlign = TextAlign.Center,
             )
             Text(
-                text = "Radio streams require an active internet connection.",
+                text = stringResource(R.string.no_internet_desc),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
@@ -961,7 +983,7 @@ private fun HomeContent(
     ) {
         item("favorites-header") {
             Text(
-                text = "Your favorites",
+                text = stringResource(R.string.favorites_header),
                 style = MaterialTheme.typography.headlineSmall,
                 color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 20.dp, bottom = 12.dp),
@@ -1006,7 +1028,7 @@ private fun HomeContent(
         if (stations.isEmpty() && featuredStations.isNotEmpty()) {
             item("get-started-header") {
                 Text(
-                    text = "Get started",
+                    text = stringResource(R.string.get_started),
                     style = MaterialTheme.typography.headlineSmall,
                     color = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 20.dp, bottom = 12.dp),
@@ -1029,7 +1051,7 @@ private fun HomeContent(
 
         item("just-listen-header") {
             Text(
-                text = "Just listen",
+                text = stringResource(R.string.just_listen),
                 style = MaterialTheme.typography.headlineSmall,
                 color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 20.dp, bottom = 12.dp),
@@ -1144,14 +1166,14 @@ private fun AddTile(onClick: () -> Unit, modifier: Modifier = Modifier) {
             Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
                 Icon(
                     imageVector = Icons.Rounded.Add,
-                    contentDescription = "Find a station",
+                    contentDescription = stringResource(R.string.find_a_station),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.size(32.dp),
                 )
             }
         }
         Text(
-            text = "Find one to listen to",
+            text = stringResource(R.string.find_one_to_listen),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,
@@ -1169,6 +1191,7 @@ private fun CategoryGrid(
     modifier: Modifier = Modifier,
 ) {
     if (tags.isEmpty()) return
+    val tagLabels = rememberTagLabels()
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         modifier = modifier,
@@ -1197,7 +1220,7 @@ private fun CategoryGrid(
                                 contentDescription = null,
                                 tint = MaterialTheme.colorScheme.primary,
                             )
-                            Text(tag, style = MaterialTheme.typography.titleMedium)
+                            Text(tagLabels[tag] ?: tag, style = MaterialTheme.typography.titleMedium)
                         }
                     }
                 }
@@ -1217,6 +1240,8 @@ private fun SearchFilterRow(
     hasFilters: Boolean,
     modifier: Modifier = Modifier,
 ) {
+    val appLocale = LocalConfiguration.current.locales[0]
+    val tagLabels = rememberTagLabels()
     fun chipLabel(selected: Set<String>, fallback: String, displayName: (String) -> String = { it }): String = when (selected.size) {
         0 -> fallback
         1 -> displayName(selected.first())
@@ -1231,7 +1256,7 @@ private fun SearchFilterRow(
         FilterChip(
             selected = selectedCountries.isNotEmpty(),
             onClick = onCountryClick,
-            label = { Text(chipLabel(selectedCountries, "Country", ::countryName)) },
+            label = { Text(chipLabel(selectedCountries, stringResource(R.string.filter_country)) { countryName(it, appLocale) }) },
             leadingIcon = if (selectedCountries.isNotEmpty()) {
                 { Icon(Icons.Rounded.Check, contentDescription = null, modifier = Modifier.size(FilterChipDefaults.IconSize)) }
             } else null,
@@ -1240,14 +1265,14 @@ private fun SearchFilterRow(
         FilterChip(
             selected = selectedTags.isNotEmpty(),
             onClick = onGenreClick,
-            label = { Text(chipLabel(selectedTags, "Genre")) },
+            label = { Text(chipLabel(selectedTags, stringResource(R.string.filter_genre)) { tagLabels[it] ?: it }) },
             leadingIcon = if (selectedTags.isNotEmpty()) {
                 { Icon(Icons.Rounded.Check, contentDescription = null, modifier = Modifier.size(FilterChipDefaults.IconSize)) }
             } else null,
             trailingIcon = { Icon(Icons.Rounded.KeyboardArrowDown, contentDescription = null, modifier = Modifier.size(18.dp)) },
         )
         if (hasFilters) {
-            TextButton(onClick = onClearAll) { Text("Clear all") }
+            TextButton(onClick = onClearAll) { Text(stringResource(R.string.clear_all)) }
         }
     }
 }
@@ -1272,7 +1297,7 @@ private fun StationContextSheet(
         HorizontalDivider()
         if (station.provider.isBlank()) {
             ListItem(
-                headlineContent = { Text("Edit") },
+                headlineContent = { Text(stringResource(R.string.action_edit)) },
                 leadingContent = {
                     Icon(Icons.Rounded.Edit, contentDescription = null)
                 },
@@ -1281,7 +1306,7 @@ private fun StationContextSheet(
         }
         ListItem(
             headlineContent = {
-                Text("Remove", color = MaterialTheme.colorScheme.error)
+                Text(stringResource(R.string.action_remove), color = MaterialTheme.colorScheme.error)
             },
             leadingContent = {
                 Icon(
@@ -1335,7 +1360,7 @@ private fun FilterPickerSheetContent(
                 modifier = Modifier.weight(1f),
             )
             if (selectedItems.isNotEmpty()) {
-                TextButton(onClick = onClear) { Text("Clear") }
+                TextButton(onClick = onClear) { Text(stringResource(R.string.action_clear)) }
             }
         }
         OutlinedTextField(
@@ -1347,7 +1372,7 @@ private fun FilterPickerSheetContent(
             trailingIcon = {
                 if (query.isNotEmpty()) {
                     IconButton(onClick = { onQueryChange("") }) {
-                        Icon(Icons.Rounded.Close, contentDescription = "Clear search")
+                        Icon(Icons.Rounded.Close, contentDescription = stringResource(R.string.clear_search))
                     }
                 }
             },
@@ -1359,8 +1384,8 @@ private fun FilterPickerSheetContent(
                 modifier = Modifier.fillMaxWidth().weight(1f),
             ) {
                 HomeEmptyState(
-                    text = "No matches",
-                    supportingText = "Try a different search.",
+                    text = stringResource(R.string.no_matches),
+                    supportingText = stringResource(R.string.no_matches_desc),
                 )
             }
         } else {

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -814,6 +814,10 @@ private fun RegistryResultItem(
     onAdd: () -> Unit,
     onRemove: () -> Unit,
 ) {
+    // Localize the country from its ISO code (falling back to the registry's own name).
+    val countryLabel = station.countryCode.takeIf { it.isNotBlank() }
+        ?.let { countryName(it, LocalConfiguration.current.locales[0]) }
+        ?: station.country
     ListItem(
         modifier = Modifier.fillMaxWidth().clickable(onClick = onTap),
         leadingContent = {
@@ -849,8 +853,8 @@ private fun RegistryResultItem(
                 overflow = TextOverflow.Ellipsis,
             )
         },
-        supportingContent = if (station.country.isNotBlank()) {
-            { Text(station.country, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+        supportingContent = if (countryLabel.isNotBlank()) {
+            { Text(countryLabel, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant) }
         } else null,
         trailingContent = {
             IconButton(

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -27,6 +27,7 @@ import androidx.media3.session.SessionToken
 import androidx.core.content.ContextCompat
 import com.shapeshed.aerial.AerialApp
 import com.shapeshed.aerial.PlayerService
+import com.shapeshed.aerial.R
 import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_CANCEL
 import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_SET
 import com.shapeshed.aerial.data.NowPlayingInfo
@@ -176,8 +177,12 @@ class MainViewModel(
         _currentTrackArtist,
     ) { station, info, icyTitle, icyArtist ->
         val activeInfo = info?.takeIf { it.stationId == station?.id }
-        computeNowPlayingDisplay(station?.name.orEmpty(), activeInfo, icyTitle, icyArtist)
+        computeNowPlayingDisplay(station?.name.orEmpty(), activeInfo, icyTitle, icyArtist, liveRadio())
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), NowPlayingDisplay("", ""))
+
+    // Localized "Live Radio" — the placeholder shown in the notification / mini player when a
+    // station has no track metadata, and the sentinel used to detect that placeholder below.
+    private fun liveRadio(): String = getApplication<Application>().getString(R.string.live_radio)
 
     val sleepTimer: StateFlow<SleepTimerState?> = SleepTimerStore.state
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
@@ -388,7 +393,7 @@ class MainViewModel(
                     }
                     _isPlaying.value = controller?.isPlaying ?: false
                     controller?.mediaMetadata?.artist?.toString()?.trim()
-                        ?.takeIf { it.isNotEmpty() && it != "Live Radio" }
+                        ?.takeIf { it.isNotEmpty() && it != liveRadio() }
                         ?.let { _currentTrackTitle.value = it }
                 } else if (_currentStationId.value == null) {
                     _isPlaying.value = controller?.isPlaying ?: false
@@ -442,10 +447,10 @@ class MainViewModel(
             val artwork = mediaMetadata.artworkUri?.toString()?.trim()
             val artworkData = mediaMetadata.artworkData
             when {
-                !title.isNullOrEmpty() && title != "Live Radio" -> _currentTrackTitle.value = title
-                !artist.isNullOrEmpty() && artist != "Live Radio" -> _currentTrackTitle.value = artist
+                !title.isNullOrEmpty() && title != liveRadio() -> _currentTrackTitle.value = title
+                !artist.isNullOrEmpty() && artist != liveRadio() -> _currentTrackTitle.value = artist
             }
-            _currentTrackArtist.value = artist?.takeIf { it.isNotEmpty() && it != "Live Radio" }
+            _currentTrackArtist.value = artist?.takeIf { it.isNotEmpty() && it != liveRadio() }
             _currentTrackArtworkData.value = artworkData
             _currentTrackArtworkUrl.value = if (artworkData == null && !artwork.isNullOrEmpty()) {
                 artwork
@@ -492,8 +497,8 @@ class MainViewModel(
                     }
                 }
                     .setTitle(station.name)
-                    .setArtist("Live Radio")
-                    .setSubtitle("Live Radio")
+                    .setArtist(liveRadio())
+                    .setSubtitle(liveRadio())
                     .setExtras(Bundle().apply {
                         putString("provider", station.provider)
                         putString("providerId", station.providerId)
@@ -611,8 +616,8 @@ class MainViewModel(
             .setMediaMetadata(
                 MediaMetadata.Builder()
                     .setTitle(station.name)
-                    .setArtist("Live Radio")
-                    .setSubtitle("Live Radio")
+                    .setArtist(liveRadio())
+                    .setSubtitle(liveRadio())
                     .build(),
             )
             .build()
@@ -628,36 +633,36 @@ class MainViewModel(
 /** Two-line "what's playing" summary for the mini player / notifications. */
 data class NowPlayingDisplay(val title: String, val subtitle: String)
 
-private const val LIVE_RADIO = "Live Radio"
-
 /**
  * Derives the display summary from the available metadata sources, in priority order:
  * track (song) → programme → ICY title → nothing. Pure and side-effect free so it can be
- * unit tested and reused; the ViewModel drives it from the event-fed flows.
+ * unit tested and reused; the ViewModel drives it from the event-fed flows and injects the
+ * localized [liveRadio] label.
  */
 fun computeNowPlayingDisplay(
     stationName: String,
     info: NowPlayingInfo?,
     icyTitle: String?,
     icyArtist: String? = null,
+    liveRadio: String = "Live Radio",
 ): NowPlayingDisplay {
     val track = info?.track
     return when {
-        track != null -> artistTitleDisplay(track.artist, track.title, stationName)
+        track != null -> artistTitleDisplay(track.artist, track.title, stationName, liveRadio)
         info?.programmeTitle != null -> NowPlayingDisplay(
             title = info.programmeTitle,
             subtitle = info.programmeSubtitle?.takeIf { it.isNotBlank() } ?: stationName,
         )
         // No enricher active but the stream carries ICY/ID3 track text. ICY commonly parses to
         // "Artist - Title"; show both, the same as an enriched song.
-        info == null && !icyTitle.isNullOrBlank() -> artistTitleDisplay(icyArtist.orEmpty(), icyTitle, stationName)
-        else -> NowPlayingDisplay(stationName, LIVE_RADIO)
+        info == null && !icyTitle.isNullOrBlank() -> artistTitleDisplay(icyArtist.orEmpty(), icyTitle, stationName, liveRadio)
+        else -> NowPlayingDisplay(stationName, liveRadio)
     }
 }
 
 // Artist on the top line, title below; falls back to the station name when one side is missing,
 // ignoring an "artist" that is really just the station name (ICY with no separator).
-private fun artistTitleDisplay(rawArtist: String, rawTitle: String, stationName: String): NowPlayingDisplay {
+private fun artistTitleDisplay(rawArtist: String, rawTitle: String, stationName: String, liveRadio: String): NowPlayingDisplay {
     val artist = rawArtist.takeIf { it.isNotBlank() && it != stationName }
     // Ignore a "title" that is really just the station name: with no track metadata the media
     // item's title is the station name, which would otherwise show as "Station - Station".
@@ -666,7 +671,7 @@ private fun artistTitleDisplay(rawArtist: String, rawTitle: String, stationName:
         artist != null && title != null -> NowPlayingDisplay(artist, title)
         artist != null -> NowPlayingDisplay(artist, stationName)
         title != null -> NowPlayingDisplay(title, stationName)
-        else -> NowPlayingDisplay(stationName, LIVE_RADIO)
+        else -> NowPlayingDisplay(stationName, liveRadio)
     }
 }
 

--- a/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
@@ -78,6 +78,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import kotlinx.coroutines.delay
+import androidx.compose.ui.res.stringResource
+import com.shapeshed.aerial.R
 import com.shapeshed.aerial.data.NowPlayingInfo
 import com.shapeshed.aerial.data.SleepTimerState
 import com.shapeshed.aerial.data.Station
@@ -188,7 +190,7 @@ fun NowPlayingScreen(
                         shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
                         modifier = Modifier.semantics { traversalIndex = 0f },
                     ) {
-                        Icon(Icons.Rounded.KeyboardArrowDown, contentDescription = "Close player")
+                        Icon(Icons.Rounded.KeyboardArrowDown, contentDescription = stringResource(R.string.close_player))
                     }
                 },
                 actions = {
@@ -308,7 +310,7 @@ fun NowPlayingScreen(
                     ) {
                         Icon(
                             imageVector = if (station.isFavorite) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
-                            contentDescription = if (station.isFavorite) "Remove from favorites" else "Add to favorites",
+                            contentDescription = stringResource(if (station.isFavorite) R.string.remove_from_favorites else R.string.add_to_favorites),
                             tint = if (station.isFavorite) MaterialTheme.colorScheme.primary else LocalContentColor.current,
                         )
                     }
@@ -347,7 +349,7 @@ fun NowPlayingScreen(
                             } else {
                                 Icon(
                                     imageVector = if (playing) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-                                    contentDescription = if (playing) "Pause" else "Play",
+                                    contentDescription = stringResource(if (playing) R.string.pause else R.string.play),
                                     modifier = Modifier.size(44.dp),
                                 )
                             }
@@ -366,7 +368,7 @@ fun NowPlayingScreen(
                                 putExtra(Intent.EXTRA_TEXT, "${station.name}\n${station.streamUrl}")
                             }
                             context.startActivity(
-                                Intent.createChooser(sendIntent, "Share station"),
+                                Intent.createChooser(sendIntent, context.getString(R.string.share_station)),
                             )
                         },
                         shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
@@ -376,7 +378,7 @@ fun NowPlayingScreen(
                     ) {
                         Icon(
                             imageVector = Icons.Rounded.Share,
-                            contentDescription = "Share station",
+                            contentDescription = stringResource(R.string.share_station),
                         )
                     }
                 }
@@ -449,7 +451,7 @@ fun NowPlayingScreen(
                         Spacer(Modifier.width(8.dp))
                         Icon(
                             imageVector = Icons.Rounded.ContentCopy,
-                            contentDescription = "Copy track info",
+                            contentDescription = stringResource(R.string.copy_track_info),
                             tint = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.size(18.dp),
                         )
@@ -590,7 +592,7 @@ fun NowPlayingScreen(
                                 IconButtonDefaults.smallPressedShape,
                             ),
                         ) {
-                            Icon(Icons.Rounded.ContentCopy, contentDescription = "Copy track info")
+                            Icon(Icons.Rounded.ContentCopy, contentDescription = stringResource(R.string.copy_track_info))
                         }
                     }
                 }

--- a/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
@@ -103,6 +103,7 @@ fun NowPlayingScreen(
     onDismiss: () -> Unit,
 ) {
     val context = LocalContext.current
+    val shareStationLabel = stringResource(R.string.share_station)
     val dismissThresholdPx = with(LocalDensity.current) { 96.dp.toPx() }
     var dragOffsetY by remember { mutableFloatStateOf(0f) }
     var showTrackDetail by remember { mutableStateOf(false) }
@@ -368,7 +369,7 @@ fun NowPlayingScreen(
                                 putExtra(Intent.EXTRA_TEXT, "${station.name}\n${station.streamUrl}")
                             }
                             context.startActivity(
-                                Intent.createChooser(sendIntent, context.getString(R.string.share_station)),
+                                Intent.createChooser(sendIntent, shareStationLabel),
                             )
                         },
                         shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),

--- a/app/src/main/java/com/shapeshed/aerial/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/SettingsScreen.kt
@@ -32,10 +32,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import android.os.Build
 import com.shapeshed.aerial.BuildConfig
+import com.shapeshed.aerial.R
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -66,13 +69,13 @@ fun SettingsScreen(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
-                title = { Text("Settings") },
+                title = { Text(stringResource(R.string.settings)) },
                 navigationIcon = {
                     IconButton(
                         onClick = onDismiss,
                         shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
                     ) {
-                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 },
             )
@@ -86,8 +89,8 @@ fun SettingsScreen(
             item(contentType = "setting") {
                 ListItem(
                     modifier = Modifier.clickable { viewModel.setEnrichMetadata(!enrichMetadata) },
-                    headlineContent = { Text("Show what's playing") },
-                    supportingContent = { Text("Display song, artist, and artwork when available") },
+                    headlineContent = { Text(stringResource(R.string.show_whats_playing)) },
+                    supportingContent = { Text(stringResource(R.string.show_whats_playing_desc)) },
                     trailingContent = {
                         Switch(
                             checked = enrichMetadata,
@@ -97,9 +100,16 @@ fun SettingsScreen(
                 )
                 HorizontalDivider()
             }
+            // In-app language picker only for pre-Android-13; 13+ uses the system per-app setting.
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                item(contentType = "setting") {
+                    LanguageSettingRow()
+                    HorizontalDivider()
+                }
+            }
             item(contentType = "section") {
                 Text(
-                    text = "Data",
+                    text = stringResource(R.string.section_data),
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
@@ -113,8 +123,8 @@ fun SettingsScreen(
                     leadingContent = {
                         Icon(Icons.Rounded.FileDownload, contentDescription = null)
                     },
-                    headlineContent = { Text("Export backup") },
-                    supportingContent = { Text("Save stations, settings, and local logos") },
+                    headlineContent = { Text(stringResource(R.string.export_backup)) },
+                    supportingContent = { Text(stringResource(R.string.export_backup_desc)) },
                 )
                 HorizontalDivider()
             }
@@ -126,15 +136,15 @@ fun SettingsScreen(
                     leadingContent = {
                         Icon(Icons.Rounded.FileUpload, contentDescription = null)
                     },
-                    headlineContent = { Text("Import backup") },
-                    supportingContent = { Text("Merge stations and restore settings from a backup") },
+                    headlineContent = { Text(stringResource(R.string.import_backup)) },
+                    supportingContent = { Text(stringResource(R.string.import_backup_desc)) },
                 )
                 HorizontalDivider()
             }
             if (BuildConfig.DEBUG) {
                 item(contentType = "section") {
                     Text(
-                        text = "Debug",
+                        text = stringResource(R.string.section_debug),
                         style = MaterialTheme.typography.labelLarge,
                         color = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
@@ -143,14 +153,14 @@ fun SettingsScreen(
                 item(contentType = "action") {
                     ListItem(
                         modifier = Modifier.clickable { viewModel.refreshRegistry() },
-                        headlineContent = { Text("Refresh registry") },
-                        supportingContent = { Text("Force fetch latest station registry from network") },
+                        headlineContent = { Text(stringResource(R.string.refresh_registry)) },
+                        supportingContent = { Text(stringResource(R.string.refresh_registry_desc)) },
                     )
                 }
             }
             item(contentType = "footer") {
                 Text(
-                    text = "Aerial $versionName",
+                    text = stringResource(R.string.version_format, versionName),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center,

--- a/app/src/main/java/com/shapeshed/aerial/ui/SleepTimerSheet.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/SleepTimerSheet.kt
@@ -38,8 +38,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.shapeshed.aerial.R
 import com.shapeshed.aerial.data.SleepTimerState
 
 private const val MINUTE_MS = 60_000L
@@ -62,13 +64,14 @@ fun formatSleepRemaining(ms: Long): String {
     return if (h > 0) "%d:%02d:%02d".format(h, m, s) else "%d:%02d".format(m, s)
 }
 
+@Composable
 private fun presetLabel(ms: Long): String {
-    if (ms < MINUTE_MS) return "${ms / 1000} sec"
-    val min = ms / MINUTE_MS
+    if (ms < MINUTE_MS) return stringResource(R.string.sleep_preset_seconds, (ms / 1000).toInt())
+    val min = (ms / MINUTE_MS).toInt()
     return when {
-        min < 60 -> "$min min"
-        min % 60 == 0L -> "${min / 60} hr"
-        else -> "${min / 60}h ${min % 60}m"
+        min < 60 -> stringResource(R.string.sleep_preset_minutes, min)
+        min % 60 == 0 -> stringResource(R.string.sleep_preset_hours, min / 60)
+        else -> stringResource(R.string.sleep_preset_hours_minutes, min / 60, min % 60)
     }
 }
 
@@ -95,7 +98,7 @@ fun SleepTimerAction(active: SleepTimerState?, onClick: () -> Unit) {
             ) {
                 Icon(
                     Icons.Rounded.Bedtime,
-                    contentDescription = "Sleep timer",
+                    contentDescription = stringResource(R.string.sleep_timer),
                     modifier = Modifier.size(18.dp),
                 )
                 Spacer(Modifier.width(6.dp))
@@ -114,7 +117,7 @@ fun SleepTimerAction(active: SleepTimerState?, onClick: () -> Unit) {
             shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
             modifier = Modifier.padding(end = 8.dp),
         ) {
-            Icon(Icons.Rounded.Bedtime, contentDescription = "Sleep timer")
+            Icon(Icons.Rounded.Bedtime, contentDescription = stringResource(R.string.sleep_timer))
         }
     }
 }
@@ -136,7 +139,7 @@ fun SleepTimerSheet(
                 .padding(bottom = 48.dp),
         ) {
             Text(
-                text = "Sleep timer",
+                text = stringResource(R.string.sleep_timer),
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.SemiBold,
             )
@@ -180,18 +183,18 @@ fun SleepTimerSheet(
                         onClick = { onCancel(); onDismiss() },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Text("Cancel")
+                        Text(stringResource(R.string.action_cancel))
                     }
                     FilledTonalButton(
                         onClick = { onSet(active.remainingMs + 15 * MINUTE_MS) },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Text("+15 min")
+                        Text(stringResource(R.string.sleep_add_15))
                     }
                 }
                 Spacer(Modifier.height(28.dp))
                 Text(
-                    text = "Set a new duration",
+                    text = stringResource(R.string.sleep_set_new_duration),
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/app/src/main/java/com/shapeshed/aerial/ui/StationEditScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/StationEditScreen.kt
@@ -1,5 +1,8 @@
 package com.shapeshed.aerial.ui
 
+import androidx.compose.ui.res.stringResource
+import com.shapeshed.aerial.R
+
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -72,13 +75,13 @@ fun StationEditScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(if (viewModel.isEditing) "Edit station" else "Add station") },
+                title = { Text(stringResource(if (viewModel.isEditing) R.string.edit_station else R.string.add_station)) },
                 navigationIcon = {
                     IconButton(
                         onClick = onDismiss,
                         shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
                     ) {
-                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 },
                 actions = {
@@ -86,7 +89,7 @@ fun StationEditScreen(
                         onClick = { viewModel.save(onDismiss) },
                         enabled = name.isNotBlank() && streamUrl.isNotBlank(),
                     ) {
-                        Text("Save")
+                        Text(stringResource(R.string.action_save))
                     }
                 },
             )
@@ -103,6 +106,9 @@ fun StationEditScreen(
         ) {
             Spacer(Modifier.height(8.dp))
 
+            // Hoisted: stringResource can't be called inside the semantics {} lambda.
+            val changeLogoLabel = stringResource(R.string.change_station_logo)
+            val chooseLogoLabel = stringResource(R.string.choose_station_logo)
             Box(
                 contentAlignment = Alignment.Center,
                 modifier = Modifier.size(120.dp),
@@ -115,8 +121,8 @@ fun StationEditScreen(
                         .background(MaterialTheme.colorScheme.primaryContainer)
                         .semantics {
                             role = Role.Button
-                            contentDescription = "Change station logo"
-                            onClick("Choose station logo") { true }
+                            contentDescription = changeLogoLabel
+                            onClick(chooseLogoLabel) { true }
                         }
                         .clickable { imagePicker.launch(arrayOf("image/*")) },
                 ) {
@@ -155,26 +161,26 @@ fun StationEditScreen(
 
             if (logoPath.isNotEmpty()) {
                 TextButton(onClick = { showRemoveLogoConfirm = true }) {
-                    Text("Remove icon")
+                    Text(stringResource(R.string.remove_icon))
                 }
             }
 
             if (showRemoveLogoConfirm) {
                 AlertDialog(
                     onDismissRequest = { showRemoveLogoConfirm = false },
-                    title = { Text("Remove icon?") },
-                    text = { Text("The station icon will be removed.") },
+                    title = { Text(stringResource(R.string.remove_icon_title)) },
+                    text = { Text(stringResource(R.string.remove_icon_message)) },
                     confirmButton = {
                         TextButton(onClick = {
                             viewModel.removeLogo()
                             showRemoveLogoConfirm = false
                         }) {
-                            Text("Remove", color = MaterialTheme.colorScheme.error)
+                            Text(stringResource(R.string.action_remove), color = MaterialTheme.colorScheme.error)
                         }
                     },
                     dismissButton = {
                         TextButton(onClick = { showRemoveLogoConfirm = false }) {
-                            Text("Cancel")
+                            Text(stringResource(R.string.action_cancel))
                         }
                     },
                 )
@@ -183,14 +189,14 @@ fun StationEditScreen(
             OutlinedTextField(
                 value = name,
                 onValueChange = { viewModel.onNameChange(it) },
-                label = { Text("Name") },
+                label = { Text(stringResource(R.string.field_name)) },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
             )
             OutlinedTextField(
                 value = streamUrl,
                 onValueChange = { viewModel.onStreamUrlChange(it) },
-                label = { Text("Stream URL") },
+                label = { Text(stringResource(R.string.field_stream_url)) },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
             )

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -58,7 +58,6 @@
     <string name="refresh_registry_desc">Neueste Senderliste aus dem Netzwerk erzwingen</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Sprache</string>
-    <string name="language_desc">App-Sprache wählen</string>
     <string name="language_system_default">Systemstandard</string>
 
     <!-- Station edit -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Aerial</string>
+
+    <!-- Common actions -->
+    <string name="action_back">Zurück</string>
+    <string name="action_remove">Entfernen</string>
+    <string name="action_cancel">Abbrechen</string>
+    <string name="action_clear">Löschen</string>
+    <string name="action_save">Speichern</string>
+    <string name="action_edit">Bearbeiten</string>
+
+    <!-- Search / home -->
+    <string name="search_hint">Sender suchen</string>
+    <string name="clear_search">Suche löschen</string>
+    <string name="settings">Einstellungen</string>
+    <string name="buffering">Wird gepuffert…</string>
+    <string name="play">Abspielen</string>
+    <string name="pause">Pause</string>
+    <string name="filter_country">Land</string>
+    <string name="filter_genre">Genre</string>
+    <string name="search_countries">Länder suchen</string>
+    <string name="search_genres">Genres suchen</string>
+    <string name="clear_all">Alles löschen</string>
+    <string name="remove_station_title">Sender entfernen?</string>
+    <string name="remove_station_message">\"%1$s\" wird aus deinen Favoriten entfernt.</string>
+    <string name="no_stations_found">Keine Sender gefunden</string>
+    <string name="no_stations_found_desc">Versuche eine andere Suche oder füge einen Sender über seine Stream-URL hinzu.</string>
+    <string name="add_your_own_station">Eigenen Sender hinzufügen</string>
+    <string name="save_to_favorites">Zu Favoriten hinzufügen</string>
+    <string name="remove_from_favorites">Aus Favoriten entfernen</string>
+    <string name="no_internet_title">Keine Internetverbindung</string>
+    <string name="no_internet_desc">Radio-Streams erfordern eine aktive Internetverbindung.</string>
+    <string name="favorites_header">Deine Favoriten</string>
+    <string name="get_started">Loslegen</string>
+    <string name="just_listen">Einfach zuhören</string>
+    <string name="find_a_station">Sender finden</string>
+    <string name="find_one_to_listen">Finde einen zum Anhören</string>
+    <string name="no_matches">Keine Treffer</string>
+    <string name="no_matches_desc">Versuche eine andere Suche.</string>
+
+    <!-- Now playing -->
+    <string name="close_player">Player schließen</string>
+    <string name="add_to_favorites">Zu Favoriten hinzufügen</string>
+    <string name="share_station">Sender teilen</string>
+    <string name="copy_track_info">Titelinfo kopieren</string>
+
+    <!-- Settings -->
+    <string name="show_whats_playing">Aktuellen Titel anzeigen</string>
+    <string name="show_whats_playing_desc">Zeigt Titel, Interpret und Cover an, falls verfügbar</string>
+    <string name="section_data">Daten</string>
+    <string name="export_backup">Backup exportieren</string>
+    <string name="export_backup_desc">Speichert Sender, Einstellungen und lokale Logos</string>
+    <string name="import_backup">Backup importieren</string>
+    <string name="import_backup_desc">Führt Sender zusammen und stellt Einstellungen aus einem Backup wieder her</string>
+    <string name="section_debug">Debug</string>
+    <string name="refresh_registry">Registry aktualisieren</string>
+    <string name="refresh_registry_desc">Neueste Senderliste aus dem Netzwerk erzwingen</string>
+    <string name="version_format">Aerial %1$s</string>
+    <string name="language">Sprache</string>
+    <string name="language_desc">App-Sprache wählen</string>
+    <string name="language_system_default">Systemstandard</string>
+
+    <!-- Station edit -->
+    <string name="edit_station">Sender bearbeiten</string>
+    <string name="add_station">Sender hinzufügen</string>
+    <string name="change_station_logo">Senderlogo ändern</string>
+    <string name="choose_station_logo">Senderlogo auswählen</string>
+    <string name="remove_icon">Symbol entfernen</string>
+    <string name="remove_icon_title">Symbol entfernen?</string>
+    <string name="remove_icon_message">Das Sendersymbol wird entfernt.</string>
+    <string name="field_name">Name</string>
+    <string name="field_stream_url">Stream-URL</string>
+
+    <!-- Sleep timer -->
+    <string name="sleep_timer">Sleep-Timer</string>
+    <string name="sleep_add_15">+15 Min</string>
+    <string name="sleep_set_new_duration">Neue Dauer festlegen</string>
+    <string name="sleep_preset_seconds">%1$d Sek</string>
+    <string name="sleep_preset_minutes">%1$d Min</string>
+    <string name="sleep_preset_hours">%1$d Std</string>
+    <string name="sleep_preset_hours_minutes">%1$d Std %2$d Min</string>
+    <string name="live_radio">Live-Radio</string>
+    <string name="tag_news">Nachrichten</string>
+    <string name="tag_sport">Sport</string>
+    <string name="tag_pop">Pop</string>
+    <string name="tag_rock">Rock</string>
+    <string name="tag_jazz">Jazz</string>
+    <string name="tag_classical">Klassik</string>
+    <string name="tag_dance">Dance</string>
+    <string name="tag_soul">Soul</string>
+    <string name="tag_country">Country</string>
+    <string name="tag_electronic">Elektronisch</string>
+</resources>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- British English: only the strings that differ from the base (en-US) "favorite" spelling. -->
+<resources>
+    <string name="remove_station_message">\"%1$s\" will be removed from your favourites.</string>
+    <string name="save_to_favorites">Save to favourites</string>
+    <string name="remove_from_favorites">Remove from favourites</string>
+    <string name="add_to_favorites">Add to favourites</string>
+    <string name="favorites_header">Your favourites</string>
+</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Aerial</string>
+
+    <!-- Common actions -->
+    <string name="action_back">Atrás</string>
+    <string name="action_remove">Quitar</string>
+    <string name="action_cancel">Cancelar</string>
+    <string name="action_clear">Borrar</string>
+    <string name="action_save">Guardar</string>
+    <string name="action_edit">Editar</string>
+
+    <!-- Search / home -->
+    <string name="search_hint">Buscar emisoras</string>
+    <string name="clear_search">Borrar búsqueda</string>
+    <string name="settings">Ajustes</string>
+    <string name="buffering">Cargando…</string>
+    <string name="play">Reproducir</string>
+    <string name="pause">Pausar</string>
+    <string name="filter_country">País</string>
+    <string name="filter_genre">Género</string>
+    <string name="search_countries">Buscar países</string>
+    <string name="search_genres">Buscar géneros</string>
+    <string name="clear_all">Borrar todo</string>
+    <string name="remove_station_title">¿Quitar emisora?</string>
+    <string name="remove_station_message">Se quitará \"%1$s\" de tus favoritos.</string>
+    <string name="no_stations_found">No se encontraron emisoras</string>
+    <string name="no_stations_found_desc">Prueba otra búsqueda o añade una emisora con su URL de emisión.</string>
+    <string name="add_your_own_station">Añade tu propia emisora</string>
+    <string name="save_to_favorites">Guardar en favoritos</string>
+    <string name="remove_from_favorites">Quitar de favoritos</string>
+    <string name="no_internet_title">Sin conexión a internet</string>
+    <string name="no_internet_desc">Las emisiones de radio requieren una conexión a internet activa.</string>
+    <string name="favorites_header">Tus favoritos</string>
+    <string name="get_started">Empezar</string>
+    <string name="just_listen">Solo escucha</string>
+    <string name="find_a_station">Buscar una emisora</string>
+    <string name="find_one_to_listen">Encuentra una para escuchar</string>
+    <string name="no_matches">Sin resultados</string>
+    <string name="no_matches_desc">Prueba otra búsqueda.</string>
+
+    <!-- Now playing -->
+    <string name="close_player">Cerrar reproductor</string>
+    <string name="add_to_favorites">Añadir a favoritos</string>
+    <string name="share_station">Compartir emisora</string>
+    <string name="copy_track_info">Copiar info de la pista</string>
+
+    <!-- Settings -->
+    <string name="show_whats_playing">Mostrar qué suena</string>
+    <string name="show_whats_playing_desc">Muestra la canción, el artista y la portada cuando estén disponibles</string>
+    <string name="section_data">Datos</string>
+    <string name="export_backup">Exportar copia</string>
+    <string name="export_backup_desc">Guarda emisoras, ajustes y logotipos locales</string>
+    <string name="import_backup">Importar copia</string>
+    <string name="import_backup_desc">Combina emisoras y restaura los ajustes desde una copia</string>
+    <string name="section_debug">Depuración</string>
+    <string name="refresh_registry">Actualizar registro</string>
+    <string name="refresh_registry_desc">Forzar la descarga del último registro de emisoras de la red</string>
+    <string name="version_format">Aerial %1$s</string>
+    <string name="language">Idioma</string>
+    <string name="language_desc">Elige el idioma de la app</string>
+    <string name="language_system_default">Predeterminado del sistema</string>
+
+    <!-- Station edit -->
+    <string name="edit_station">Editar emisora</string>
+    <string name="add_station">Añadir emisora</string>
+    <string name="change_station_logo">Cambiar logotipo de la emisora</string>
+    <string name="choose_station_logo">Elegir logotipo de la emisora</string>
+    <string name="remove_icon">Quitar icono</string>
+    <string name="remove_icon_title">¿Quitar icono?</string>
+    <string name="remove_icon_message">Se quitará el icono de la emisora.</string>
+    <string name="field_name">Nombre</string>
+    <string name="field_stream_url">URL de emisión</string>
+
+    <!-- Sleep timer -->
+    <string name="sleep_timer">Temporizador</string>
+    <string name="sleep_add_15">+15 min</string>
+    <string name="sleep_set_new_duration">Establecer nueva duración</string>
+    <string name="sleep_preset_seconds">%1$d s</string>
+    <string name="sleep_preset_minutes">%1$d min</string>
+    <string name="sleep_preset_hours">%1$d h</string>
+    <string name="sleep_preset_hours_minutes">%1$d h %2$d min</string>
+    <string name="live_radio">Radio en vivo</string>
+    <string name="tag_news">Noticias</string>
+    <string name="tag_sport">Deportes</string>
+    <string name="tag_pop">Pop</string>
+    <string name="tag_rock">Rock</string>
+    <string name="tag_jazz">Jazz</string>
+    <string name="tag_classical">Clásica</string>
+    <string name="tag_dance">Dance</string>
+    <string name="tag_soul">Soul</string>
+    <string name="tag_country">Country</string>
+    <string name="tag_electronic">Electrónica</string>
+</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -58,7 +58,6 @@
     <string name="refresh_registry_desc">Forzar la descarga del último registro de emisoras de la red</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Idioma</string>
-    <string name="language_desc">Elige el idioma de la app</string>
     <string name="language_system_default">Predeterminado del sistema</string>
 
     <!-- Station edit -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -58,7 +58,6 @@
     <string name="refresh_registry_desc">Forcer le téléchargement du dernier registre des stations depuis le réseau</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Langue</string>
-    <string name="language_desc">Choisir la langue de l\'application</string>
     <string name="language_system_default">Par défaut du système</string>
 
     <!-- Station edit -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Aerial</string>
+
+    <!-- Common actions -->
+    <string name="action_back">Retour</string>
+    <string name="action_remove">Supprimer</string>
+    <string name="action_cancel">Annuler</string>
+    <string name="action_clear">Effacer</string>
+    <string name="action_save">Enregistrer</string>
+    <string name="action_edit">Modifier</string>
+
+    <!-- Search / home -->
+    <string name="search_hint">Rechercher des stations</string>
+    <string name="clear_search">Effacer la recherche</string>
+    <string name="settings">Paramètres</string>
+    <string name="buffering">Mise en mémoire tampon…</string>
+    <string name="play">Lire</string>
+    <string name="pause">Pause</string>
+    <string name="filter_country">Pays</string>
+    <string name="filter_genre">Genre</string>
+    <string name="search_countries">Rechercher des pays</string>
+    <string name="search_genres">Rechercher des genres</string>
+    <string name="clear_all">Tout effacer</string>
+    <string name="remove_station_title">Supprimer la station ?</string>
+    <string name="remove_station_message">\"%1$s\" sera supprimée de vos favoris.</string>
+    <string name="no_stations_found">Aucune station trouvée</string>
+    <string name="no_stations_found_desc">Essayez une autre recherche ou ajoutez une station avec son URL de flux.</string>
+    <string name="add_your_own_station">Ajoutez votre propre station</string>
+    <string name="save_to_favorites">Ajouter aux favoris</string>
+    <string name="remove_from_favorites">Retirer des favoris</string>
+    <string name="no_internet_title">Aucune connexion internet</string>
+    <string name="no_internet_desc">Les flux radio nécessitent une connexion internet active.</string>
+    <string name="favorites_header">Vos favoris</string>
+    <string name="get_started">Commencer</string>
+    <string name="just_listen">Écoutez, tout simplement</string>
+    <string name="find_a_station">Trouver une station</string>
+    <string name="find_one_to_listen">Trouvez-en une à écouter</string>
+    <string name="no_matches">Aucun résultat</string>
+    <string name="no_matches_desc">Essayez une autre recherche.</string>
+
+    <!-- Now playing -->
+    <string name="close_player">Fermer le lecteur</string>
+    <string name="add_to_favorites">Ajouter aux favoris</string>
+    <string name="share_station">Partager la station</string>
+    <string name="copy_track_info">Copier les infos du titre</string>
+
+    <!-- Settings -->
+    <string name="show_whats_playing">Afficher le titre en cours</string>
+    <string name="show_whats_playing_desc">Affiche le morceau, l\'artiste et la pochette lorsque disponibles</string>
+    <string name="section_data">Données</string>
+    <string name="export_backup">Exporter la sauvegarde</string>
+    <string name="export_backup_desc">Enregistre les stations, les paramètres et les logos locaux</string>
+    <string name="import_backup">Importer la sauvegarde</string>
+    <string name="import_backup_desc">Fusionne les stations et restaure les paramètres depuis une sauvegarde</string>
+    <string name="section_debug">Débogage</string>
+    <string name="refresh_registry">Actualiser le registre</string>
+    <string name="refresh_registry_desc">Forcer le téléchargement du dernier registre des stations depuis le réseau</string>
+    <string name="version_format">Aerial %1$s</string>
+    <string name="language">Langue</string>
+    <string name="language_desc">Choisir la langue de l\'application</string>
+    <string name="language_system_default">Par défaut du système</string>
+
+    <!-- Station edit -->
+    <string name="edit_station">Modifier la station</string>
+    <string name="add_station">Ajouter une station</string>
+    <string name="change_station_logo">Changer le logo de la station</string>
+    <string name="choose_station_logo">Choisir le logo de la station</string>
+    <string name="remove_icon">Supprimer l\'icône</string>
+    <string name="remove_icon_title">Supprimer l\'icône ?</string>
+    <string name="remove_icon_message">L\'icône de la station sera supprimée.</string>
+    <string name="field_name">Nom</string>
+    <string name="field_stream_url">URL du flux</string>
+
+    <!-- Sleep timer -->
+    <string name="sleep_timer">Minuteur de veille</string>
+    <string name="sleep_add_15">+15 min</string>
+    <string name="sleep_set_new_duration">Définir une nouvelle durée</string>
+    <string name="sleep_preset_seconds">%1$d s</string>
+    <string name="sleep_preset_minutes">%1$d min</string>
+    <string name="sleep_preset_hours">%1$d h</string>
+    <string name="sleep_preset_hours_minutes">%1$d h %2$d min</string>
+    <string name="live_radio">Radio en direct</string>
+    <string name="tag_news">Actualités</string>
+    <string name="tag_sport">Sport</string>
+    <string name="tag_pop">Pop</string>
+    <string name="tag_rock">Rock</string>
+    <string name="tag_jazz">Jazz</string>
+    <string name="tag_classical">Classique</string>
+    <string name="tag_dance">Dance</string>
+    <string name="tag_soul">Soul</string>
+    <string name="tag_country">Country</string>
+    <string name="tag_electronic">Électronique</string>
+</resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -58,7 +58,6 @@
     <string name="refresh_registry_desc">Forza il download dell\'ultimo registro delle stazioni dalla rete</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Lingua</string>
-    <string name="language_desc">Scegli la lingua dell\'app</string>
     <string name="language_system_default">Predefinita di sistema</string>
 
     <!-- Station edit -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Aerial</string>
+
+    <!-- Common actions -->
+    <string name="action_back">Indietro</string>
+    <string name="action_remove">Rimuovi</string>
+    <string name="action_cancel">Annulla</string>
+    <string name="action_clear">Cancella</string>
+    <string name="action_save">Salva</string>
+    <string name="action_edit">Modifica</string>
+
+    <!-- Search / home -->
+    <string name="search_hint">Cerca stazioni</string>
+    <string name="clear_search">Cancella ricerca</string>
+    <string name="settings">Impostazioni</string>
+    <string name="buffering">Buffering…</string>
+    <string name="play">Riproduci</string>
+    <string name="pause">Pausa</string>
+    <string name="filter_country">Paese</string>
+    <string name="filter_genre">Genere</string>
+    <string name="search_countries">Cerca paesi</string>
+    <string name="search_genres">Cerca generi</string>
+    <string name="clear_all">Cancella tutto</string>
+    <string name="remove_station_title">Rimuovere la stazione?</string>
+    <string name="remove_station_message">\"%1$s\" verrà rimossa dai tuoi preferiti.</string>
+    <string name="no_stations_found">Nessuna stazione trovata</string>
+    <string name="no_stations_found_desc">Prova un\'altra ricerca oppure aggiungi una stazione tramite il suo URL di streaming.</string>
+    <string name="add_your_own_station">Aggiungi la tua stazione</string>
+    <string name="save_to_favorites">Salva nei preferiti</string>
+    <string name="remove_from_favorites">Rimuovi dai preferiti</string>
+    <string name="no_internet_title">Nessuna connessione a internet</string>
+    <string name="no_internet_desc">Gli stream radio richiedono una connessione a internet attiva.</string>
+    <string name="favorites_header">I tuoi preferiti</string>
+    <string name="get_started">Inizia</string>
+    <string name="just_listen">Ascolta e basta</string>
+    <string name="find_a_station">Trova una stazione</string>
+    <string name="find_one_to_listen">Trovane una da ascoltare</string>
+    <string name="no_matches">Nessun risultato</string>
+    <string name="no_matches_desc">Prova un\'altra ricerca.</string>
+
+    <!-- Now playing -->
+    <string name="close_player">Chiudi player</string>
+    <string name="add_to_favorites">Aggiungi ai preferiti</string>
+    <string name="share_station">Condividi stazione</string>
+    <string name="copy_track_info">Copia info brano</string>
+
+    <!-- Settings -->
+    <string name="show_whats_playing">Mostra cosa è in onda</string>
+    <string name="show_whats_playing_desc">Mostra brano, artista e copertina quando disponibili</string>
+    <string name="section_data">Dati</string>
+    <string name="export_backup">Esporta backup</string>
+    <string name="export_backup_desc">Salva stazioni, impostazioni e loghi locali</string>
+    <string name="import_backup">Importa backup</string>
+    <string name="import_backup_desc">Unisce le stazioni e ripristina le impostazioni da un backup</string>
+    <string name="section_debug">Debug</string>
+    <string name="refresh_registry">Aggiorna registro</string>
+    <string name="refresh_registry_desc">Forza il download dell\'ultimo registro delle stazioni dalla rete</string>
+    <string name="version_format">Aerial %1$s</string>
+    <string name="language">Lingua</string>
+    <string name="language_desc">Scegli la lingua dell\'app</string>
+    <string name="language_system_default">Predefinita di sistema</string>
+
+    <!-- Station edit -->
+    <string name="edit_station">Modifica stazione</string>
+    <string name="add_station">Aggiungi stazione</string>
+    <string name="change_station_logo">Cambia logo stazione</string>
+    <string name="choose_station_logo">Scegli logo stazione</string>
+    <string name="remove_icon">Rimuovi icona</string>
+    <string name="remove_icon_title">Rimuovere l\'icona?</string>
+    <string name="remove_icon_message">L\'icona della stazione verrà rimossa.</string>
+    <string name="field_name">Nome</string>
+    <string name="field_stream_url">URL streaming</string>
+
+    <!-- Sleep timer -->
+    <string name="sleep_timer">Timer di spegnimento</string>
+    <string name="sleep_add_15">+15 min</string>
+    <string name="sleep_set_new_duration">Imposta una nuova durata</string>
+    <string name="sleep_preset_seconds">%1$d sec</string>
+    <string name="sleep_preset_minutes">%1$d min</string>
+    <string name="sleep_preset_hours">%1$d h</string>
+    <string name="sleep_preset_hours_minutes">%1$d h %2$d min</string>
+    <string name="live_radio">Radio in diretta</string>
+    <string name="tag_news">Notizie</string>
+    <string name="tag_sport">Sport</string>
+    <string name="tag_pop">Pop</string>
+    <string name="tag_rock">Rock</string>
+    <string name="tag_jazz">Jazz</string>
+    <string name="tag_classical">Classica</string>
+    <string name="tag_dance">Dance</string>
+    <string name="tag_soul">Soul</string>
+    <string name="tag_country">Country</string>
+    <string name="tag_electronic">Elettronica</string>
+</resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -58,7 +58,6 @@
     <string name="refresh_registry_desc">最新の放送局レジストリをネットワークから強制取得</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">言語</string>
-    <string name="language_desc">アプリの言語を選択</string>
     <string name="language_system_default">システムのデフォルト</string>
 
     <!-- Station edit -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Aerial</string>
+
+    <!-- Common actions -->
+    <string name="action_back">戻る</string>
+    <string name="action_remove">削除</string>
+    <string name="action_cancel">キャンセル</string>
+    <string name="action_clear">クリア</string>
+    <string name="action_save">保存</string>
+    <string name="action_edit">編集</string>
+
+    <!-- Search / home -->
+    <string name="search_hint">放送局を検索</string>
+    <string name="clear_search">検索をクリア</string>
+    <string name="settings">設定</string>
+    <string name="buffering">バッファ中…</string>
+    <string name="play">再生</string>
+    <string name="pause">一時停止</string>
+    <string name="filter_country">国</string>
+    <string name="filter_genre">ジャンル</string>
+    <string name="search_countries">国を検索</string>
+    <string name="search_genres">ジャンルを検索</string>
+    <string name="clear_all">すべてクリア</string>
+    <string name="remove_station_title">放送局を削除しますか？</string>
+    <string name="remove_station_message">「%1$s」をお気に入りから削除します。</string>
+    <string name="no_stations_found">放送局が見つかりません</string>
+    <string name="no_stations_found_desc">別のキーワードで検索するか、ストリームURLを使って放送局を追加してください。</string>
+    <string name="add_your_own_station">自分の放送局を追加</string>
+    <string name="save_to_favorites">お気に入りに保存</string>
+    <string name="remove_from_favorites">お気に入りから削除</string>
+    <string name="no_internet_title">インターネットに接続されていません</string>
+    <string name="no_internet_desc">ラジオのストリーミングには有効なインターネット接続が必要です。</string>
+    <string name="favorites_header">お気に入り</string>
+    <string name="get_started">はじめる</string>
+    <string name="just_listen">ただ聴くだけ</string>
+    <string name="find_a_station">放送局を探す</string>
+    <string name="find_one_to_listen">聴きたい放送局を見つけよう</string>
+    <string name="no_matches">一致するものがありません</string>
+    <string name="no_matches_desc">別のキーワードで検索してください。</string>
+
+    <!-- Now playing -->
+    <string name="close_player">プレーヤーを閉じる</string>
+    <string name="add_to_favorites">お気に入りに追加</string>
+    <string name="share_station">放送局を共有</string>
+    <string name="copy_track_info">曲情報をコピー</string>
+
+    <!-- Settings -->
+    <string name="show_whats_playing">再生中の曲を表示</string>
+    <string name="show_whats_playing_desc">利用可能な場合、曲名・アーティスト・アートワークを表示</string>
+    <string name="section_data">データ</string>
+    <string name="export_backup">バックアップを書き出す</string>
+    <string name="export_backup_desc">放送局、設定、ローカルのロゴを保存</string>
+    <string name="import_backup">バックアップを読み込む</string>
+    <string name="import_backup_desc">放送局を統合し、バックアップから設定を復元</string>
+    <string name="section_debug">デバッグ</string>
+    <string name="refresh_registry">レジストリを更新</string>
+    <string name="refresh_registry_desc">最新の放送局レジストリをネットワークから強制取得</string>
+    <string name="version_format">Aerial %1$s</string>
+    <string name="language">言語</string>
+    <string name="language_desc">アプリの言語を選択</string>
+    <string name="language_system_default">システムのデフォルト</string>
+
+    <!-- Station edit -->
+    <string name="edit_station">放送局を編集</string>
+    <string name="add_station">放送局を追加</string>
+    <string name="change_station_logo">放送局のロゴを変更</string>
+    <string name="choose_station_logo">放送局のロゴを選択</string>
+    <string name="remove_icon">アイコンを削除</string>
+    <string name="remove_icon_title">アイコンを削除しますか？</string>
+    <string name="remove_icon_message">放送局のアイコンを削除します。</string>
+    <string name="field_name">名前</string>
+    <string name="field_stream_url">ストリームURL</string>
+
+    <!-- Sleep timer -->
+    <string name="sleep_timer">スリープタイマー</string>
+    <string name="sleep_add_15">+15分</string>
+    <string name="sleep_set_new_duration">新しい時間を設定</string>
+    <string name="sleep_preset_seconds">%1$d秒</string>
+    <string name="sleep_preset_minutes">%1$d分</string>
+    <string name="sleep_preset_hours">%1$d時間</string>
+    <string name="sleep_preset_hours_minutes">%1$d時間%2$d分</string>
+    <string name="live_radio">ライブラジオ</string>
+    <string name="tag_news">ニュース</string>
+    <string name="tag_sport">スポーツ</string>
+    <string name="tag_pop">ポップ</string>
+    <string name="tag_rock">ロック</string>
+    <string name="tag_jazz">ジャズ</string>
+    <string name="tag_classical">クラシック</string>
+    <string name="tag_dance">ダンス</string>
+    <string name="tag_soul">ソウル</string>
+    <string name="tag_country">カントリー</string>
+    <string name="tag_electronic">エレクトロニック</string>
+</resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -58,7 +58,6 @@
     <string name="refresh_registry_desc">네트워크에서 최신 방송국 레지스트리를 강제로 가져오기</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">언어</string>
-    <string name="language_desc">앱 언어 선택</string>
     <string name="language_system_default">시스템 기본값</string>
 
     <!-- Station edit -->

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Aerial</string>
+
+    <!-- Common actions -->
+    <string name="action_back">뒤로</string>
+    <string name="action_remove">삭제</string>
+    <string name="action_cancel">취소</string>
+    <string name="action_clear">지우기</string>
+    <string name="action_save">저장</string>
+    <string name="action_edit">편집</string>
+
+    <!-- Search / home -->
+    <string name="search_hint">방송국 검색</string>
+    <string name="clear_search">검색어 지우기</string>
+    <string name="settings">설정</string>
+    <string name="buffering">버퍼링 중…</string>
+    <string name="play">재생</string>
+    <string name="pause">일시정지</string>
+    <string name="filter_country">국가</string>
+    <string name="filter_genre">장르</string>
+    <string name="search_countries">국가 검색</string>
+    <string name="search_genres">장르 검색</string>
+    <string name="clear_all">모두 지우기</string>
+    <string name="remove_station_title">방송국을 삭제할까요?</string>
+    <string name="remove_station_message">즐겨찾기에서 \"%1$s\"이(가) 삭제됩니다.</string>
+    <string name="no_stations_found">방송국을 찾을 수 없습니다</string>
+    <string name="no_stations_found_desc">다른 검색어를 시도하거나 스트림 URL로 방송국을 추가하세요.</string>
+    <string name="add_your_own_station">나만의 방송국 추가</string>
+    <string name="save_to_favorites">즐겨찾기에 저장</string>
+    <string name="remove_from_favorites">즐겨찾기에서 삭제</string>
+    <string name="no_internet_title">인터넷 연결 없음</string>
+    <string name="no_internet_desc">라디오 스트림에는 인터넷 연결이 필요합니다.</string>
+    <string name="favorites_header">즐겨찾기</string>
+    <string name="get_started">시작하기</string>
+    <string name="just_listen">그냥 들어보세요</string>
+    <string name="find_a_station">방송국 찾기</string>
+    <string name="find_one_to_listen">들을 방송국을 찾아보세요</string>
+    <string name="no_matches">일치하는 항목 없음</string>
+    <string name="no_matches_desc">다른 검색어를 시도하세요.</string>
+
+    <!-- Now playing -->
+    <string name="close_player">플레이어 닫기</string>
+    <string name="add_to_favorites">즐겨찾기에 추가</string>
+    <string name="share_station">방송국 공유</string>
+    <string name="copy_track_info">트랙 정보 복사</string>
+
+    <!-- Settings -->
+    <string name="show_whats_playing">재생 중인 곡 표시</string>
+    <string name="show_whats_playing_desc">가능한 경우 곡, 아티스트, 아트워크를 표시</string>
+    <string name="section_data">데이터</string>
+    <string name="export_backup">백업 내보내기</string>
+    <string name="export_backup_desc">방송국, 설정, 로컬 로고 저장</string>
+    <string name="import_backup">백업 가져오기</string>
+    <string name="import_backup_desc">백업에서 방송국을 병합하고 설정을 복원</string>
+    <string name="section_debug">디버그</string>
+    <string name="refresh_registry">레지스트리 새로고침</string>
+    <string name="refresh_registry_desc">네트워크에서 최신 방송국 레지스트리를 강제로 가져오기</string>
+    <string name="version_format">Aerial %1$s</string>
+    <string name="language">언어</string>
+    <string name="language_desc">앱 언어 선택</string>
+    <string name="language_system_default">시스템 기본값</string>
+
+    <!-- Station edit -->
+    <string name="edit_station">방송국 편집</string>
+    <string name="add_station">방송국 추가</string>
+    <string name="change_station_logo">방송국 로고 변경</string>
+    <string name="choose_station_logo">방송국 로고 선택</string>
+    <string name="remove_icon">아이콘 삭제</string>
+    <string name="remove_icon_title">아이콘을 삭제할까요?</string>
+    <string name="remove_icon_message">방송국 아이콘이 삭제됩니다.</string>
+    <string name="field_name">이름</string>
+    <string name="field_stream_url">스트림 URL</string>
+
+    <!-- Sleep timer -->
+    <string name="sleep_timer">취침 타이머</string>
+    <string name="sleep_add_15">+15분</string>
+    <string name="sleep_set_new_duration">새 시간 설정</string>
+    <string name="sleep_preset_seconds">%1$d초</string>
+    <string name="sleep_preset_minutes">%1$d분</string>
+    <string name="sleep_preset_hours">%1$d시간</string>
+    <string name="sleep_preset_hours_minutes">%1$d시간 %2$d분</string>
+    <string name="live_radio">라이브 라디오</string>
+    <string name="tag_news">뉴스</string>
+    <string name="tag_sport">스포츠</string>
+    <string name="tag_pop">팝</string>
+    <string name="tag_rock">록</string>
+    <string name="tag_jazz">재즈</string>
+    <string name="tag_classical">클래식</string>
+    <string name="tag_dance">댄스</string>
+    <string name="tag_soul">소울</string>
+    <string name="tag_country">컨트리</string>
+    <string name="tag_electronic">일렉트로닉</string>
+</resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Aerial</string>
+
+    <!-- Common actions -->
+    <string name="action_back">Terug</string>
+    <string name="action_remove">Verwijderen</string>
+    <string name="action_cancel">Annuleren</string>
+    <string name="action_clear">Wissen</string>
+    <string name="action_save">Opslaan</string>
+    <string name="action_edit">Bewerken</string>
+
+    <!-- Search / home -->
+    <string name="search_hint">Zenders zoeken</string>
+    <string name="clear_search">Zoekopdracht wissen</string>
+    <string name="settings">Instellingen</string>
+    <string name="buffering">Bufferen…</string>
+    <string name="play">Afspelen</string>
+    <string name="pause">Pauzeren</string>
+    <string name="filter_country">Land</string>
+    <string name="filter_genre">Genre</string>
+    <string name="search_countries">Landen zoeken</string>
+    <string name="search_genres">Genres zoeken</string>
+    <string name="clear_all">Alles wissen</string>
+    <string name="remove_station_title">Zender verwijderen?</string>
+    <string name="remove_station_message">\"%1$s\" wordt uit je favorieten verwijderd.</string>
+    <string name="no_stations_found">Geen zenders gevonden</string>
+    <string name="no_stations_found_desc">Probeer een andere zoekopdracht of voeg een zender toe met de stream-URL.</string>
+    <string name="add_your_own_station">Voeg je eigen zender toe</string>
+    <string name="save_to_favorites">Opslaan in favorieten</string>
+    <string name="remove_from_favorites">Uit favorieten verwijderen</string>
+    <string name="no_internet_title">Geen internetverbinding</string>
+    <string name="no_internet_desc">Radiostreams vereisen een actieve internetverbinding.</string>
+    <string name="favorites_header">Je favorieten</string>
+    <string name="get_started">Aan de slag</string>
+    <string name="just_listen">Gewoon luisteren</string>
+    <string name="find_a_station">Zoek een zender</string>
+    <string name="find_one_to_listen">Zoek er een om naar te luisteren</string>
+    <string name="no_matches">Geen resultaten</string>
+    <string name="no_matches_desc">Probeer een andere zoekopdracht.</string>
+
+    <!-- Now playing -->
+    <string name="close_player">Speler sluiten</string>
+    <string name="add_to_favorites">Aan favorieten toevoegen</string>
+    <string name="share_station">Zender delen</string>
+    <string name="copy_track_info">Nummerinfo kopiëren</string>
+
+    <!-- Settings -->
+    <string name="show_whats_playing">Toon wat er speelt</string>
+    <string name="show_whats_playing_desc">Toont nummer, artiest en albumhoes indien beschikbaar</string>
+    <string name="section_data">Gegevens</string>
+    <string name="export_backup">Back-up exporteren</string>
+    <string name="export_backup_desc">Slaat zenders, instellingen en lokale logo\'s op</string>
+    <string name="import_backup">Back-up importeren</string>
+    <string name="import_backup_desc">Voegt zenders samen en herstelt instellingen uit een back-up</string>
+    <string name="section_debug">Foutopsporing</string>
+    <string name="refresh_registry">Register vernieuwen</string>
+    <string name="refresh_registry_desc">Forceer het ophalen van het nieuwste zenderregister uit het netwerk</string>
+    <string name="version_format">Aerial %1$s</string>
+    <string name="language">Taal</string>
+    <string name="language_desc">Kies de taal van de app</string>
+    <string name="language_system_default">Systeemstandaard</string>
+
+    <!-- Station edit -->
+    <string name="edit_station">Zender bewerken</string>
+    <string name="add_station">Zender toevoegen</string>
+    <string name="change_station_logo">Zenderlogo wijzigen</string>
+    <string name="choose_station_logo">Zenderlogo kiezen</string>
+    <string name="remove_icon">Pictogram verwijderen</string>
+    <string name="remove_icon_title">Pictogram verwijderen?</string>
+    <string name="remove_icon_message">Het zenderpictogram wordt verwijderd.</string>
+    <string name="field_name">Naam</string>
+    <string name="field_stream_url">Stream-URL</string>
+
+    <!-- Sleep timer -->
+    <string name="sleep_timer">Slaaptimer</string>
+    <string name="sleep_add_15">+15 min</string>
+    <string name="sleep_set_new_duration">Nieuwe duur instellen</string>
+    <string name="sleep_preset_seconds">%1$d sec</string>
+    <string name="sleep_preset_minutes">%1$d min</string>
+    <string name="sleep_preset_hours">%1$d u</string>
+    <string name="sleep_preset_hours_minutes">%1$d u %2$d min</string>
+    <string name="live_radio">Live radio</string>
+    <string name="tag_news">Nieuws</string>
+    <string name="tag_sport">Sport</string>
+    <string name="tag_pop">Pop</string>
+    <string name="tag_rock">Rock</string>
+    <string name="tag_jazz">Jazz</string>
+    <string name="tag_classical">Klassiek</string>
+    <string name="tag_dance">Dance</string>
+    <string name="tag_soul">Soul</string>
+    <string name="tag_country">Country</string>
+    <string name="tag_electronic">Elektronisch</string>
+</resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -58,7 +58,6 @@
     <string name="refresh_registry_desc">Forceer het ophalen van het nieuwste zenderregister uit het netwerk</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Taal</string>
-    <string name="language_desc">Kies de taal van de app</string>
     <string name="language_system_default">Systeemstandaard</string>
 
     <!-- Station edit -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -58,7 +58,6 @@
     <string name="refresh_registry_desc">Forçar o download do registro de estações mais recente da rede</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Idioma</string>
-    <string name="language_desc">Escolha o idioma do app</string>
     <string name="language_system_default">Padrão do sistema</string>
 
     <!-- Station edit -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Aerial</string>
+
+    <!-- Common actions -->
+    <string name="action_back">Voltar</string>
+    <string name="action_remove">Remover</string>
+    <string name="action_cancel">Cancelar</string>
+    <string name="action_clear">Limpar</string>
+    <string name="action_save">Salvar</string>
+    <string name="action_edit">Editar</string>
+
+    <!-- Search / home -->
+    <string name="search_hint">Buscar estações</string>
+    <string name="clear_search">Limpar busca</string>
+    <string name="settings">Configurações</string>
+    <string name="buffering">Carregando…</string>
+    <string name="play">Reproduzir</string>
+    <string name="pause">Pausar</string>
+    <string name="filter_country">País</string>
+    <string name="filter_genre">Gênero</string>
+    <string name="search_countries">Buscar países</string>
+    <string name="search_genres">Buscar gêneros</string>
+    <string name="clear_all">Limpar tudo</string>
+    <string name="remove_station_title">Remover estação?</string>
+    <string name="remove_station_message">\"%1$s\" será removida dos seus favoritos.</string>
+    <string name="no_stations_found">Nenhuma estação encontrada</string>
+    <string name="no_stations_found_desc">Tente outra busca ou adicione uma estação usando o URL do stream.</string>
+    <string name="add_your_own_station">Adicione sua própria estação</string>
+    <string name="save_to_favorites">Salvar nos favoritos</string>
+    <string name="remove_from_favorites">Remover dos favoritos</string>
+    <string name="no_internet_title">Sem conexão com a internet</string>
+    <string name="no_internet_desc">Os streams de rádio exigem uma conexão ativa com a internet.</string>
+    <string name="favorites_header">Seus favoritos</string>
+    <string name="get_started">Começar</string>
+    <string name="just_listen">É só ouvir</string>
+    <string name="find_a_station">Encontrar uma estação</string>
+    <string name="find_one_to_listen">Encontre uma para ouvir</string>
+    <string name="no_matches">Nenhum resultado</string>
+    <string name="no_matches_desc">Tente outra busca.</string>
+
+    <!-- Now playing -->
+    <string name="close_player">Fechar player</string>
+    <string name="add_to_favorites">Adicionar aos favoritos</string>
+    <string name="share_station">Compartilhar estação</string>
+    <string name="copy_track_info">Copiar info da faixa</string>
+
+    <!-- Settings -->
+    <string name="show_whats_playing">Mostrar o que está tocando</string>
+    <string name="show_whats_playing_desc">Exibe música, artista e capa quando disponíveis</string>
+    <string name="section_data">Dados</string>
+    <string name="export_backup">Exportar backup</string>
+    <string name="export_backup_desc">Salva estações, configurações e logotipos locais</string>
+    <string name="import_backup">Importar backup</string>
+    <string name="import_backup_desc">Mescla estações e restaura configurações de um backup</string>
+    <string name="section_debug">Depuração</string>
+    <string name="refresh_registry">Atualizar registro</string>
+    <string name="refresh_registry_desc">Forçar o download do registro de estações mais recente da rede</string>
+    <string name="version_format">Aerial %1$s</string>
+    <string name="language">Idioma</string>
+    <string name="language_desc">Escolha o idioma do app</string>
+    <string name="language_system_default">Padrão do sistema</string>
+
+    <!-- Station edit -->
+    <string name="edit_station">Editar estação</string>
+    <string name="add_station">Adicionar estação</string>
+    <string name="change_station_logo">Alterar logotipo da estação</string>
+    <string name="choose_station_logo">Escolher logotipo da estação</string>
+    <string name="remove_icon">Remover ícone</string>
+    <string name="remove_icon_title">Remover ícone?</string>
+    <string name="remove_icon_message">O ícone da estação será removido.</string>
+    <string name="field_name">Nome</string>
+    <string name="field_stream_url">URL do stream</string>
+
+    <!-- Sleep timer -->
+    <string name="sleep_timer">Temporizador</string>
+    <string name="sleep_add_15">+15 min</string>
+    <string name="sleep_set_new_duration">Definir nova duração</string>
+    <string name="sleep_preset_seconds">%1$d s</string>
+    <string name="sleep_preset_minutes">%1$d min</string>
+    <string name="sleep_preset_hours">%1$d h</string>
+    <string name="sleep_preset_hours_minutes">%1$d h %2$d min</string>
+    <string name="live_radio">Rádio ao vivo</string>
+    <string name="tag_news">Notícias</string>
+    <string name="tag_sport">Esportes</string>
+    <string name="tag_pop">Pop</string>
+    <string name="tag_rock">Rock</string>
+    <string name="tag_jazz">Jazz</string>
+    <string name="tag_classical">Clássica</string>
+    <string name="tag_dance">Dance</string>
+    <string name="tag_soul">Soul</string>
+    <string name="tag_country">Country</string>
+    <string name="tag_electronic">Eletrônica</string>
+</resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Aerial</string>
+
+    <!-- Common actions -->
+    <string name="action_back">返回</string>
+    <string name="action_remove">移除</string>
+    <string name="action_cancel">取消</string>
+    <string name="action_clear">清除</string>
+    <string name="action_save">保存</string>
+    <string name="action_edit">编辑</string>
+
+    <!-- Search / home -->
+    <string name="search_hint">搜索电台</string>
+    <string name="clear_search">清除搜索</string>
+    <string name="settings">设置</string>
+    <string name="buffering">缓冲中…</string>
+    <string name="play">播放</string>
+    <string name="pause">暂停</string>
+    <string name="filter_country">国家/地区</string>
+    <string name="filter_genre">类型</string>
+    <string name="search_countries">搜索国家/地区</string>
+    <string name="search_genres">搜索类型</string>
+    <string name="clear_all">全部清除</string>
+    <string name="remove_station_title">移除电台？</string>
+    <string name="remove_station_message">将从收藏中移除“%1$s”。</string>
+    <string name="no_stations_found">未找到电台</string>
+    <string name="no_stations_found_desc">请尝试其他搜索，或使用电台的流媒体地址添加电台。</string>
+    <string name="add_your_own_station">添加自己的电台</string>
+    <string name="save_to_favorites">保存到收藏</string>
+    <string name="remove_from_favorites">从收藏中移除</string>
+    <string name="no_internet_title">无网络连接</string>
+    <string name="no_internet_desc">收听广播需要有效的网络连接。</string>
+    <string name="favorites_header">你的收藏</string>
+    <string name="get_started">开始使用</string>
+    <string name="just_listen">尽情聆听</string>
+    <string name="find_a_station">查找电台</string>
+    <string name="find_one_to_listen">找一个来收听</string>
+    <string name="no_matches">无匹配结果</string>
+    <string name="no_matches_desc">请尝试其他搜索。</string>
+
+    <!-- Now playing -->
+    <string name="close_player">关闭播放器</string>
+    <string name="add_to_favorites">添加到收藏</string>
+    <string name="share_station">分享电台</string>
+    <string name="copy_track_info">复制曲目信息</string>
+
+    <!-- Settings -->
+    <string name="show_whats_playing">显示正在播放</string>
+    <string name="show_whats_playing_desc">在可用时显示歌曲、艺人和封面</string>
+    <string name="section_data">数据</string>
+    <string name="export_backup">导出备份</string>
+    <string name="export_backup_desc">保存电台、设置和本地徽标</string>
+    <string name="import_backup">导入备份</string>
+    <string name="import_backup_desc">从备份合并电台并恢复设置</string>
+    <string name="section_debug">调试</string>
+    <string name="refresh_registry">刷新注册表</string>
+    <string name="refresh_registry_desc">强制从网络获取最新的电台注册表</string>
+    <string name="version_format">Aerial %1$s</string>
+    <string name="language">语言</string>
+    <string name="language_desc">选择应用语言</string>
+    <string name="language_system_default">系统默认</string>
+
+    <!-- Station edit -->
+    <string name="edit_station">编辑电台</string>
+    <string name="add_station">添加电台</string>
+    <string name="change_station_logo">更换电台徽标</string>
+    <string name="choose_station_logo">选择电台徽标</string>
+    <string name="remove_icon">移除图标</string>
+    <string name="remove_icon_title">移除图标？</string>
+    <string name="remove_icon_message">将移除电台图标。</string>
+    <string name="field_name">名称</string>
+    <string name="field_stream_url">流媒体地址</string>
+
+    <!-- Sleep timer -->
+    <string name="sleep_timer">睡眠定时器</string>
+    <string name="sleep_add_15">+15 分钟</string>
+    <string name="sleep_set_new_duration">设置新时长</string>
+    <string name="sleep_preset_seconds">%1$d 秒</string>
+    <string name="sleep_preset_minutes">%1$d 分钟</string>
+    <string name="sleep_preset_hours">%1$d 小时</string>
+    <string name="sleep_preset_hours_minutes">%1$d 小时 %2$d 分钟</string>
+    <string name="live_radio">直播电台</string>
+    <string name="tag_news">新闻</string>
+    <string name="tag_sport">体育</string>
+    <string name="tag_pop">流行</string>
+    <string name="tag_rock">摇滚</string>
+    <string name="tag_jazz">爵士</string>
+    <string name="tag_classical">古典</string>
+    <string name="tag_dance">舞曲</string>
+    <string name="tag_soul">灵魂乐</string>
+    <string name="tag_country">乡村</string>
+    <string name="tag_electronic">电子</string>
+</resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -58,7 +58,6 @@
     <string name="refresh_registry_desc">强制从网络获取最新的电台注册表</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">语言</string>
-    <string name="language_desc">选择应用语言</string>
     <string name="language_system_default">系统默认</string>
 
     <!-- Station edit -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,98 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Aerial</string>
+
+    <!-- Common actions -->
+    <string name="action_back">Back</string>
+    <string name="action_remove">Remove</string>
+    <string name="action_cancel">Cancel</string>
+    <string name="action_clear">Clear</string>
+    <string name="action_save">Save</string>
+    <string name="action_edit">Edit</string>
+
+    <!-- Search / home -->
+    <string name="search_hint">Search stations</string>
+    <string name="clear_search">Clear search</string>
+    <string name="settings">Settings</string>
+    <string name="buffering">Buffering…</string>
+    <string name="play">Play</string>
+    <string name="pause">Pause</string>
+    <string name="filter_country">Country</string>
+    <string name="filter_genre">Genre</string>
+    <string name="search_countries">Search countries</string>
+    <string name="search_genres">Search genres</string>
+    <string name="clear_all">Clear all</string>
+    <string name="remove_station_title">Remove station?</string>
+    <string name="remove_station_message">\"%1$s\" will be removed from your favorites.</string>
+    <string name="no_stations_found">No stations found</string>
+    <string name="no_stations_found_desc">Try a different search, or add a station using its stream URL.</string>
+    <string name="add_your_own_station">Add your own station</string>
+    <string name="save_to_favorites">Save to favorites</string>
+    <string name="remove_from_favorites">Remove from favorites</string>
+    <string name="no_internet_title">No internet connection</string>
+    <string name="no_internet_desc">Radio streams require an active internet connection.</string>
+    <string name="favorites_header">Your favorites</string>
+    <string name="get_started">Get started</string>
+    <string name="just_listen">Just listen</string>
+    <string name="find_a_station">Find a station</string>
+    <string name="find_one_to_listen">Find one to listen to</string>
+    <string name="no_matches">No matches</string>
+    <string name="no_matches_desc">Try a different search.</string>
+
+    <!-- Now playing -->
+    <string name="close_player">Close player</string>
+    <string name="add_to_favorites">Add to favorites</string>
+    <string name="share_station">Share station</string>
+    <string name="copy_track_info">Copy track info</string>
+
+    <!-- Settings -->
+    <string name="show_whats_playing">Show what\'s playing</string>
+    <string name="show_whats_playing_desc">Display song, artist, and artwork when available</string>
+    <string name="section_data">Data</string>
+    <string name="export_backup">Export backup</string>
+    <string name="export_backup_desc">Save stations, settings, and local logos</string>
+    <string name="import_backup">Import backup</string>
+    <string name="import_backup_desc">Merge stations and restore settings from a backup</string>
+    <string name="section_debug">Debug</string>
+    <string name="refresh_registry">Refresh registry</string>
+    <string name="refresh_registry_desc">Force fetch latest station registry from network</string>
+    <string name="version_format">Aerial %1$s</string>
+    <string name="language">Language</string>
+    <string name="language_desc">Choose the app language</string>
+    <string name="language_system_default">System default</string>
+
+    <!-- Station edit -->
+    <string name="edit_station">Edit station</string>
+    <string name="add_station">Add station</string>
+    <string name="change_station_logo">Change station logo</string>
+    <string name="choose_station_logo">Choose station logo</string>
+    <string name="remove_icon">Remove icon</string>
+    <string name="remove_icon_title">Remove icon?</string>
+    <string name="remove_icon_message">The station icon will be removed.</string>
+    <string name="field_name">Name</string>
+    <string name="field_stream_url">Stream URL</string>
+
+    <!-- Playback -->
+    <string name="live_radio">Live Radio</string>
+
+    <!-- Curated genre/category tags. Display only — the English tag is the matching key. -->
+    <string name="tag_news">News</string>
+    <string name="tag_sport">Sport</string>
+    <string name="tag_pop">Pop</string>
+    <string name="tag_rock">Rock</string>
+    <string name="tag_jazz">Jazz</string>
+    <string name="tag_classical">Classical</string>
+    <string name="tag_dance">Dance</string>
+    <string name="tag_soul">Soul</string>
+    <string name="tag_country">Country</string>
+    <string name="tag_electronic">Electronic</string>
+
+    <!-- Sleep timer -->
+    <string name="sleep_timer">Sleep timer</string>
+    <string name="sleep_add_15">+15 min</string>
+    <string name="sleep_set_new_duration">Set a new duration</string>
+    <string name="sleep_preset_seconds">%1$d sec</string>
+    <string name="sleep_preset_minutes">%1$d min</string>
+    <string name="sleep_preset_hours">%1$d hr</string>
+    <string name="sleep_preset_hours_minutes">%1$dh %2$dm</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:locale="en">
     <string name="app_name">Aerial</string>
 
     <!-- Common actions -->
@@ -58,7 +58,6 @@
     <string name="refresh_registry_desc">Force fetch latest station registry from network</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Language</string>
-    <string name="language_desc">Choose the app language</string>
     <string name="language_system_default">System default</string>
 
     <!-- Station edit -->

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en" />
+    <locale android:name="en-GB" />
+    <locale android:name="es" />
+    <locale android:name="fr" />
+    <locale android:name="de" />
+    <locale android:name="it" />
+    <locale android:name="pt" />
+    <locale android:name="nl" />
+    <locale android:name="zh-CN" />
+    <locale android:name="ja" />
+    <locale android:name="ko" />
+</locale-config>


### PR DESCRIPTION
## Summary

Full internationalisation of the app using the modern **per-app language** APIs. Users can pick a language from the Android 13+ system setting, or from an in-app picker on older versions.

## Infrastructure

- **`res/xml/locales_config.xml`** + `android:localeConfig` in the manifest → enables the system per-app language picker (Settings → Apps → Aerial → Language) on Android 13+.
- **AppCompat `autoStoreLocales` service** for locale persistence on pre-13, and `MainActivity` → `AppCompatActivity` so `AppCompatDelegate.setApplicationLocales` applies on all API levels (theme was already AppCompat-based).
- **In-app language picker** in Settings, shown **only on API < 33** (13+ uses the system setting).

## Strings & translations

- All ~65 user-facing strings extracted to `res/values/strings.xml`; UI switched to `stringResource`.
- Translations: **es, fr, de, it, pt, nl, zh-CN, ja, ko**, plus **en-GB** ("favourites") overrides. All locales carry the full key set with format specifiers preserved.
- Sleep-timer duration labels and the version string use format strings.

## Localised beyond static strings

- **"Live Radio"** — routed through a single `getString`, used for *both* the notification/mini-player text and the internal no-track sentinel, so they stay consistent across languages.
- **Country names** — derived from the stored ISO code via `getDisplayCountry(appLocale)` (ICU), so they localise for free; selected values remain ISO codes.
- **Genre tags** — the curated 10 (`CURATED_TAG_ORDER`) get localised display names; the English tag stays the matching/persistence key.

## Not localised (deliberate)

- Free-form registry data (station names, arbitrary tags) — it's user/registry data, not app copy.

## Testing

- `assembleDebug` and `testDebugUnitTest` pass.
- Verified on-device (API 36) via `adb shell cmd locale set-app-locales com.shapeshed.aerial --locales <tag>`: German UI, localised category tiles + country names, and "Live-Radio" in both the mini player and the notification.
- Translations are best-effort (machine-generated) and worth a native-speaker pass before release, especially CJK.