### PR TITLE
chore(registry): disable remote registry fetch

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/AerialApp.kt
+++ b/app/src/main/java/com/shapeshed/aerial/AerialApp.kt
@@ -4,9 +4,7 @@ import android.app.Application
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.booleanPreferencesKey
-import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.shapeshed.aerial.data.BauerProvider
 import com.shapeshed.aerial.data.BbcProvider
@@ -29,15 +27,12 @@ import coil3.svg.SvgDecoder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 
 val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
-val REGISTRY_LAST_SYNC_KEY = longPreferencesKey("registry_last_network_sync")
 val ENRICH_METADATA_KEY = booleanPreferencesKey("enrich_metadata")
 val SHOW_STREAM_BITRATE_KEY = booleanPreferencesKey("show_stream_bitrate")
-private const val REGISTRY_SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000L
 
 class AerialApp : Application(), SingletonImageLoader.Factory {
     val okHttpClient: OkHttpClient = OkHttpClient.Builder()
@@ -51,7 +46,7 @@ class AerialApp : Application(), SingletonImageLoader.Factory {
         .build()
     private val db by lazy { StationDatabase.get(this) }
     val repository by lazy { StationRepository(db.stationDao()) }
-    val registryRepository by lazy { RegistryRepository(db.registryDao(), okHttpClient) }
+    val registryRepository by lazy { RegistryRepository(db.registryDao()) }
     val settingsDataStore get() = dataStore
     val networkMonitor by lazy { NetworkMonitor(this) }
     val providers: List<Provider> = listOf(BbcProvider(), BauerProvider(), GlobalPlayerProvider(okHttpClient), WirelessProvider(), RadioFranceProvider(), RinseProvider(), RteProvider(), MusicBrainzProvider())
@@ -62,19 +57,7 @@ class AerialApp : Application(), SingletonImageLoader.Factory {
         super.onCreate()
         appScope.launch {
             runCatching {
-                if (registryRepository.isEmpty() || BuildConfig.DEBUG) {
-                    registryRepository.syncFromAssets(this@AerialApp)
-                }
-                if (!BuildConfig.DEBUG) {
-                    val lastSync = dataStore.data.first()[REGISTRY_LAST_SYNC_KEY] ?: 0L
-                    if (System.currentTimeMillis() - lastSync > REGISTRY_SYNC_INTERVAL_MS) {
-                        val stations = registryRepository.syncFromNetwork()
-                        if (stations != null) {
-                            repository.updateStreamUrlsFromRegistry(stations)
-                            dataStore.edit { it[REGISTRY_LAST_SYNC_KEY] = System.currentTimeMillis() }
-                        }
-                    }
-                }
+                registryRepository.syncFromAssets(this@AerialApp)
             }.onFailure { e ->
                 Log.e("AerialApp", "Registry bootstrap failed", e)
             }

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
@@ -1,16 +1,10 @@
 package com.shapeshed.aerial.data
 
 import android.content.Context
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.withContext
-import okhttp3.OkHttpClient
-import okhttp3.Request
 import org.json.JSONArray
 import java.io.ByteArrayInputStream
 import java.util.zip.GZIPInputStream
-
-private const val REGISTRY_URL = "https://aerial.shapeshed.com/registry.json.gz"
 
 // provider_id is only unique within a single provider's own namespace — e.g. NRK and DR
 // both use "p1"/"p2"/"p3" — so featured lookups must match on (provider, providerId)
@@ -37,7 +31,7 @@ internal fun toFtsMatchQuery(normalized: String): String =
         .filter { it.isNotBlank() }
         .joinToString(" ") { "$it*" }
 
-class RegistryRepository(private val dao: RegistryDao, private val httpClient: OkHttpClient) {
+class RegistryRepository(private val dao: RegistryDao) {
 
     fun countAsFlow(): Flow<Int> = dao.countAsFlow()
 
@@ -55,22 +49,6 @@ class RegistryRepository(private val dao: RegistryDao, private val httpClient: O
         val stations = parseRegistry(json)
         if (stations.isEmpty()) return
         dao.clearAndInsertAll(stations)
-    }
-
-    suspend fun syncFromNetwork(): List<RegistryStation>? = withContext(Dispatchers.IO) {
-        try {
-            val request = Request.Builder().url(REGISTRY_URL).build()
-            val json = httpClient.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) return@withContext null
-                response.body.bytes().readRegistryJson()
-            }
-            val stations = parseRegistry(json)
-            if (stations.isEmpty()) return@withContext null
-            dao.clearAndInsertAll(stations)
-            stations
-        } catch (e: Exception) {
-            null
-        }
     }
 
     suspend fun availableCountryCodes(): List<String> = dao.distinctCountryCodes()

--- a/app/src/main/java/com/shapeshed/aerial/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/SettingsViewModel.kt
@@ -12,7 +12,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.shapeshed.aerial.AerialApp
 import com.shapeshed.aerial.ENRICH_METADATA_KEY
-import com.shapeshed.aerial.REGISTRY_LAST_SYNC_KEY
 import com.shapeshed.aerial.SHOW_STREAM_BITRATE_KEY
 import com.shapeshed.aerial.data.Station
 import com.shapeshed.aerial.data.StationRepository
@@ -68,14 +67,10 @@ class SettingsViewModel(
     fun refreshRegistry() {
         viewModelScope.launch {
             val app = getApplication<AerialApp>()
-            val stations = runCatching {
-                withContext(Dispatchers.IO) { app.registryRepository.syncFromNetwork() }
-            }.getOrNull()
-            if (stations != null) {
-                withContext(Dispatchers.IO) { app.repository.updateStreamUrlsFromRegistry(stations) }
-                dataStore.edit { it[REGISTRY_LAST_SYNC_KEY] = System.currentTimeMillis() }
-            }
-            _messages.emit(if (stations != null) "Registry refreshed" else "Registry refresh failed")
+            val refreshed = runCatching {
+                withContext(Dispatchers.IO) { app.registryRepository.syncFromAssets(app) }
+            }.isSuccess
+            _messages.emit(if (refreshed) "Embedded registry refreshed" else "Embedded registry refresh failed")
         }
     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -61,7 +61,7 @@
     <string name="import_backup_desc">Führt Sender zusammen und stellt Einstellungen aus einem Backup wieder her</string>
     <string name="section_debug">Debug</string>
     <string name="refresh_registry">Registry aktualisieren</string>
-    <string name="refresh_registry_desc">Neueste Senderliste aus dem Netzwerk erzwingen</string>
+    <string name="refresh_registry_desc">Eingebettete Senderliste neu laden</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Sprache</string>
     <string name="language_system_default">Systemstandard</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -61,7 +61,7 @@
     <string name="import_backup_desc">Combina emisoras y restaura los ajustes desde una copia</string>
     <string name="section_debug">Depuración</string>
     <string name="refresh_registry">Actualizar registro</string>
-    <string name="refresh_registry_desc">Forzar la descarga del último registro de emisoras de la red</string>
+    <string name="refresh_registry_desc">Recargar el registro de emisoras incluido</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Idioma</string>
     <string name="language_system_default">Predeterminado del sistema</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -61,7 +61,7 @@
     <string name="import_backup_desc">Fusionne les stations et restaure les paramètres depuis une sauvegarde</string>
     <string name="section_debug">Débogage</string>
     <string name="refresh_registry">Actualiser le registre</string>
-    <string name="refresh_registry_desc">Forcer le téléchargement du dernier registre des stations depuis le réseau</string>
+    <string name="refresh_registry_desc">Recharge le registre des stations intégré</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Langue</string>
     <string name="language_system_default">Par défaut du système</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -61,7 +61,7 @@
     <string name="import_backup_desc">Unisce le stazioni e ripristina le impostazioni da un backup</string>
     <string name="section_debug">Debug</string>
     <string name="refresh_registry">Aggiorna registro</string>
-    <string name="refresh_registry_desc">Forza il download dell\'ultimo registro delle stazioni dalla rete</string>
+    <string name="refresh_registry_desc">Ricarica il registro stazioni integrato</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Lingua</string>
     <string name="language_system_default">Predefinita di sistema</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -61,7 +61,7 @@
     <string name="import_backup_desc">放送局を統合し、バックアップから設定を復元</string>
     <string name="section_debug">デバッグ</string>
     <string name="refresh_registry">レジストリを更新</string>
-    <string name="refresh_registry_desc">最新の放送局レジストリをネットワークから強制取得</string>
+    <string name="refresh_registry_desc">同梱の放送局レジストリを再読み込み</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">言語</string>
     <string name="language_system_default">システムのデフォルト</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -61,7 +61,7 @@
     <string name="import_backup_desc">백업에서 방송국을 병합하고 설정을 복원</string>
     <string name="section_debug">디버그</string>
     <string name="refresh_registry">레지스트리 새로고침</string>
-    <string name="refresh_registry_desc">네트워크에서 최신 방송국 레지스트리를 강제로 가져오기</string>
+    <string name="refresh_registry_desc">내장된 방송국 레지스트리를 다시 불러오기</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">언어</string>
     <string name="language_system_default">시스템 기본값</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -61,7 +61,7 @@
     <string name="import_backup_desc">Voegt zenders samen en herstelt instellingen uit een back-up</string>
     <string name="section_debug">Foutopsporing</string>
     <string name="refresh_registry">Register vernieuwen</string>
-    <string name="refresh_registry_desc">Forceer het ophalen van het nieuwste zenderregister uit het netwerk</string>
+    <string name="refresh_registry_desc">Laad het ingebouwde zenderregister opnieuw</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Taal</string>
     <string name="language_system_default">Systeemstandaard</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -61,7 +61,7 @@
     <string name="import_backup_desc">Mescla estações e restaura configurações de um backup</string>
     <string name="section_debug">Depuração</string>
     <string name="refresh_registry">Atualizar registro</string>
-    <string name="refresh_registry_desc">Forçar o download do registro de estações mais recente da rede</string>
+    <string name="refresh_registry_desc">Recarrega o registro de estações embutido</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Idioma</string>
     <string name="language_system_default">Padrão do sistema</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -61,7 +61,7 @@
     <string name="import_backup_desc">从备份合并电台并恢复设置</string>
     <string name="section_debug">调试</string>
     <string name="refresh_registry">刷新注册表</string>
-    <string name="refresh_registry_desc">强制从网络获取最新的电台注册表</string>
+    <string name="refresh_registry_desc">重新加载内置电台注册表</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">语言</string>
     <string name="language_system_default">系统默认</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,7 +61,7 @@
     <string name="import_backup_desc">Merge stations and restore settings from a backup</string>
     <string name="section_debug">Debug</string>
     <string name="refresh_registry">Refresh registry</string>
-    <string name="refresh_registry_desc">Force fetch latest station registry from network</string>
+    <string name="refresh_registry_desc">Reload the embedded station registry</string>
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Language</string>
     <string name="language_system_default">System default</string>


### PR DESCRIPTION
## Summary
- load the station registry only from the embedded app asset at startup
- remove the remote registry URL and network sync method from RegistryRepository
- update the debug registry refresh action and translations so it reloads the embedded registry instead of fetching from the network

## Tests
- ./gradlew compileDebugKotlin
- ./gradlew testDebugUnitTest
- ./gradlew lintDebug
- ./gradlew installDebug