### PR TITLE
feat(now-playing): add stream bitrate display

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/AerialApp.kt
+++ b/app/src/main/java/com/shapeshed/aerial/AerialApp.kt
@@ -36,6 +36,7 @@ import okhttp3.OkHttpClient
 val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
 val REGISTRY_LAST_SYNC_KEY = longPreferencesKey("registry_last_network_sync")
 val ENRICH_METADATA_KEY = booleanPreferencesKey("enrich_metadata")
+val SHOW_STREAM_BITRATE_KEY = booleanPreferencesKey("show_stream_bitrate")
 private const val REGISTRY_SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000L
 
 class AerialApp : Application(), SingletonImageLoader.Factory {

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -227,6 +227,7 @@ fun MainScreen(
     val currentTrackArtist by viewModel.currentTrackArtist.collectAsStateWithLifecycle()
     val currentTrackArtworkData by viewModel.currentTrackArtworkData.collectAsStateWithLifecycle()
     val currentTrackArtworkUrl by viewModel.currentTrackArtworkUrl.collectAsStateWithLifecycle()
+    val currentBitrateKbps by viewModel.currentBitrateKbps.collectAsStateWithLifecycle()
     val nowPlayingInfo by viewModel.nowPlayingInfo.collectAsStateWithLifecycle()
     val nowPlayingDisplay by viewModel.nowPlayingDisplay.collectAsStateWithLifecycle()
     val sleepTimer by viewModel.sleepTimer.collectAsStateWithLifecycle()
@@ -243,6 +244,7 @@ fun MainScreen(
     val featuredStations by viewModel.featuredStations.collectAsStateWithLifecycle()
     val defaultStations by viewModel.defaultStations.collectAsStateWithLifecycle()
     val homeViewMode by viewModel.homeViewMode.collectAsStateWithLifecycle()
+    val showStreamBitrate by viewModel.showStreamBitrate.collectAsStateWithLifecycle()
     val selectedCountries: Set<String> by viewModel.selectedCountries.collectAsStateWithLifecycle()
     val selectedTags: Set<String> by viewModel.selectedTags.collectAsStateWithLifecycle()
     val availableCountries: List<String> by viewModel.availableCountries.collectAsStateWithLifecycle()
@@ -537,6 +539,8 @@ fun MainScreen(
                     currentTrackArtist = currentTrackArtist,
                     currentTrackArtworkData = currentTrackArtworkData,
                     currentTrackArtworkUrl = currentTrackArtworkUrl,
+                    currentBitrateKbps = currentBitrateKbps,
+                    showStreamBitrate = showStreamBitrate,
                     sleepTimer = sleepTimer,
                     onToggle = { viewModel.togglePlayback() },
                     onToggleFavorite = { viewModel.toggleFavorite(station) },

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -18,10 +18,14 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.media3.common.C
+import androidx.media3.common.Format
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
+import androidx.media3.common.Tracks
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionToken
@@ -29,6 +33,7 @@ import androidx.core.content.ContextCompat
 import com.shapeshed.aerial.AerialApp
 import com.shapeshed.aerial.PlayerService
 import com.shapeshed.aerial.R
+import com.shapeshed.aerial.SHOW_STREAM_BITRATE_KEY
 import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_CANCEL
 import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_SET
 import com.shapeshed.aerial.data.NowPlayingInfo
@@ -163,6 +168,9 @@ class MainViewModel(
     private val _currentTrackArtworkData = MutableStateFlow<ByteArray?>(null)
     val currentTrackArtworkData: StateFlow<ByteArray?> = _currentTrackArtworkData.asStateFlow()
 
+    private val _currentBitrateKbps = MutableStateFlow<Int?>(null)
+    val currentBitrateKbps: StateFlow<Int?> = _currentBitrateKbps.asStateFlow()
+
     private val _playbackError = MutableStateFlow<String?>(null)
     val playbackError: StateFlow<String?> = _playbackError.asStateFlow()
 
@@ -210,6 +218,10 @@ class MainViewModel(
     val homeViewMode: StateFlow<HomeViewMode> = dataStore.data
         .map { prefs -> if (prefs[HOME_CARDS_VIEW_KEY] == false) HomeViewMode.List else HomeViewMode.Cards }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), HomeViewMode.Cards)
+
+    val showStreamBitrate: StateFlow<Boolean> = dataStore.data
+        .map { prefs -> prefs[SHOW_STREAM_BITRATE_KEY] ?: false }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
     fun setHomeViewMode(mode: HomeViewMode) {
         viewModelScope.launch {
@@ -428,11 +440,13 @@ class MainViewModel(
                         _ephemeralStation.value = null
                     }
                     _isPlaying.value = controller?.isPlaying ?: false
+                    updateCurrentBitrate(controller?.currentTracks ?: Tracks.EMPTY)
                     controller?.mediaMetadata?.artist?.toString()?.trim()
                         ?.takeIf { it.isNotEmpty() && it != liveRadio() }
                         ?.let { _currentTrackTitle.value = it }
                 } else if (_currentStationId.value == null) {
                     _isPlaying.value = controller?.isPlaying ?: false
+                    updateCurrentBitrate(controller?.currentTracks ?: Tracks.EMPTY)
                 }
             }
             if (controller?.currentMediaItem == null) {
@@ -494,6 +508,24 @@ class MainViewModel(
                 null
             }
         }
+        override fun onTracksChanged(tracks: Tracks) {
+            updateCurrentBitrate(tracks)
+        }
+    }
+
+    @androidx.annotation.OptIn(UnstableApi::class)
+    private fun updateCurrentBitrate(tracks: Tracks) {
+        _currentBitrateKbps.value = tracks.getGroups()
+            .asSequence()
+            .filter { group -> group.type == C.TRACK_TYPE_AUDIO && group.isSelected }
+            .flatMap { group ->
+                (0 until group.length).asSequence()
+                    .filter { index -> group.isTrackSelected(index) }
+                    .map { index -> group.getTrackFormat(index) }
+            }
+            .mapNotNull { format -> format.bitrate.takeIf { it != Format.NO_VALUE && it > 0 } }
+            .firstOrNull()
+            ?.let { bitrate -> (bitrate / 1_000).coerceAtLeast(1) }
     }
 
     fun play(station: Station) {
@@ -508,6 +540,7 @@ class MainViewModel(
         _currentTrackArtist.value = null
         _currentTrackArtworkUrl.value = null
         _currentTrackArtworkData.value = null
+        _currentBitrateKbps.value = null
         _playbackError.value = null
         persistLastPlayedStation(station)
         val artworkUri = station.logoPath

--- a/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
@@ -96,6 +96,8 @@ fun NowPlayingScreen(
     currentTrackArtist: String? = null,
     currentTrackArtworkData: ByteArray? = null,
     currentTrackArtworkUrl: String? = null,
+    currentBitrateKbps: Int? = null,
+    showStreamBitrate: Boolean = false,
     sleepTimer: SleepTimerState? = null,
     onToggle: () -> Unit,
     onToggleFavorite: () -> Unit,
@@ -153,6 +155,9 @@ fun NowPlayingScreen(
     var mainArtworkFailed by remember(mainArtworkModel) { mutableStateOf(false) }
     var trackArtworkFailed by remember(trackArtworkModel) { mutableStateOf(false) }
     val showTrackBlock = !trackTitle.isNullOrBlank() && trackTitle != programmeTitle
+    val bitrateLabel = currentBitrateKbps
+        ?.takeIf { showStreamBitrate && it > 0 }
+        ?.let { stringResource(R.string.stream_bitrate_format, it) }
     LaunchedEffect(showTrackBlock) { if (!showTrackBlock) showTrackDetail = false }
     // When the timer clears (it expired, or was cancelled), close the picker too. Keyed on the
     // active->inactive transition so a picker opened with no timer running stays open.
@@ -262,6 +267,14 @@ fun NowPlayingScreen(
                             )
                         }
                     }
+                }
+                if (bitrateLabel != null) {
+                    StreamBitratePill(
+                        text = bitrateLabel,
+                        modifier = Modifier
+                            .align(Alignment.BottomStart)
+                            .padding(start = 12.dp, bottom = 12.dp),
+                    )
                 }
             }
             Spacer(Modifier.height(28.dp))
@@ -603,5 +616,25 @@ fun NowPlayingScreen(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun StreamBitratePill(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        tonalElevation = 1.dp,
+        modifier = modifier,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
+        )
     }
 }

--- a/app/src/main/java/com/shapeshed/aerial/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/SettingsScreen.kt
@@ -48,6 +48,7 @@ fun SettingsScreen(
 ) {
     val context = LocalContext.current
     val enrichMetadata by viewModel.enrichMetadata.collectAsStateWithLifecycle()
+    val showStreamBitrate by viewModel.showStreamBitrate.collectAsStateWithLifecycle()
     val versionName = BuildConfig.VERSION_NAME
     val snackbarHostState = remember { SnackbarHostState() }
     val exportLauncher = rememberLauncherForActivityResult(
@@ -98,6 +99,21 @@ fun SettingsScreen(
                     },
                 ) {
                     Text(stringResource(R.string.show_whats_playing))
+                }
+                HorizontalDivider()
+            }
+            item(contentType = "setting") {
+                ListItem(
+                    modifier = Modifier.clickable { viewModel.setShowStreamBitrate(!showStreamBitrate) },
+                    supportingContent = { Text(stringResource(R.string.show_stream_bitrate_desc)) },
+                    trailingContent = {
+                        Switch(
+                            checked = showStreamBitrate,
+                            onCheckedChange = { viewModel.setShowStreamBitrate(it) },
+                        )
+                    },
+                ) {
+                    Text(stringResource(R.string.show_stream_bitrate))
                 }
                 HorizontalDivider()
             }

--- a/app/src/main/java/com/shapeshed/aerial/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/SettingsViewModel.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.viewModelScope
 import com.shapeshed.aerial.AerialApp
 import com.shapeshed.aerial.ENRICH_METADATA_KEY
 import com.shapeshed.aerial.REGISTRY_LAST_SYNC_KEY
+import com.shapeshed.aerial.SHOW_STREAM_BITRATE_KEY
 import com.shapeshed.aerial.data.Station
 import com.shapeshed.aerial.data.StationRepository
 import java.io.ByteArrayOutputStream
@@ -45,12 +46,22 @@ class SettingsViewModel(
         .map { it[ENRICH_METADATA_KEY] ?: false }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
+    val showStreamBitrate = dataStore.data
+        .map { it[SHOW_STREAM_BITRATE_KEY] ?: false }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
     private val _messages = MutableSharedFlow<String>()
     val messages: SharedFlow<String> = _messages
 
     fun setEnrichMetadata(enabled: Boolean) {
         viewModelScope.launch {
             dataStore.edit { it[ENRICH_METADATA_KEY] = enabled }
+        }
+    }
+
+    fun setShowStreamBitrate(enabled: Boolean) {
+        viewModelScope.launch {
+            dataStore.edit { it[SHOW_STREAM_BITRATE_KEY] = enabled }
         }
     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -47,10 +47,13 @@
     <string name="add_to_favorites">Zu Favoriten hinzufügen</string>
     <string name="share_station">Sender teilen</string>
     <string name="copy_track_info">Titelinfo kopieren</string>
+    <string name="stream_bitrate_format">%1$d kbps</string>
 
     <!-- Settings -->
     <string name="show_whats_playing">Aktuellen Titel anzeigen</string>
     <string name="show_whats_playing_desc">Zeigt Titel, Interpret und Cover an, falls verfügbar</string>
+    <string name="show_stream_bitrate">Stream-Bitrate anzeigen</string>
+    <string name="show_stream_bitrate_desc">Zeigt die aktuelle Streamqualität im Player an</string>
     <string name="section_data">Daten</string>
     <string name="export_backup">Backup exportieren</string>
     <string name="export_backup_desc">Speichert Sender, Einstellungen und lokale Logos</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -47,10 +47,13 @@
     <string name="add_to_favorites">Añadir a favoritos</string>
     <string name="share_station">Compartir emisora</string>
     <string name="copy_track_info">Copiar info de la pista</string>
+    <string name="stream_bitrate_format">%1$d kbps</string>
 
     <!-- Settings -->
     <string name="show_whats_playing">Mostrar qué suena</string>
     <string name="show_whats_playing_desc">Muestra la canción, el artista y la portada cuando estén disponibles</string>
+    <string name="show_stream_bitrate">Mostrar bitrate del stream</string>
+    <string name="show_stream_bitrate_desc">Muestra la calidad actual del stream en el reproductor</string>
     <string name="section_data">Datos</string>
     <string name="export_backup">Exportar copia</string>
     <string name="export_backup_desc">Guarda emisoras, ajustes y logotipos locales</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -47,10 +47,13 @@
     <string name="add_to_favorites">Ajouter aux favoris</string>
     <string name="share_station">Partager la station</string>
     <string name="copy_track_info">Copier les infos du titre</string>
+    <string name="stream_bitrate_format">%1$d kbps</string>
 
     <!-- Settings -->
     <string name="show_whats_playing">Afficher le titre en cours</string>
     <string name="show_whats_playing_desc">Affiche le morceau, l\'artiste et la pochette lorsque disponibles</string>
+    <string name="show_stream_bitrate">Afficher le débit du flux</string>
+    <string name="show_stream_bitrate_desc">Affiche la qualité actuelle du flux dans le lecteur</string>
     <string name="section_data">Données</string>
     <string name="export_backup">Exporter la sauvegarde</string>
     <string name="export_backup_desc">Enregistre les stations, les paramètres et les logos locaux</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -47,10 +47,13 @@
     <string name="add_to_favorites">Aggiungi ai preferiti</string>
     <string name="share_station">Condividi stazione</string>
     <string name="copy_track_info">Copia info brano</string>
+    <string name="stream_bitrate_format">%1$d kbps</string>
 
     <!-- Settings -->
     <string name="show_whats_playing">Mostra cosa è in onda</string>
     <string name="show_whats_playing_desc">Mostra brano, artista e copertina quando disponibili</string>
+    <string name="show_stream_bitrate">Mostra bitrate dello stream</string>
+    <string name="show_stream_bitrate_desc">Mostra la qualità attuale dello stream nel player</string>
     <string name="section_data">Dati</string>
     <string name="export_backup">Esporta backup</string>
     <string name="export_backup_desc">Salva stazioni, impostazioni e loghi locali</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -47,10 +47,13 @@
     <string name="add_to_favorites">お気に入りに追加</string>
     <string name="share_station">放送局を共有</string>
     <string name="copy_track_info">曲情報をコピー</string>
+    <string name="stream_bitrate_format">%1$d kbps</string>
 
     <!-- Settings -->
     <string name="show_whats_playing">再生中の曲を表示</string>
     <string name="show_whats_playing_desc">利用可能な場合、曲名・アーティスト・アートワークを表示</string>
+    <string name="show_stream_bitrate">ストリームのビットレートを表示</string>
+    <string name="show_stream_bitrate_desc">プレーヤーに現在のストリーム品質を表示</string>
     <string name="section_data">データ</string>
     <string name="export_backup">バックアップを書き出す</string>
     <string name="export_backup_desc">放送局、設定、ローカルのロゴを保存</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -47,10 +47,13 @@
     <string name="add_to_favorites">즐겨찾기에 추가</string>
     <string name="share_station">방송국 공유</string>
     <string name="copy_track_info">트랙 정보 복사</string>
+    <string name="stream_bitrate_format">%1$d kbps</string>
 
     <!-- Settings -->
     <string name="show_whats_playing">재생 중인 곡 표시</string>
     <string name="show_whats_playing_desc">가능한 경우 곡, 아티스트, 아트워크를 표시</string>
+    <string name="show_stream_bitrate">스트림 비트레이트 표시</string>
+    <string name="show_stream_bitrate_desc">플레이어에 현재 스트림 품질을 표시</string>
     <string name="section_data">데이터</string>
     <string name="export_backup">백업 내보내기</string>
     <string name="export_backup_desc">방송국, 설정, 로컬 로고 저장</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -47,10 +47,13 @@
     <string name="add_to_favorites">Aan favorieten toevoegen</string>
     <string name="share_station">Zender delen</string>
     <string name="copy_track_info">Nummerinfo kopiëren</string>
+    <string name="stream_bitrate_format">%1$d kbps</string>
 
     <!-- Settings -->
     <string name="show_whats_playing">Toon wat er speelt</string>
     <string name="show_whats_playing_desc">Toont nummer, artiest en albumhoes indien beschikbaar</string>
+    <string name="show_stream_bitrate">Stream-bitrate tonen</string>
+    <string name="show_stream_bitrate_desc">Toont de huidige streamkwaliteit in de speler</string>
     <string name="section_data">Gegevens</string>
     <string name="export_backup">Back-up exporteren</string>
     <string name="export_backup_desc">Slaat zenders, instellingen en lokale logo\'s op</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -47,10 +47,13 @@
     <string name="add_to_favorites">Adicionar aos favoritos</string>
     <string name="share_station">Compartilhar estação</string>
     <string name="copy_track_info">Copiar info da faixa</string>
+    <string name="stream_bitrate_format">%1$d kbps</string>
 
     <!-- Settings -->
     <string name="show_whats_playing">Mostrar o que está tocando</string>
     <string name="show_whats_playing_desc">Exibe música, artista e capa quando disponíveis</string>
+    <string name="show_stream_bitrate">Mostrar bitrate do stream</string>
+    <string name="show_stream_bitrate_desc">Exibe a qualidade atual do stream no player</string>
     <string name="section_data">Dados</string>
     <string name="export_backup">Exportar backup</string>
     <string name="export_backup_desc">Salva estações, configurações e logotipos locais</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -47,10 +47,13 @@
     <string name="add_to_favorites">添加到收藏</string>
     <string name="share_station">分享电台</string>
     <string name="copy_track_info">复制曲目信息</string>
+    <string name="stream_bitrate_format">%1$d kbps</string>
 
     <!-- Settings -->
     <string name="show_whats_playing">显示正在播放</string>
     <string name="show_whats_playing_desc">在可用时显示歌曲、艺人和封面</string>
+    <string name="show_stream_bitrate">显示流比特率</string>
+    <string name="show_stream_bitrate_desc">在播放器中显示当前流质量</string>
     <string name="section_data">数据</string>
     <string name="export_backup">导出备份</string>
     <string name="export_backup_desc">保存电台、设置和本地徽标</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,10 +47,13 @@
     <string name="add_to_favorites">Add to favorites</string>
     <string name="share_station">Share station</string>
     <string name="copy_track_info">Copy track info</string>
+    <string name="stream_bitrate_format">%1$d kbps</string>
 
     <!-- Settings -->
     <string name="show_whats_playing">Show what\'s playing</string>
     <string name="show_whats_playing_desc">Display song, artist, and artwork when available</string>
+    <string name="show_stream_bitrate">Show stream bitrate</string>
+    <string name="show_stream_bitrate_desc">Display the current stream quality on the player</string>
     <string name="section_data">Data</string>
     <string name="export_backup">Export backup</string>
     <string name="export_backup_desc">Save stations, settings, and local logos</string>


### PR DESCRIPTION
## Summary
- derive the active stream bitrate from the selected Media3 audio track
- add an off-by-default setting to show stream bitrate on the now playing view
- display bitrate as a compact tonal overlay on the artwork so show title/description space is unchanged
- add translations for the setting and bitrate label

Refs #41

## Tests
- ./gradlew compileDebugKotlin
- ./gradlew testDebugUnitTest
- ./gradlew lintDebug
- ./gradlew installDebug