### PR TITLE
fix(favorites): preserve registry station snapshots

### DIFF
--- a/app/schemas/com.shapeshed.aerial.data.StationDatabase/12.json
+++ b/app/schemas/com.shapeshed.aerial.data.StationDatabase/12.json
@@ -1,0 +1,245 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "a8d557deffc2e7a82f84ba202c015e25",
+    "entities": [
+      {
+        "tableName": "stations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `streamUrl` TEXT NOT NULL, `logoPath` TEXT NOT NULL, `isFavorite` INTEGER NOT NULL, `provider` TEXT NOT NULL, `providerId` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoPath",
+            "columnName": "logoPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerId",
+            "columnName": "providerId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stations_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, `streamUrl` TEXT NOT NULL, `provider` TEXT NOT NULL, `providerId` TEXT NOT NULL, tokenize=unicode61 `remove_diacritics=1`, content=`stations`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerId",
+            "columnName": "providerId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [
+            "remove_diacritics=1"
+          ],
+          "contentTable": "stations",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_BEFORE_UPDATE BEFORE UPDATE ON `stations` BEGIN DELETE FROM `stations_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_BEFORE_DELETE BEFORE DELETE ON `stations` BEGIN DELETE FROM `stations_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_AFTER_UPDATE AFTER UPDATE ON `stations` BEGIN INSERT INTO `stations_fts`(`docid`, `name`, `streamUrl`, `provider`, `providerId`) VALUES (NEW.`rowid`, NEW.`name`, NEW.`streamUrl`, NEW.`provider`, NEW.`providerId`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_AFTER_INSERT AFTER INSERT ON `stations` BEGIN INSERT INTO `stations_fts`(`docid`, `name`, `streamUrl`, `provider`, `providerId`) VALUES (NEW.`rowid`, NEW.`name`, NEW.`streamUrl`, NEW.`provider`, NEW.`providerId`); END"
+        ]
+      },
+      {
+        "tableName": "registry_stations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `streamUrl` TEXT NOT NULL, `logoUrl` TEXT NOT NULL, `country` TEXT NOT NULL, `countryCode` TEXT NOT NULL, `tags` TEXT NOT NULL, `provider` TEXT NOT NULL, `providerId` TEXT NOT NULL, `description` TEXT NOT NULL, `searchText` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoUrl",
+            "columnName": "logoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countryCode",
+            "columnName": "countryCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerId",
+            "columnName": "providerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchText",
+            "columnName": "searchText",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "registry_stations_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`searchText` TEXT NOT NULL, `description` TEXT NOT NULL, `country` TEXT NOT NULL, tokenize=unicode61 `remove_diacritics=1`, content=`registry_stations`)",
+        "fields": [
+          {
+            "fieldPath": "searchText",
+            "columnName": "searchText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [
+            "remove_diacritics=1"
+          ],
+          "contentTable": "registry_stations",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_registry_stations_fts_BEFORE_UPDATE BEFORE UPDATE ON `registry_stations` BEGIN DELETE FROM `registry_stations_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_registry_stations_fts_BEFORE_DELETE BEFORE DELETE ON `registry_stations` BEGIN DELETE FROM `registry_stations_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_registry_stations_fts_AFTER_UPDATE AFTER UPDATE ON `registry_stations` BEGIN INSERT INTO `registry_stations_fts`(`docid`, `searchText`, `description`, `country`) VALUES (NEW.`rowid`, NEW.`searchText`, NEW.`description`, NEW.`country`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_registry_stations_fts_AFTER_INSERT AFTER INSERT ON `registry_stations` BEGIN INSERT INTO `registry_stations_fts`(`docid`, `searchText`, `description`, `country`) VALUES (NEW.`rowid`, NEW.`searchText`, NEW.`description`, NEW.`country`); END"
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a8d557deffc2e7a82f84ba202c015e25')"
+    ]
+  }
+}

