### PR TITLE
feat(search): full-text search with accent folding and descriptions

### DIFF
--- a/app/schemas/com.shapeshed.aerial.data.StationDatabase/11.json
+++ b/app/schemas/com.shapeshed.aerial.data.StationDatabase/11.json
@@ -1,0 +1,192 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "4bbe2fa571c550057ee3b71556a945bd",
+    "entities": [
+      {
+        "tableName": "stations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `streamUrl` TEXT NOT NULL, `logoPath` TEXT NOT NULL, `isFavorite` INTEGER NOT NULL, `provider` TEXT NOT NULL, `providerId` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoPath",
+            "columnName": "logoPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerId",
+            "columnName": "providerId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "registry_stations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `streamUrl` TEXT NOT NULL, `logoUrl` TEXT NOT NULL, `country` TEXT NOT NULL, `countryCode` TEXT NOT NULL, `tags` TEXT NOT NULL, `provider` TEXT NOT NULL, `providerId` TEXT NOT NULL, `description` TEXT NOT NULL, `searchText` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoUrl",
+            "columnName": "logoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countryCode",
+            "columnName": "countryCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerId",
+            "columnName": "providerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchText",
+            "columnName": "searchText",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "registry_stations_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`searchText` TEXT NOT NULL, `description` TEXT NOT NULL, `country` TEXT NOT NULL, tokenize=unicode61 `remove_diacritics=1`, content=`registry_stations`)",
+        "fields": [
+          {
+            "fieldPath": "searchText",
+            "columnName": "searchText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [
+            "remove_diacritics=1"
+          ],
+          "contentTable": "registry_stations",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_registry_stations_fts_BEFORE_UPDATE BEFORE UPDATE ON `registry_stations` BEGIN DELETE FROM `registry_stations_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_registry_stations_fts_BEFORE_DELETE BEFORE DELETE ON `registry_stations` BEGIN DELETE FROM `registry_stations_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_registry_stations_fts_AFTER_UPDATE AFTER UPDATE ON `registry_stations` BEGIN INSERT INTO `registry_stations_fts`(`docid`, `searchText`, `description`, `country`) VALUES (NEW.`rowid`, NEW.`searchText`, NEW.`description`, NEW.`country`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_registry_stations_fts_AFTER_INSERT AFTER INSERT ON `registry_stations` BEGIN INSERT INTO `registry_stations_fts`(`docid`, `searchText`, `description`, `country`) VALUES (NEW.`rowid`, NEW.`searchText`, NEW.`description`, NEW.`country`); END"
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4bbe2fa571c550057ee3b71556a945bd')"
+    ]
+  }
+}

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryDao.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryDao.kt
@@ -19,7 +19,21 @@ abstract class RegistryDao {
     open suspend fun clearAndInsertAll(stations: List<RegistryStation>) {
         clear()
         insertAll(stations)
+        // External-content FTS isn't auto-maintained; rebuild the index after a bulk import.
+        rebuildFts()
     }
+
+    @Query("INSERT INTO registry_stations_fts(registry_stations_fts) VALUES('rebuild')")
+    abstract suspend fun rebuildFts()
+
+    // Full-text search over name+tags (via searchText), description, and country. The join maps
+    // FTS rowids back to the content rows. MATCH does the accent-folded, tokenized matching.
+    @Query(
+        "SELECT rs.* FROM registry_stations rs " +
+            "JOIN registry_stations_fts fts ON rs.id = fts.rowid " +
+            "WHERE registry_stations_fts MATCH :match ORDER BY rs.name LIMIT 200",
+    )
+    abstract suspend fun searchFts(match: String): List<RegistryStation>
 
     @Query("SELECT COUNT(*) FROM registry_stations")
     abstract fun countAsFlow(): Flow<Int>
@@ -29,9 +43,6 @@ abstract class RegistryDao {
 
     @Query("SELECT * FROM registry_stations WHERE LOWER(tags) LIKE '%' || LOWER(:tag) || '%' ORDER BY RANDOM() LIMIT 1")
     abstract suspend fun randomStationByTag(tag: String): RegistryStation?
-
-    @Query("SELECT * FROM registry_stations WHERE LOWER(searchText) LIKE '%' || LOWER(:query) || '%' OR LOWER(country) LIKE '%' || LOWER(:query) || '%' OR LOWER(countryCode) LIKE '%' || LOWER(:query) || '%' ORDER BY name LIMIT 200")
-    abstract suspend fun search(query: String): List<RegistryStation>
 
     @Query("SELECT * FROM registry_stations WHERE providerId IN (:ids)")
     abstract suspend fun getByProviderIds(ids: List<String>): List<RegistryStation>

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
@@ -28,6 +28,15 @@ private val CURATED_TAG_ORDER = listOf(
     "News", "Sport", "Pop", "Rock", "Jazz", "Classical", "Dance", "Soul", "Country", "Electronic"
 )
 
+// Turn a normalised query into an FTS4 MATCH expression: split into tokens (which also drops FTS
+// operator characters, avoiding syntax errors) and prefix-match each so search-as-you-type works.
+// e.g. "radio jazz" -> "radio* jazz*". Accent folding is handled by the tokenizer, not here.
+internal fun toFtsMatchQuery(normalized: String): String =
+    normalized.lowercase()
+        .split(Regex("[^\\p{L}\\p{N}]+"))
+        .filter { it.isNotBlank() }
+        .joinToString(" ") { "$it*" }
+
 class RegistryRepository(private val dao: RegistryDao, private val httpClient: OkHttpClient) {
 
     fun countAsFlow(): Flow<Int> = dao.countAsFlow()
@@ -95,20 +104,10 @@ class RegistryRepository(private val dao: RegistryDao, private val httpClient: O
         if (!hasQuery && !hasFilter) return emptyList()
 
         val candidates = if (hasQuery) {
-            val normalized = NumberNormalizer.normalize(query.trim())
-            val words = normalized.lowercase().split(" ").filter { it.isNotBlank() }
-            // For multi-word queries pass only the first word to the DB so the LIKE
-            // clause searches a single token; Kotlin does the per-word narrowing below.
-            val raw = dao.search(words.first())
-            if (words.size > 1) {
-                val completeWords = words.dropLast(1)
-                val prefix = words.last()
-                raw.filter { station ->
-                    val haystack = " ${station.searchText.lowercase()} ${station.country.lowercase()} ${station.countryCode.lowercase()} "
-                    completeWords.all { word -> haystack.contains(" $word ") } &&
-                        haystack.contains(" $prefix")
-                }
-            } else raw
+            // Tokenised, accent-folded FTS4 match (see RegistryStationFts). Number-word
+            // normalisation is applied first so "radio 1" still matches "Radio One".
+            val match = toFtsMatchQuery(NumberNormalizer.normalize(query.trim()))
+            if (match.isBlank()) emptyList() else dao.searchFts(match)
         } else if (countryCodes.isNotEmpty() && tags.isEmpty()) {
             dao.filterByCountryCodes(countryCodes.map { it.lowercase() })
         } else {
@@ -155,6 +154,8 @@ class RegistryRepository(private val dao: RegistryDao, private val httpClient: O
                     tags = tags,
                     provider = obj.optString("provider").trim(),
                     providerId = obj.optString("provider_id").trim(),
+                    // Optional: absent in the current registry, so it defaults to "".
+                    description = obj.optString("description").trim(),
                     searchText = NumberNormalizer.normalize("$name $tags"),
                 )
             }

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryStation.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryStation.kt
@@ -14,5 +14,6 @@ data class RegistryStation(
     val tags: String = "",
     val provider: String = "",
     val providerId: String = "",
+    val description: String = "",
     val searchText: String = "",
 )

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryStationFts.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryStationFts.kt
@@ -1,0 +1,24 @@
+package com.shapeshed.aerial.data
+
+import androidx.room.Entity
+import androidx.room.Fts4
+
+/**
+ * Full-text search index over [RegistryStation]. External-content FTS4 (no duplicated storage;
+ * reads columns straight from registry_stations, kept in sync by rebuilding after each import).
+ *
+ * The unicode61 tokenizer with remove_diacritics=1 folds accents on both the indexed text and
+ * the query, so "cafe" matches "Café" and vice-versa. remove_diacritics=2 would be better but
+ * needs SQLite >= 3.27 (~API 30); =1 works on the app's minSdk 26 and covers Latin accents.
+ */
+@Fts4(
+    contentEntity = RegistryStation::class,
+    tokenizer = "unicode61",
+    tokenizerArgs = ["remove_diacritics=1"],
+)
+@Entity(tableName = "registry_stations_fts")
+data class RegistryStationFts(
+    val searchText: String,
+    val description: String,
+    val country: String,
+)

--- a/app/src/main/java/com/shapeshed/aerial/data/StationDatabase.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/StationDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [Station::class, RegistryStation::class], version = 10, exportSchema = true)
+@Database(entities = [Station::class, RegistryStation::class, RegistryStationFts::class], version = 11, exportSchema = true)
 abstract class StationDatabase : RoomDatabase() {
     abstract fun stationDao(): StationDao
     abstract fun registryDao(): RegistryDao
@@ -21,7 +21,7 @@ abstract class StationDatabase : RoomDatabase() {
                     // Explicit migrations cover versions 6–9 → 10.
                     // Any user still on v5 or below will have their data wiped by the fallback.
                     // Future version bumps MUST add an explicit Migration before relying on this fallback.
-                    .addMigrations(MIGRATION_6_10, MIGRATION_7_10, MIGRATION_8_10, MIGRATION_9_10)
+                    .addMigrations(MIGRATION_6_10, MIGRATION_7_10, MIGRATION_8_10, MIGRATION_9_10, MIGRATION_10_11)
                     .fallbackToDestructiveMigration(dropAllTables = true)
                     .build()
                     .also { instance = it }
@@ -53,6 +53,21 @@ abstract class StationDatabase : RoomDatabase() {
         private val MIGRATION_9_10 = object : Migration(9, 10) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 migrateStationsWithProviderColumns(db)
+            }
+        }
+
+        // Adds the description column and the FTS4 search index. The CREATE VIRTUAL TABLE DDL
+        // must match Room's generated schema exactly (see schemas/…/11.json) or the identity
+        // check fails on open. The final INSERT('rebuild') populates the index from the content.
+        private val MIGRATION_10_11 = object : Migration(10, 11) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `registry_stations` ADD COLUMN `description` TEXT NOT NULL DEFAULT ''")
+                db.execSQL(
+                    "CREATE VIRTUAL TABLE IF NOT EXISTS `registry_stations_fts` USING FTS4(" +
+                        "`searchText` TEXT NOT NULL, `description` TEXT NOT NULL, `country` TEXT NOT NULL, " +
+                        "tokenize=unicode61 `remove_diacritics=1`, content=`registry_stations`)",
+                )
+                db.execSQL("INSERT INTO `registry_stations_fts`(`registry_stations_fts`) VALUES('rebuild')")
             }
         }
 

--- a/app/src/test/java/com/shapeshed/aerial/data/FtsMatchQueryTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/data/FtsMatchQueryTest.kt
@@ -1,0 +1,36 @@
+package com.shapeshed.aerial.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FtsMatchQueryTest {
+
+    @Test
+    fun singleTermGetsPrefixWildcard() {
+        assertEquals("jazz*", toFtsMatchQuery("jazz"))
+    }
+
+    @Test
+    fun multipleTermsEachGetPrefixWildcard() {
+        assertEquals("radio* jazz*", toFtsMatchQuery("radio jazz"))
+    }
+
+    @Test
+    fun punctuationAndOperatorsAreStripped() {
+        // Splitting on non-alphanumerics also removes FTS operator chars, avoiding syntax errors.
+        assertEquals("rock* roll*", toFtsMatchQuery("rock & roll"))
+        assertEquals("radio* 1*", toFtsMatchQuery("radio-1"))
+    }
+
+    @Test
+    fun accentsArePreservedInTheTerm() {
+        // Folding is done by the tokenizer at query time, not here.
+        assertEquals("café*", toFtsMatchQuery("Café"))
+    }
+
+    @Test
+    fun blankQueryProducesEmptyMatch() {
+        assertEquals("", toFtsMatchQuery("   "))
+        assertEquals("", toFtsMatchQuery("!!!"))
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the `LIKE`-based registry search with a tokenized **FTS4** index that folds accents and searches station descriptions.

## What changed

- **FTS4 index** (`RegistryStationFts`) — an external-content FTS4 table over `searchText` (name + tags), `description`, and `country`, using the `unicode61` tokenizer with `remove_diacritics=1`. Accents fold on both the index and the query, so **"cafe" matches "Café"** and vice-versa. Rebuilt after each registry import (external content isn't auto-maintained).
- **`description` field** — added to `RegistryStation`, parsed from the registry when present (**362 of the 942 bundled stations** already carry one) and included in the index. Absent → defaults to `""`, so it's backward-compatible.
- **Search** now runs a **prefix `MATCH`** query (`radio* jazz*`) for search-as-you-type, replacing the substring `LIKE`. Structured country/tag filter chips are unchanged.
- **Room migration 10 → 11** — adds the column, creates the FTS virtual table (DDL matches Room's exported schema), and populates it. Exported `11.json` committed.
- Unit test for the `MATCH` query builder.

## Behaviour notes / trade-offs

- **Token/prefix matching, not arbitrary substring**: "jaz" matches "Jazz" (prefix), "azz" no longer does — generally better relevance for station search.
- **`remove_diacritics=1`** (not `=2`) because minSdk is 26; it covers Latin accents (é, ç, ä, ñ…) but not German ß.
- **countryCode** is no longer free-text searchable; the English country *name* still is. Localized country/genre search (e.g. "Royaume-Uni" → GB) is deferred.
- Field weighting (title › tags › description) is intentionally **not** included yet — evaluating plain FTS first.

## Testing

- `assembleDebug`, `testDebugUnitTest`, `lintDebug` pass.
- Verified on-device (API 36): migration ran clean with no data loss; FTS populated **942/942**; prefix matching works; accent folding confirmed (`nouveautes`→"Nouveautés", `francais`→"français", `sander`→"sänder"); description-only words are searchable (`emiss`→Antena3 Dance, `independ`→Brasil 200).