--- a/app/schemas/com.shapeshed.aerial.data.StationDatabase/13.json
+++ b/app/schemas/com.shapeshed.aerial.data.StationDatabase/13.json
@@ -1,0 +1,287 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "3412f7dc4b8e90ff073e5e7e20899f7f",
+    "entities": [
+      {
+        "tableName": "stations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `streamUrl` TEXT NOT NULL, `logoPath` TEXT NOT NULL, `isFavorite` INTEGER NOT NULL, `provider` TEXT NOT NULL, `providerId` TEXT NOT NULL, `tags` TEXT NOT NULL, `description` TEXT NOT NULL, `country` TEXT NOT NULL, `countryCode` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoPath",
+            "columnName": "logoPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerId",
+            "columnName": "providerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countryCode",
+            "columnName": "countryCode",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stations_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, `streamUrl` TEXT NOT NULL, `provider` TEXT NOT NULL, `providerId` TEXT NOT NULL, `tags` TEXT NOT NULL, `description` TEXT NOT NULL, `country` TEXT NOT NULL, tokenize=unicode61 `remove_diacritics=1`, content=`stations`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerId",
+            "columnName": "providerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [
+            "remove_diacritics=1"
+          ],
+          "contentTable": "stations",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_BEFORE_UPDATE BEFORE UPDATE ON `stations` BEGIN DELETE FROM `stations_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_BEFORE_DELETE BEFORE DELETE ON `stations` BEGIN DELETE FROM `stations_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_AFTER_UPDATE AFTER UPDATE ON `stations` BEGIN INSERT INTO `stations_fts`(`docid`, `name`, `streamUrl`, `provider`, `providerId`, `tags`, `description`, `country`) VALUES (NEW.`rowid`, NEW.`name`, NEW.`streamUrl`, NEW.`provider`, NEW.`providerId`, NEW.`tags`, NEW.`description`, NEW.`country`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_AFTER_INSERT AFTER INSERT ON `stations` BEGIN INSERT INTO `stations_fts`(`docid`, `name`, `streamUrl`, `provider`, `providerId`, `tags`, `description`, `country`) VALUES (NEW.`rowid`, NEW.`name`, NEW.`streamUrl`, NEW.`provider`, NEW.`providerId`, NEW.`tags`, NEW.`description`, NEW.`country`); END"
+        ]
+      },
+      {
+        "tableName": "registry_stations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `streamUrl` TEXT NOT NULL, `logoUrl` TEXT NOT NULL, `country` TEXT NOT NULL, `countryCode` TEXT NOT NULL, `tags` TEXT NOT NULL, `provider` TEXT NOT NULL, `providerId` TEXT NOT NULL, `description` TEXT NOT NULL, `searchText` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoUrl",
+            "columnName": "logoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countryCode",
+            "columnName": "countryCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerId",
+            "columnName": "providerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchText",
+            "columnName": "searchText",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "registry_stations_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`searchText` TEXT NOT NULL, `description` TEXT NOT NULL, `country` TEXT NOT NULL, tokenize=unicode61 `remove_diacritics=1`, content=`registry_stations`)",
+        "fields": [
+          {
+            "fieldPath": "searchText",
+            "columnName": "searchText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [
+            "remove_diacritics=1"
+          ],
+          "contentTable": "registry_stations",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_registry_stations_fts_BEFORE_UPDATE BEFORE UPDATE ON `registry_stations` BEGIN DELETE FROM `registry_stations_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_registry_stations_fts_BEFORE_DELETE BEFORE DELETE ON `registry_stations` BEGIN DELETE FROM `registry_stations_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_registry_stations_fts_AFTER_UPDATE AFTER UPDATE ON `registry_stations` BEGIN INSERT INTO `registry_stations_fts`(`docid`, `searchText`, `description`, `country`) VALUES (NEW.`rowid`, NEW.`searchText`, NEW.`description`, NEW.`country`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_registry_stations_fts_AFTER_INSERT AFTER INSERT ON `registry_stations` BEGIN INSERT INTO `registry_stations_fts`(`docid`, `searchText`, `description`, `country`) VALUES (NEW.`rowid`, NEW.`searchText`, NEW.`description`, NEW.`country`); END"
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3412f7dc4b8e90ff073e5e7e20899f7f')"
+    ]
+  }
+}

--- a/app/src/main/java/com/shapeshed/aerial/data/Station.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/Station.kt
@@ -12,4 +12,8 @@ data class Station(
     val isFavorite: Boolean = false,
     val provider: String = "",
     val providerId: String = "",
+    val tags: String = "",
+    val description: String = "",
+    val country: String = "",
+    val countryCode: String = "",
 )

--- a/app/src/main/java/com/shapeshed/aerial/data/StationDao.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/StationDao.kt
@@ -18,6 +18,16 @@ interface StationDao {
     @Query("SELECT * FROM stations WHERE streamUrl = :streamUrl LIMIT 1")
     suspend fun getByStreamUrl(streamUrl: String): Station?
 
+    @Query("SELECT * FROM stations WHERE provider = :provider AND providerId = :providerId LIMIT 1")
+    suspend fun getByProviderId(provider: String, providerId: String): Station?
+
+    @Query(
+        "SELECT s.* FROM stations s " +
+            "JOIN stations_fts fts ON s.id = fts.rowid " +
+            "WHERE stations_fts MATCH :match ORDER BY s.name COLLATE NOCASE ASC LIMIT 20",
+    )
+    suspend fun searchStationFts(match: String): List<Station>
+
     @Query("UPDATE stations SET streamUrl = :streamUrl WHERE provider = :provider AND providerId = :providerId AND streamUrl != :streamUrl")
     suspend fun updateStreamUrlByProviderId(provider: String, providerId: String, streamUrl: String)
 

--- a/app/src/main/java/com/shapeshed/aerial/data/StationDatabase.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/StationDatabase.kt
@@ -7,7 +7,11 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [Station::class, RegistryStation::class, RegistryStationFts::class], version = 11, exportSchema = true)
+@Database(
+    entities = [Station::class, StationFts::class, RegistryStation::class, RegistryStationFts::class],
+    version = 13,
+    exportSchema = true,
+)
 abstract class StationDatabase : RoomDatabase() {
     abstract fun stationDao(): StationDao
     abstract fun registryDao(): RegistryDao
@@ -21,7 +25,15 @@ abstract class StationDatabase : RoomDatabase() {
                     // Explicit migrations cover versions 6–9 → 10.
                     // Any user still on v5 or below will have their data wiped by the fallback.
                     // Future version bumps MUST add an explicit Migration before relying on this fallback.
-                    .addMigrations(MIGRATION_6_10, MIGRATION_7_10, MIGRATION_8_10, MIGRATION_9_10, MIGRATION_10_11)
+                    .addMigrations(
+                        MIGRATION_6_10,
+                        MIGRATION_7_10,
+                        MIGRATION_8_10,
+                        MIGRATION_9_10,
+                        MIGRATION_10_11,
+                        MIGRATION_11_12,
+                        MIGRATION_12_13,
+                    )
                     .fallbackToDestructiveMigration(dropAllTables = true)
                     .build()
                     .also { instance = it }
@@ -71,6 +83,93 @@ abstract class StationDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_11_12 = object : Migration(11, 12) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE VIRTUAL TABLE IF NOT EXISTS `stations_fts` USING FTS4(" +
+                        "`name` TEXT NOT NULL, `streamUrl` TEXT NOT NULL, `provider` TEXT NOT NULL, " +
+                        "`providerId` TEXT NOT NULL, tokenize=unicode61 `remove_diacritics=1`, content=`stations`)",
+                )
+                db.execSQL(
+                    "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_BEFORE_UPDATE " +
+                        "BEFORE UPDATE ON `stations` BEGIN DELETE FROM `stations_fts` WHERE `docid`=OLD.`rowid`; END",
+                )
+                db.execSQL(
+                    "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_BEFORE_DELETE " +
+                        "BEFORE DELETE ON `stations` BEGIN DELETE FROM `stations_fts` WHERE `docid`=OLD.`rowid`; END",
+                )
+                db.execSQL(
+                    "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_AFTER_UPDATE " +
+                        "AFTER UPDATE ON `stations` BEGIN INSERT INTO `stations_fts`(`docid`, `name`, `streamUrl`, `provider`, `providerId`) " +
+                        "VALUES (NEW.`rowid`, NEW.`name`, NEW.`streamUrl`, NEW.`provider`, NEW.`providerId`); END",
+                )
+                db.execSQL(
+                    "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_AFTER_INSERT " +
+                        "AFTER INSERT ON `stations` BEGIN INSERT INTO `stations_fts`(`docid`, `name`, `streamUrl`, `provider`, `providerId`) " +
+                        "VALUES (NEW.`rowid`, NEW.`name`, NEW.`streamUrl`, NEW.`provider`, NEW.`providerId`); END",
+                )
+                db.execSQL("INSERT INTO `stations_fts`(`stations_fts`) VALUES('rebuild')")
+            }
+        }
+
+        private val MIGRATION_12_13 = object : Migration(12, 13) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `stations` ADD COLUMN `tags` TEXT NOT NULL DEFAULT ''")
+                db.execSQL("ALTER TABLE `stations` ADD COLUMN `description` TEXT NOT NULL DEFAULT ''")
+                db.execSQL("ALTER TABLE `stations` ADD COLUMN `country` TEXT NOT NULL DEFAULT ''")
+                db.execSQL("ALTER TABLE `stations` ADD COLUMN `countryCode` TEXT NOT NULL DEFAULT ''")
+                db.execSQL(
+                    """
+                    UPDATE `stations`
+                    SET
+                      `tags` = COALESCE((
+                        SELECT `registry_stations`.`tags`
+                        FROM `registry_stations`
+                        WHERE
+                          (`stations`.`provider` != '' AND `stations`.`providerId` != ''
+                            AND `registry_stations`.`provider` = `stations`.`provider`
+                            AND `registry_stations`.`providerId` = `stations`.`providerId`)
+                          OR `registry_stations`.`streamUrl` = `stations`.`streamUrl`
+                        LIMIT 1
+                      ), ''),
+                      `description` = COALESCE((
+                        SELECT `registry_stations`.`description`
+                        FROM `registry_stations`
+                        WHERE
+                          (`stations`.`provider` != '' AND `stations`.`providerId` != ''
+                            AND `registry_stations`.`provider` = `stations`.`provider`
+                            AND `registry_stations`.`providerId` = `stations`.`providerId`)
+                          OR `registry_stations`.`streamUrl` = `stations`.`streamUrl`
+                        LIMIT 1
+                      ), ''),
+                      `country` = COALESCE((
+                        SELECT `registry_stations`.`country`
+                        FROM `registry_stations`
+                        WHERE
+                          (`stations`.`provider` != '' AND `stations`.`providerId` != ''
+                            AND `registry_stations`.`provider` = `stations`.`provider`
+                            AND `registry_stations`.`providerId` = `stations`.`providerId`)
+                          OR `registry_stations`.`streamUrl` = `stations`.`streamUrl`
+                        LIMIT 1
+                      ), ''),
+                      `countryCode` = COALESCE((
+                        SELECT `registry_stations`.`countryCode`
+                        FROM `registry_stations`
+                        WHERE
+                          (`stations`.`provider` != '' AND `stations`.`providerId` != ''
+                            AND `registry_stations`.`provider` = `stations`.`provider`
+                            AND `registry_stations`.`providerId` = `stations`.`providerId`)
+                          OR `registry_stations`.`streamUrl` = `stations`.`streamUrl`
+                        LIMIT 1
+                      ), '')
+                    WHERE `tags` = '' AND `description` = '' AND `country` = '' AND `countryCode` = ''
+                    """.trimIndent(),
+                )
+                dropStationsFts(db)
+                createStationsFts(db)
+            }
+        }
+
         private fun migrateStationsWithoutProviderColumns(db: SupportSQLiteDatabase) {
             db.execSQL(createStationsNewSql())
             db.execSQL(
@@ -110,6 +209,43 @@ abstract class StationDatabase : RoomDatabase() {
               `providerId` TEXT NOT NULL
             )
             """.trimIndent()
+
+        private fun dropStationsFts(db: SupportSQLiteDatabase) {
+            db.execSQL("DROP TRIGGER IF EXISTS room_fts_content_sync_stations_fts_BEFORE_UPDATE")
+            db.execSQL("DROP TRIGGER IF EXISTS room_fts_content_sync_stations_fts_BEFORE_DELETE")
+            db.execSQL("DROP TRIGGER IF EXISTS room_fts_content_sync_stations_fts_AFTER_UPDATE")
+            db.execSQL("DROP TRIGGER IF EXISTS room_fts_content_sync_stations_fts_AFTER_INSERT")
+            db.execSQL("DROP TABLE IF EXISTS `stations_fts`")
+        }
+
+        private fun createStationsFts(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                "CREATE VIRTUAL TABLE IF NOT EXISTS `stations_fts` USING FTS4(" +
+                    "`name` TEXT NOT NULL, `streamUrl` TEXT NOT NULL, `provider` TEXT NOT NULL, " +
+                    "`providerId` TEXT NOT NULL, `tags` TEXT NOT NULL, `description` TEXT NOT NULL, " +
+                    "`country` TEXT NOT NULL, " +
+                    "tokenize=unicode61 `remove_diacritics=1`, content=`stations`)",
+            )
+            db.execSQL(
+                "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_BEFORE_UPDATE " +
+                    "BEFORE UPDATE ON `stations` BEGIN DELETE FROM `stations_fts` WHERE `docid`=OLD.`rowid`; END",
+            )
+            db.execSQL(
+                "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_BEFORE_DELETE " +
+                    "BEFORE DELETE ON `stations` BEGIN DELETE FROM `stations_fts` WHERE `docid`=OLD.`rowid`; END",
+            )
+            db.execSQL(
+                "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_AFTER_UPDATE " +
+                    "AFTER UPDATE ON `stations` BEGIN INSERT INTO `stations_fts`(`docid`, `name`, `streamUrl`, `provider`, `providerId`, `tags`, `description`, `country`) " +
+                    "VALUES (NEW.`rowid`, NEW.`name`, NEW.`streamUrl`, NEW.`provider`, NEW.`providerId`, NEW.`tags`, NEW.`description`, NEW.`country`); END",
+            )
+            db.execSQL(
+                "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_AFTER_INSERT " +
+                    "AFTER INSERT ON `stations` BEGIN INSERT INTO `stations_fts`(`docid`, `name`, `streamUrl`, `provider`, `providerId`, `tags`, `description`, `country`) " +
+                    "VALUES (NEW.`rowid`, NEW.`name`, NEW.`streamUrl`, NEW.`provider`, NEW.`providerId`, NEW.`tags`, NEW.`description`, NEW.`country`); END",
+            )
+            db.execSQL("INSERT INTO `stations_fts`(`stations_fts`) VALUES('rebuild')")
+        }
 
         private fun createRegistryTable(db: SupportSQLiteDatabase) {
             db.execSQL(

--- a/app/src/main/java/com/shapeshed/aerial/data/StationFts.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/StationFts.kt
@@ -1,0 +1,24 @@
+package com.shapeshed.aerial.data
+
+import androidx.room.Entity
+import androidx.room.Fts4
+
+/**
+ * Full-text search index over locally saved stations. Local station rows are the source of truth
+ * for favorites, including user-edited names, stream URLs, and registry identity.
+ */
+@Fts4(
+    contentEntity = Station::class,
+    tokenizer = "unicode61",
+    tokenizerArgs = ["remove_diacritics=1"],
+)
+@Entity(tableName = "stations_fts")
+data class StationFts(
+    val name: String,
+    val streamUrl: String,
+    val provider: String,
+    val providerId: String,
+    val tags: String,
+    val description: String,
+    val country: String,
+)

--- a/app/src/main/java/com/shapeshed/aerial/data/StationRepository.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/StationRepository.kt
@@ -6,6 +6,10 @@ class StationRepository(private val dao: StationDao) {
     fun getAll(): Flow<List<Station>> = dao.getAll()
     suspend fun getById(id: Long): Station? = dao.getById(id)
     suspend fun getByStreamUrl(streamUrl: String): Station? = dao.getByStreamUrl(streamUrl)
+    suspend fun searchFavorites(query: String): List<Station> {
+        val match = toFtsMatchQuery(NumberNormalizer.normalize(query.trim()))
+        return if (match.isBlank()) emptyList() else dao.searchStationFts(match)
+    }
     suspend fun insert(station: Station): Long = dao.insert(station)
     suspend fun update(station: Station) = dao.update(station)
     suspend fun delete(station: Station) = dao.delete(station)
@@ -15,6 +19,10 @@ class StationRepository(private val dao: StationDao) {
         if (existing != null) {
             val updated = existing.copy(
                 logoPath = existing.logoPath.ifBlank { station.logoPath },
+                tags = existing.tags.ifBlank { station.tags },
+                description = existing.description.ifBlank { station.description },
+                country = existing.country.ifBlank { station.country },
+                countryCode = existing.countryCode.ifBlank { station.countryCode },
             )
             if (updated != existing) dao.update(updated)
             return existing.id
@@ -43,7 +51,15 @@ class StationRepository(private val dao: StationDao) {
     suspend fun saveAsFavorite(station: Station): Long {
         val existing = findExisting(station)
         return if (existing != null) {
-            if (!existing.isFavorite) dao.update(existing.copy(isFavorite = true))
+            val updated = existing.copy(
+                isFavorite = true,
+                logoPath = existing.logoPath.ifBlank { station.logoPath },
+                tags = existing.tags.ifBlank { station.tags },
+                description = existing.description.ifBlank { station.description },
+                country = existing.country.ifBlank { station.country },
+                countryCode = existing.countryCode.ifBlank { station.countryCode },
+            )
+            if (updated != existing) dao.update(updated)
             existing.id
         } else {
             dao.insert(station.copy(id = 0, isFavorite = true))
@@ -51,6 +67,10 @@ class StationRepository(private val dao: StationDao) {
     }
 
     private suspend fun findExisting(station: Station): Station? {
-        return dao.getByStreamUrl(station.streamUrl)
+        return if (station.provider.isNotBlank() && station.providerId.isNotBlank()) {
+            dao.getByProviderId(station.provider, station.providerId)
+        } else {
+            null
+        } ?: dao.getByStreamUrl(station.streamUrl)
     }
 }

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -182,6 +182,21 @@ private val CATEGORY_ICONS = mapOf(
     "Electronic" to Icons.Rounded.GraphicEq,
 )
 
+private data class RegistryStationKey(
+    val provider: String,
+    val providerId: String,
+)
+
+private fun RegistryStation.savedKey(): RegistryStationKey? =
+    RegistryStationKey(provider, providerId).takeIf {
+        it.provider.isNotBlank() && it.providerId.isNotBlank()
+    }
+
+private fun Station.savedKey(): RegistryStationKey? =
+    RegistryStationKey(provider, providerId).takeIf {
+        it.provider.isNotBlank() && it.providerId.isNotBlank()
+    }
+
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun MainScreen(
@@ -209,6 +224,7 @@ fun MainScreen(
     val haptic = LocalHapticFeedback.current
     val showNowPlaying by viewModel.showNowPlaying.collectAsStateWithLifecycle()
     val registrySearchResults by viewModel.registrySearchResults.collectAsStateWithLifecycle()
+    val favoriteSearchResults by viewModel.favoriteSearchResults.collectAsStateWithLifecycle()
     val recentSearches by viewModel.recentSearches.collectAsStateWithLifecycle()
     val allTags by viewModel.allTags.collectAsStateWithLifecycle()
     val featuredStations by viewModel.featuredStations.collectAsStateWithLifecycle()
@@ -235,6 +251,7 @@ fun MainScreen(
     val scope = rememberCoroutineScope()
 
     val savedStreamUrls = remember(stations) { stations.map { it.streamUrl }.toSet() }
+    val savedRegistryKeys = remember(stations) { stations.mapNotNull { it.savedKey() }.toSet() }
 
     var miniPlayerHeightPx by remember { mutableIntStateOf(0) }
     val density = LocalDensity.current
@@ -545,6 +562,7 @@ fun MainScreen(
                         DefaultSearchResults(
                             stations = defaultStations,
                             savedStreamUrls = savedStreamUrls,
+                            savedRegistryKeys = savedRegistryKeys,
                             onPlay = { station ->
                                 viewModel.playFromRegistry(station)
                                 textFieldState.edit { replace(0, length, "") }
@@ -556,8 +574,16 @@ fun MainScreen(
                     }
                 } else {
                     RegistrySearchResults(
+                        favoriteResults = favoriteSearchResults,
                         results = registrySearchResults,
                         savedStreamUrls = savedStreamUrls,
+                        savedRegistryKeys = savedRegistryKeys,
+                        onFavoritePlay = { station ->
+                            viewModel.saveRecentSearch(searchQueryText)
+                            viewModel.play(station)
+                            textFieldState.edit { replace(0, length, "") }
+                            scope.launch { searchBarState.animateToCollapsed() }
+                        },
                         onPlay = { station ->
                             viewModel.saveRecentSearch(searchQueryText)
                             viewModel.playFromRegistry(station)
@@ -669,6 +695,7 @@ fun MainScreen(
 private fun DefaultSearchResults(
     stations: List<RegistryStation>,
     savedStreamUrls: Set<String>,
+    savedRegistryKeys: Set<RegistryStationKey>,
     onPlay: (RegistryStation) -> Unit,
     onAdd: (RegistryStation) -> Unit,
     onRemove: (RegistryStation) -> Unit,
@@ -682,7 +709,7 @@ private fun DefaultSearchResults(
         ) { station ->
             RegistryResultItem(
                 station = station,
-                alreadySaved = station.streamUrl in savedStreamUrls,
+                alreadySaved = station.streamUrl in savedStreamUrls || station.savedKey() in savedRegistryKeys,
                 onTap = { onPlay(station) },
                 onAdd = { onAdd(station) },
                 onRemove = { onRemove(station) },
@@ -727,15 +754,18 @@ private fun RecentSearches(
 
 @Composable
 private fun RegistrySearchResults(
+    favoriteResults: List<Station>,
     results: List<RegistryStation>,
     savedStreamUrls: Set<String>,
+    savedRegistryKeys: Set<RegistryStationKey>,
+    onFavoritePlay: (Station) -> Unit,
     onPlay: (RegistryStation) -> Unit,
     onAdd: (RegistryStation) -> Unit,
     onRemove: (RegistryStation) -> Unit,
     bottomPadding: androidx.compose.ui.unit.Dp,
     onAddManually: (() -> Unit)? = null,
 ) {
-    if (results.isEmpty()) {
+    if (favoriteResults.isEmpty() && results.isEmpty()) {
         Box(
             modifier = androidx.compose.ui.Modifier.fillMaxSize().padding(32.dp),
             contentAlignment = Alignment.Center,
@@ -788,12 +818,42 @@ private fun RegistrySearchResults(
         LazyColumn(
             contentPadding = PaddingValues(bottom = bottomPadding),
         ) {
+            if (favoriteResults.isNotEmpty()) {
+                item("favorite-results-header") {
+                    Text(
+                        text = stringResource(R.string.favorites_header),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 12.dp, bottom = 4.dp),
+                    )
+                }
+                items(
+                    items = favoriteResults,
+                    key = { "favorite-${it.id}" },
+                    contentType = { "favorite-result" },
+                ) { station ->
+                    FavoriteResultItem(
+                        station = station,
+                        onTap = { onFavoritePlay(station) },
+                    )
+                }
+                if (results.isNotEmpty()) {
+                    item("registry-results-header") {
+                        Text(
+                            text = stringResource(R.string.search_stations_header),
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 12.dp, bottom = 4.dp),
+                        )
+                    }
+                }
+            }
             items(
                 items = results,
                 key = { it.id },
                 contentType = { "registry-result" },
             ) { station ->
-                val alreadySaved = station.streamUrl in savedStreamUrls
+                val alreadySaved = station.streamUrl in savedStreamUrls || station.savedKey() in savedRegistryKeys
                 RegistryResultItem(
                     station = station,
                     alreadySaved = alreadySaved,
@@ -804,6 +864,49 @@ private fun RegistrySearchResults(
             }
         }
     }
+}
+
+@Composable
+private fun FavoriteResultItem(
+    station: Station,
+    onTap: () -> Unit,
+) {
+    val countryLabel = station.countryCode.takeIf { it.isNotBlank() }
+        ?.let { countryName(it, LocalConfiguration.current.locales[0]) }
+        ?: station.country
+    ListItem(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onTap),
+        leadingContent = {
+            StationAvatar(station = station, isActive = false, size = 50.dp)
+        },
+        headlineContent = {
+            Text(
+                text = station.name,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
+        supportingContent = if (countryLabel.isNotBlank()) {
+            {
+                Text(
+                    text = countryLabel,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        } else null,
+        trailingContent = {
+            Icon(
+                imageVector = Icons.Rounded.Favorite,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(20.dp),
+            )
+        },
+    )
 }
 
 @Composable
@@ -1111,6 +1214,12 @@ private fun StationTile(
                 ),
         ) {
             Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                Icon(
+                    imageVector = Icons.Rounded.Radio,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(48.dp),
+                )
                 if (logoModel != null && !logoFailed) {
                     AsyncImage(
                         model = logoModel,
@@ -1299,15 +1408,13 @@ private fun StationContextSheet(
             modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
         )
         HorizontalDivider()
-        if (station.provider.isBlank()) {
-            ListItem(
-                headlineContent = { Text(stringResource(R.string.action_edit)) },
-                leadingContent = {
-                    Icon(Icons.Rounded.Edit, contentDescription = null)
-                },
-                modifier = Modifier.clickable(onClick = onEdit),
-            )
-        }
+        ListItem(
+            headlineContent = { Text(stringResource(R.string.action_edit)) },
+            leadingContent = {
+                Icon(Icons.Rounded.Edit, contentDescription = null)
+            },
+            modifier = Modifier.clickable(onClick = onEdit),
+        )
         ListItem(
             headlineContent = {
                 Text(stringResource(R.string.action_remove), color = MaterialTheme.colorScheme.error)
@@ -1486,6 +1593,12 @@ fun StationAvatar(
                 else MaterialTheme.colorScheme.surfaceContainerHigh,
             ),
     ) {
+        Icon(
+            imageVector = Icons.Rounded.Radio,
+            contentDescription = null,
+            tint = iconTint,
+            modifier = Modifier.size(size * 0.55f),
+        )
         if (logoModel != null && !logoFailed) {
             val imageRequest = remember(context, logoModel) { ImageRequest.Builder(context).data(logoModel).build() }
             AsyncImage(
@@ -1494,13 +1607,6 @@ fun StationAvatar(
                 contentScale = ContentScale.Fit,
                 onError = { logoFailed = true },
                 modifier = Modifier.fillMaxSize(),
-            )
-        } else {
-            Icon(
-                imageVector = Icons.Rounded.Radio,
-                contentDescription = null,
-                tint = iconTint,
-                modifier = Modifier.size(size * 0.55f),
             )
         }
     }

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -208,6 +208,9 @@ class MainViewModel(
     private val _registrySearchResults = MutableStateFlow<List<RegistryStation>>(emptyList())
     val registrySearchResults: StateFlow<List<RegistryStation>> = _registrySearchResults.asStateFlow()
 
+    private val _favoriteSearchResults = MutableStateFlow<List<Station>>(emptyList())
+    val favoriteSearchResults: StateFlow<List<Station>> = _favoriteSearchResults.asStateFlow()
+
     private val _selectedCountries = MutableStateFlow<Set<String>>(emptySet())
     val selectedCountries: StateFlow<Set<String>> = _selectedCountries.asStateFlow()
 
@@ -267,6 +270,11 @@ class MainViewModel(
     private fun runSearch(query: String) {
         searchJob?.cancel()
         searchJob = viewModelScope.launch(Dispatchers.IO) {
+            _favoriteSearchResults.value = if (query.isBlank()) {
+                emptyList()
+            } else {
+                repository.searchFavorites(query)
+            }
             _registrySearchResults.value = registryRepository.search(
                 query = query,
                 countryCodes = _selectedCountries.value,
@@ -298,6 +306,10 @@ class MainViewModel(
             logoPath = registryStation.logoUrl,
             provider = registryStation.provider,
             providerId = registryStation.providerId,
+            tags = registryStation.tags,
+            description = registryStation.description,
+            country = registryStation.country,
+            countryCode = registryStation.countryCode,
         )
         play(station)
     }
@@ -317,6 +329,10 @@ class MainViewModel(
                     isFavorite = true,
                     provider = registryStation.provider,
                     providerId = registryStation.providerId,
+                    tags = registryStation.tags,
+                    description = registryStation.description,
+                    country = registryStation.country,
+                    countryCode = registryStation.countryCode,
                 ),
             )
             _recentlyAddedStationId.value = stationId
@@ -324,7 +340,13 @@ class MainViewModel(
     }
 
     fun removeFromRegistry(registryStation: RegistryStation) {
-        val station = _allStations.value.find { it.streamUrl == registryStation.streamUrl } ?: return
+        val station = _allStations.value.find { station ->
+            station.streamUrl == registryStation.streamUrl ||
+                station.provider.isNotBlank() &&
+                station.providerId.isNotBlank() &&
+                station.provider == registryStation.provider &&
+                station.providerId == registryStation.providerId
+        } ?: return
         deleteStation(station)
     }
 
@@ -686,6 +708,10 @@ private fun Station.toLastPlayedJson(): JSONObject =
         .put("isFavorite", isFavorite)
         .put("provider", provider)
         .put("providerId", providerId)
+        .put("tags", tags)
+        .put("description", description)
+        .put("country", country)
+        .put("countryCode", countryCode)
 
 private fun lastPlayedStationSnapshot(json: String): LastPlayedStationSnapshot {
     val obj = JSONObject(json)
@@ -698,6 +724,10 @@ private fun lastPlayedStationSnapshot(json: String): LastPlayedStationSnapshot {
             isFavorite = obj.optBoolean("isFavorite"),
             provider = obj.optString("provider"),
             providerId = obj.optString("providerId"),
+            tags = obj.optString("tags"),
+            description = obj.optString("description"),
+            country = obj.optString("country"),
+            countryCode = obj.optString("countryCode"),
         ),
     )
 }

--- a/app/src/main/java/com/shapeshed/aerial/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/SettingsViewModel.kt
@@ -114,6 +114,12 @@ class SettingsViewModel(
                     .put("name", station.name)
                     .put("streamUrl", station.streamUrl)
                     .put("isFavorite", station.isFavorite)
+                    .put("provider", station.provider)
+                    .put("providerId", station.providerId)
+                    .put("tags", station.tags)
+                    .put("description", station.description)
+                    .put("country", station.country)
+                    .put("countryCode", station.countryCode)
 
                 val logoFile = station.logoPath
                     .takeIf { it.isNotBlank() && !it.startsWith("http") }
@@ -192,7 +198,13 @@ class SettingsViewModel(
                     name = item.getString("name").trim(),
                     streamUrl = item.getString("streamUrl").trim(),
                     logoPath = logoPath.trim(),
-                    isFavorite = item.optBoolean("isFavorite"),
+                    isFavorite = item.optBoolean("isFavorite", true),
+                    provider = item.optString("provider").trim(),
+                    providerId = item.optString("providerId").trim(),
+                    tags = item.optString("tags").trim(),
+                    description = item.optString("description").trim(),
+                    country = item.optString("country").trim(),
+                    countryCode = item.optString("countryCode").trim(),
                 )
             )
         }

--- a/app/src/main/java/com/shapeshed/aerial/ui/StationEditViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/StationEditViewModel.kt
@@ -33,11 +33,13 @@ class StationEditViewModel(
     val isEditing: Boolean = stationId != null
 
     private var logoCopyJob: Job? = null
+    private var existingStation: Station? = null
 
     init {
         if (stationId != null) {
             viewModelScope.launch {
                 repository.getById(stationId)?.let { station ->
+                    existingStation = station
                     _name.value = station.name
                     _streamUrl.value = station.streamUrl
                     val path = station.logoPath
@@ -73,7 +75,11 @@ class StationEditViewModel(
         if (_name.value.isBlank() || _streamUrl.value.isBlank()) return
         viewModelScope.launch {
             logoCopyJob?.join()  // wait for any in-progress copy before reading the path
-            val station = Station(
+            val station = (existingStation ?: Station(
+                name = "",
+                streamUrl = "",
+                isFavorite = true,
+            )).copy(
                 id = stationId ?: 0,
                 name = _name.value.trim(),
                 streamUrl = _streamUrl.value.trim(),

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -32,6 +32,7 @@
     <string name="no_internet_title">Keine Internetverbindung</string>
     <string name="no_internet_desc">Radio-Streams erfordern eine aktive Internetverbindung.</string>
     <string name="favorites_header">Deine Favoriten</string>
+    <string name="search_stations_header">Stationen</string>
     <string name="get_started">Loslegen</string>
     <string name="just_listen">Einfach zuhören</string>
     <string name="find_a_station">Sender finden</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -6,4 +6,5 @@
     <string name="remove_from_favorites">Remove from favourites</string>
     <string name="add_to_favorites">Add to favourites</string>
     <string name="favorites_header">Your favourites</string>
+    <string name="search_stations_header">Stations</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -32,6 +32,7 @@
     <string name="no_internet_title">Sin conexión a internet</string>
     <string name="no_internet_desc">Las emisiones de radio requieren una conexión a internet activa.</string>
     <string name="favorites_header">Tus favoritos</string>
+    <string name="search_stations_header">Emisoras</string>
     <string name="get_started">Empezar</string>
     <string name="just_listen">Solo escucha</string>
     <string name="find_a_station">Buscar una emisora</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -32,6 +32,7 @@
     <string name="no_internet_title">Aucune connexion internet</string>
     <string name="no_internet_desc">Les flux radio nécessitent une connexion internet active.</string>
     <string name="favorites_header">Vos favoris</string>
+    <string name="search_stations_header">Stations</string>
     <string name="get_started">Commencer</string>
     <string name="just_listen">Écoutez, tout simplement</string>
     <string name="find_a_station">Trouver une station</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -32,6 +32,7 @@
     <string name="no_internet_title">Nessuna connessione a internet</string>
     <string name="no_internet_desc">Gli stream radio richiedono una connessione a internet attiva.</string>
     <string name="favorites_header">I tuoi preferiti</string>
+    <string name="search_stations_header">Stazioni</string>
     <string name="get_started">Inizia</string>
     <string name="just_listen">Ascolta e basta</string>
     <string name="find_a_station">Trova una stazione</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -32,6 +32,7 @@
     <string name="no_internet_title">インターネットに接続されていません</string>
     <string name="no_internet_desc">ラジオのストリーミングには有効なインターネット接続が必要です。</string>
     <string name="favorites_header">お気に入り</string>
+    <string name="search_stations_header">放送局</string>
     <string name="get_started">はじめる</string>
     <string name="just_listen">ただ聴くだけ</string>
     <string name="find_a_station">放送局を探す</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -32,6 +32,7 @@
     <string name="no_internet_title">인터넷 연결 없음</string>
     <string name="no_internet_desc">라디오 스트림에는 인터넷 연결이 필요합니다.</string>
     <string name="favorites_header">즐겨찾기</string>
+    <string name="search_stations_header">방송국</string>
     <string name="get_started">시작하기</string>
     <string name="just_listen">그냥 들어보세요</string>
     <string name="find_a_station">방송국 찾기</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -32,6 +32,7 @@
     <string name="no_internet_title">Geen internetverbinding</string>
     <string name="no_internet_desc">Radiostreams vereisen een actieve internetverbinding.</string>
     <string name="favorites_header">Je favorieten</string>
+    <string name="search_stations_header">Stations</string>
     <string name="get_started">Aan de slag</string>
     <string name="just_listen">Gewoon luisteren</string>
     <string name="find_a_station">Zoek een zender</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -32,6 +32,7 @@
     <string name="no_internet_title">Sem conexão com a internet</string>
     <string name="no_internet_desc">Os streams de rádio exigem uma conexão ativa com a internet.</string>
     <string name="favorites_header">Seus favoritos</string>
+    <string name="search_stations_header">Estações</string>
     <string name="get_started">Começar</string>
     <string name="just_listen">É só ouvir</string>
     <string name="find_a_station">Encontrar uma estação</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -32,6 +32,7 @@
     <string name="no_internet_title">无网络连接</string>
     <string name="no_internet_desc">收听广播需要有效的网络连接。</string>
     <string name="favorites_header">你的收藏</string>
+    <string name="search_stations_header">电台</string>
     <string name="get_started">开始使用</string>
     <string name="just_listen">尽情聆听</string>
     <string name="find_a_station">查找电台</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="no_internet_title">No internet connection</string>
     <string name="no_internet_desc">Radio streams require an active internet connection.</string>
     <string name="favorites_header">Your favorites</string>
+    <string name="search_stations_header">Stations</string>
     <string name="get_started">Get started</string>
     <string name="just_listen">Just listen</string>
     <string name="find_a_station">Find a station</string>

--- a/app/src/test/java/com/shapeshed/aerial/data/StationRepositoryTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/data/StationRepositoryTest.kt
@@ -52,6 +52,30 @@ class StationRepositoryTest {
     }
 
     @Test
+    fun insertOrGetExistingMatchesByProviderIdWhenStreamUrlChanged() = runBlocking {
+        val existing = station(
+            id = 5L,
+            streamUrl = "https://stream.example.com/local-correction",
+            provider = "aerial",
+            providerId = "mango",
+        )
+        val dao = FakeStationDao(existing)
+        val repository = StationRepository(dao)
+
+        val id = repository.insertOrGetExisting(
+            station(
+                streamUrl = "https://stream.example.com/registry",
+                provider = "aerial",
+                providerId = "mango",
+            )
+        )
+
+        assertEquals(5L, id)
+        assertEquals(0, dao.insertCount)
+        assertEquals(existing, dao.stations.single())
+    }
+
+    @Test
     fun insertOrGetExistingKeepsExistingLogoWhenPresent() = runBlocking {
         val existing = station(id = 3L, logoPath = "/logos/existing.png")
         val dao = FakeStationDao(existing)
@@ -62,16 +86,88 @@ class StationRepositoryTest {
         assertEquals("/logos/existing.png", dao.stations.single().logoPath)
     }
 
+    @Test
+    fun saveAsFavoriteMatchesProviderIdAndKeepsLocalEdits() = runBlocking {
+        val existing = station(
+            id = 8L,
+            name = "Mango Local",
+            streamUrl = "https://stream.example.com/local-correction",
+            logoPath = "/logos/local.png",
+            isFavorite = true,
+            provider = "aerial",
+            providerId = "mango",
+        )
+        val dao = FakeStationDao(existing)
+        val repository = StationRepository(dao)
+
+        val id = repository.saveAsFavorite(
+            station(
+                name = "Mango Registry",
+                streamUrl = "https://stream.example.com/registry",
+                logoPath = "/logos/registry.png",
+                provider = "aerial",
+                providerId = "mango",
+            )
+        )
+
+        assertEquals(8L, id)
+        assertEquals(existing, dao.stations.single())
+    }
+
+    @Test
+    fun searchFavoritesIncludesSavedStationsImportedWithoutFavoriteFlag() = runBlocking {
+        val dao = FakeStationDao(
+            station(id = 2L, name = "dublab", isFavorite = false),
+        )
+        val repository = StationRepository(dao)
+
+        val results = repository.searchFavorites("dublab")
+
+        assertEquals(listOf(dao.stations.single()), results)
+    }
+
+    @Test
+    fun searchFavoritesMatchesTagsAndDescription() = runBlocking {
+        val dao = FakeStationDao(
+            station(
+                id = 3L,
+                name = "Kool FM",
+                tags = "drum bass jungle",
+                description = "Underground radio",
+                country = "United Kingdom",
+            ),
+        )
+        val repository = StationRepository(dao)
+
+        assertEquals(listOf(dao.stations.single()), repository.searchFavorites("jungle"))
+        assertEquals(listOf(dao.stations.single()), repository.searchFavorites("underground"))
+        assertEquals(listOf(dao.stations.single()), repository.searchFavorites("kingdom"))
+    }
+
     private fun station(
         id: Long = 0,
         name: String = "Mango",
         streamUrl: String = "https://stream.example.com/mango",
         logoPath: String = "",
+        isFavorite: Boolean = false,
+        provider: String = "",
+        providerId: String = "",
+        tags: String = "",
+        description: String = "",
+        country: String = "",
+        countryCode: String = "",
     ) = Station(
         id = id,
         name = name,
         streamUrl = streamUrl,
         logoPath = logoPath,
+        isFavorite = isFavorite,
+        provider = provider,
+        providerId = providerId,
+        tags = tags,
+        description = description,
+        country = country,
+        countryCode = countryCode,
     )
 
     private class FakeStationDao(vararg initialStations: Station) : StationDao {
@@ -87,6 +183,23 @@ class StationRepositoryTest {
 
         override suspend fun getByStreamUrl(streamUrl: String): Station? {
             return stations.firstOrNull { it.streamUrl == streamUrl }
+        }
+
+        override suspend fun getByProviderId(provider: String, providerId: String): Station? {
+            return stations.firstOrNull { it.provider == provider && it.providerId == providerId }
+        }
+
+        override suspend fun searchStationFts(match: String): List<Station> {
+            val terms = match.split(" ").map { it.removeSuffix("*").lowercase() }
+            return stations
+                .filter { station ->
+                    val text = "${station.name} ${station.streamUrl} ${station.provider} ${station.providerId} " +
+                        "${station.tags} ${station.description} ${station.country}"
+                    val searchable = text.lowercase()
+                    terms.all { searchable.contains(it) }
+                }
+                .sortedBy { it.name.lowercase() }
+                .take(20)
         }
 
         override suspend fun updateStreamUrlByProviderId(provider: String, providerId: String, streamUrl: String) {


### PR DESCRIPTION
## Summary
- keep saved registry stations as editable local snapshots, including provider identity and search metadata
- add local station FTS so saved stations appear above registry search results
- preserve favorites when registry entries disappear and show default icons for stations without logos

## Testing
- ./gradlew compileDebugKotlin
- ./gradlew testDebugUnitTest
- ./gradlew installDebug

Fixes #41