### PR TITLE
feat(favorites): sort by A to Z, last played, or most played

### DIFF
--- a/app/schemas/com.shapeshed.aerial.data.StationDatabase/15.json
+++ b/app/schemas/com.shapeshed.aerial.data.StationDatabase/15.json
@@ -1,0 +1,174 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 15,
+    "identityHash": "e6728ded7f03b641167c92c574859db3",
+    "entities": [
+      {
+        "tableName": "stations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `streamUrl` TEXT NOT NULL, `logoPath` TEXT NOT NULL, `isFavorite` INTEGER NOT NULL, `provider` TEXT NOT NULL, `providerId` TEXT NOT NULL, `tags` TEXT NOT NULL, `description` TEXT NOT NULL, `country` TEXT NOT NULL, `countryCode` TEXT NOT NULL, `playCount` INTEGER NOT NULL, `lastPlayedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoPath",
+            "columnName": "logoPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerId",
+            "columnName": "providerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countryCode",
+            "columnName": "countryCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "playCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "lastPlayedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stations_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, `streamUrl` TEXT NOT NULL, `provider` TEXT NOT NULL, `providerId` TEXT NOT NULL, `tags` TEXT NOT NULL, `description` TEXT NOT NULL, `country` TEXT NOT NULL, tokenize=unicode61 `remove_diacritics=1`, content=`stations`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerId",
+            "columnName": "providerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [
+            "remove_diacritics=1"
+          ],
+          "contentTable": "stations",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_BEFORE_UPDATE BEFORE UPDATE ON `stations` BEGIN DELETE FROM `stations_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_BEFORE_DELETE BEFORE DELETE ON `stations` BEGIN DELETE FROM `stations_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_AFTER_UPDATE AFTER UPDATE ON `stations` BEGIN INSERT INTO `stations_fts`(`docid`, `name`, `streamUrl`, `provider`, `providerId`, `tags`, `description`, `country`) VALUES (NEW.`rowid`, NEW.`name`, NEW.`streamUrl`, NEW.`provider`, NEW.`providerId`, NEW.`tags`, NEW.`description`, NEW.`country`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_AFTER_INSERT AFTER INSERT ON `stations` BEGIN INSERT INTO `stations_fts`(`docid`, `name`, `streamUrl`, `provider`, `providerId`, `tags`, `description`, `country`) VALUES (NEW.`rowid`, NEW.`name`, NEW.`streamUrl`, NEW.`provider`, NEW.`providerId`, NEW.`tags`, NEW.`description`, NEW.`country`); END"
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e6728ded7f03b641167c92c574859db3')"
+    ]
+  }
+}

--- a/app/src/main/java/com/shapeshed/aerial/data/Station.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/Station.kt
@@ -16,4 +16,6 @@ data class Station(
     val description: String = "",
     val country: String = "",
     val countryCode: String = "",
+    val playCount: Int = 0,
+    val lastPlayedAt: Long = 0,
 )

--- a/app/src/main/java/com/shapeshed/aerial/data/StationDao.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/StationDao.kt
@@ -31,6 +31,9 @@ interface StationDao {
     @Query("UPDATE stations SET streamUrl = :streamUrl WHERE provider = :provider AND providerId = :providerId AND streamUrl != :streamUrl")
     suspend fun updateStreamUrlByProviderId(provider: String, providerId: String, streamUrl: String)
 
+    @Query("UPDATE stations SET playCount = playCount + 1, lastPlayedAt = :playedAt WHERE id = :id")
+    suspend fun recordPlay(id: Long, playedAt: Long)
+
     @Insert
     suspend fun insert(station: Station): Long
 

--- a/app/src/main/java/com/shapeshed/aerial/data/StationDatabase.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/StationDatabase.kt
@@ -9,7 +9,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [Station::class, StationFts::class],
-    version = 14,
+    version = 15,
     exportSchema = true,
 )
 abstract class StationDatabase : RoomDatabase() {
@@ -33,6 +33,7 @@ abstract class StationDatabase : RoomDatabase() {
                         MIGRATION_11_12,
                         MIGRATION_12_13,
                         MIGRATION_13_14,
+                        MIGRATION_14_15,
                     )
                     .fallbackToDestructiveMigration(dropAllTables = true)
                     .build()
@@ -174,6 +175,13 @@ abstract class StationDatabase : RoomDatabase() {
             override fun migrate(db: SupportSQLiteDatabase) {
                 dropRegistryFts(db)
                 db.execSQL("DROP TABLE IF EXISTS `registry_stations`")
+            }
+        }
+
+        private val MIGRATION_14_15 = object : Migration(14, 15) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `stations` ADD COLUMN `playCount` INTEGER NOT NULL DEFAULT 0")
+                db.execSQL("ALTER TABLE `stations` ADD COLUMN `lastPlayedAt` INTEGER NOT NULL DEFAULT 0")
             }
         }
 

--- a/app/src/main/java/com/shapeshed/aerial/data/StationRepository.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/StationRepository.kt
@@ -38,7 +38,15 @@ class StationRepository(private val dao: StationDao) {
         if (existing == null) {
             dao.insert(station.copy(id = 0))
         } else {
-            dao.update(station.copy(id = existing.id))
+            // Merge play stats rather than overwrite: a restored backup may be older than
+            // the local row, and importing must never regress listening history.
+            dao.update(
+                station.copy(
+                    id = existing.id,
+                    playCount = maxOf(existing.playCount, station.playCount),
+                    lastPlayedAt = maxOf(existing.lastPlayedAt, station.lastPlayedAt),
+                ),
+            )
         }
     }
 

--- a/app/src/main/java/com/shapeshed/aerial/data/StationRepository.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/StationRepository.kt
@@ -13,6 +13,7 @@ class StationRepository(private val dao: StationDao) {
     suspend fun insert(station: Station): Long = dao.insert(station)
     suspend fun update(station: Station) = dao.update(station)
     suspend fun delete(station: Station) = dao.delete(station)
+    suspend fun recordPlay(id: Long, playedAt: Long) = dao.recordPlay(id, playedAt)
 
     suspend fun insertOrGetExisting(station: Station): Long {
         val existing = findExisting(station)

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -41,6 +42,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.Article
+import androidx.compose.material.icons.automirrored.rounded.Sort
 import androidx.compose.material.icons.automirrored.rounded.ViewList
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Check
@@ -104,6 +106,7 @@ import androidx.compose.material3.ButtonGroupDefaults
 import androidx.compose.material3.ExpandedFullScreenContainedSearchBar
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ShortNavigationBar
@@ -138,6 +141,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.traversalIndex
@@ -252,6 +256,7 @@ fun MainScreen(
     val featuredStations by viewModel.featuredStations.collectAsStateWithLifecycle()
     val defaultStations by viewModel.defaultStations.collectAsStateWithLifecycle()
     val homeViewMode by viewModel.homeViewMode.collectAsStateWithLifecycle()
+    val favoritesSort by viewModel.favoritesSort.collectAsStateWithLifecycle()
     val showStreamBitrate by viewModel.showStreamBitrate.collectAsStateWithLifecycle()
     val selectedCountries: Set<String> by viewModel.selectedCountries.collectAsStateWithLifecycle()
     val selectedTags: Set<String> by viewModel.selectedTags.collectAsStateWithLifecycle()
@@ -432,10 +437,12 @@ fun MainScreen(
                         isPlaying = isPlaying,
                         isBuffering = isBuffering,
                         homeViewMode = homeViewMode,
+                        favoritesSort = favoritesSort,
                         listState = favoritesListState,
                         bottomPadding = stationContentBottomPadding,
                         onPlay = { viewModel.play(it) },
                         onHomeViewModeChange = { viewModel.setHomeViewMode(it) },
+                        onSortSelected = { viewModel.setFavoritesSort(it) },
                         onAddTapped = ::openRegistrySearch,
                         onStationLongPress = { contextStation = it },
                     )
@@ -1200,6 +1207,15 @@ private fun HomeTabContent(
 }
 
 @Composable
+private fun favoritesSortLabel(sort: FavoritesSort): String = stringResource(
+    when (sort) {
+        FavoritesSort.AZ -> R.string.sort_az
+        FavoritesSort.LAST_PLAYED -> R.string.sort_last_played
+        FavoritesSort.MOST_PLAYED -> R.string.sort_most_played
+    },
+)
+
+@Composable
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 private fun FavoritesTabContent(
     stations: List<Station>,
@@ -1207,10 +1223,12 @@ private fun FavoritesTabContent(
     isPlaying: Boolean,
     isBuffering: Boolean,
     homeViewMode: HomeViewMode,
+    favoritesSort: FavoritesSort,
     listState: LazyListState,
     bottomPadding: androidx.compose.ui.unit.Dp,
     onPlay: (Station) -> Unit,
     onHomeViewModeChange: (HomeViewMode) -> Unit,
+    onSortSelected: (FavoritesSort) -> Unit,
     onAddTapped: () -> Unit,
     onStationLongPress: (Station) -> Unit,
 ) {
@@ -1221,6 +1239,18 @@ private fun FavoritesTabContent(
     val showFavoriteActivityIndicators by remember {
         derivedStateOf { !listState.isScrollInProgress }
     }
+    var showSortSheet by remember { mutableStateOf(false) }
+
+    if (showSortSheet) {
+        FavoritesSortSheet(
+            current = favoritesSort,
+            onSelect = { sort ->
+                onSortSelected(sort)
+                showSortSheet = false
+            },
+            onDismiss = { showSortSheet = false },
+        )
+    }
 
     LazyColumn(
         state = listState,
@@ -1228,14 +1258,23 @@ private fun FavoritesTabContent(
     ) {
         item("favorites-header") {
             // No headline — the Favourites tab already names the screen (Material tabs
-            // convention); only the view-mode toggle remains.
+            // convention); just the sort selector and the view-mode toggle.
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.End,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(start = 20.dp, end = 16.dp, top = 8.dp, bottom = 8.dp),
+                    .padding(start = 8.dp, end = 16.dp, top = 8.dp, bottom = 8.dp),
             ) {
+                TextButton(onClick = { showSortSheet = true }) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Rounded.Sort,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(favoritesSortLabel(favoritesSort))
+                }
+                Spacer(modifier = Modifier.weight(1f))
                 HomeViewModeToggle(
                     selected = homeViewMode,
                     onSelected = onHomeViewModeChange,
@@ -1288,6 +1327,53 @@ private fun FavoritesTabContent(
                 )
             }
         }
+    }
+}
+
+// Single-select sort picker in a modal bottom sheet — the Material 3 pattern used by
+// Google apps (list of radio rows under a small title).
+@Composable
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+private fun FavoritesSortSheet(
+    current: FavoritesSort,
+    onSelect: (FavoritesSort) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        ),
+        dragHandle = { BottomSheetDefaults.DragHandle() },
+    ) {
+        Text(
+            text = stringResource(R.string.sort_by),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+        )
+        FavoritesSort.entries.forEach { sort ->
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .selectable(
+                        selected = current == sort,
+                        role = Role.RadioButton,
+                        onClick = { onSelect(sort) },
+                    )
+                    .padding(horizontal = 24.dp, vertical = 14.dp),
+            ) {
+                RadioButton(selected = current == sort, onClick = null)
+                Text(
+                    text = favoritesSortLabel(sort),
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(start = 16.dp),
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(24.dp))
     }
 }
 

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -73,6 +73,13 @@ private val SEARCH_TAGS_KEY = stringPreferencesKey("search_tags")
 private val LAST_PLAYED_STATION_KEY = stringPreferencesKey("last_played_station")
 private val HOME_CARDS_VIEW_KEY = booleanPreferencesKey("home_cards_view")
 private val LAST_HOME_TAB_KEY = intPreferencesKey("last_home_tab")
+private val FAVORITES_SORT_KEY = stringPreferencesKey("favorites_sort")
+
+enum class FavoritesSort {
+    AZ,
+    LAST_PLAYED,
+    MOST_PLAYED,
+}
 private const val MAX_RECENT_SEARCHES = 5
 
 private data class LastPlayedStationSnapshot(
@@ -127,15 +134,38 @@ class MainViewModel(
             _selectedTags.value = prefs[SEARCH_TAGS_KEY]
                 ?.split(",")?.filter { it.isNotBlank() }?.toSet() ?: emptySet()
             _selectedHomeTab.value = prefs[LAST_HOME_TAB_KEY] ?: 0
+            _favoritesSort.value = prefs[FAVORITES_SORT_KEY]
+                ?.let { saved -> FavoritesSort.entries.firstOrNull { it.name == saved } }
+                ?: FavoritesSort.AZ
         }
     }
 
     private val _allStations: StateFlow<List<Station>> = repository.getAll()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
-    val stations: StateFlow<List<Station>> = _allStations
-        .map { list -> list.sortedWith(compareBy { stationSortKey(it.name) }) }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+    // Sort order for the Favourites tab. Updated synchronously so the list reorders
+    // immediately; the DataStore write catches up in the background.
+    private val _favoritesSort = MutableStateFlow(FavoritesSort.AZ)
+    val favoritesSort: StateFlow<FavoritesSort> = _favoritesSort.asStateFlow()
+
+    fun setFavoritesSort(sort: FavoritesSort) {
+        _favoritesSort.value = sort
+        viewModelScope.launch {
+            dataStore.edit { prefs -> prefs[FAVORITES_SORT_KEY] = sort.name }
+        }
+    }
+
+    val stations: StateFlow<List<Station>> = combine(_allStations, _favoritesSort) { list, sort ->
+        when (sort) {
+            FavoritesSort.AZ -> list.sortedWith(compareBy { stationSortKey(it.name) })
+            FavoritesSort.LAST_PLAYED -> list.sortedWith(
+                compareByDescending<Station> { it.lastPlayedAt }.thenBy { stationSortKey(it.name) },
+            )
+            FavoritesSort.MOST_PLAYED -> list.sortedWith(
+                compareByDescending<Station> { it.playCount }.thenBy { stationSortKey(it.name) },
+            )
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     private val appIconArtwork: ByteArray? by lazy { appIconBitmap(getApplication()) }
 
@@ -587,6 +617,9 @@ class MainViewModel(
         } else {
             _ephemeralStation.value = null
             _currentStationId.value = station.id
+            viewModelScope.launch {
+                repository.recordPlay(station.id, System.currentTimeMillis())
+            }
         }
         _currentTrackTitle.value = null
         _currentTrackArtist.value = null

--- a/app/src/main/java/com/shapeshed/aerial/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/SettingsViewModel.kt
@@ -115,6 +115,8 @@ class SettingsViewModel(
                     .put("description", station.description)
                     .put("country", station.country)
                     .put("countryCode", station.countryCode)
+                    .put("playCount", station.playCount)
+                    .put("lastPlayedAt", station.lastPlayedAt)
 
                 val logoFile = station.logoPath
                     .takeIf { it.isNotBlank() && !it.startsWith("http") }
@@ -200,6 +202,9 @@ class SettingsViewModel(
                     description = item.optString("description").trim(),
                     country = item.optString("country").trim(),
                     countryCode = item.optString("countryCode").trim(),
+                    // Absent in version-1 backups written before play tracking; defaults to 0.
+                    playCount = item.optInt("playCount"),
+                    lastPlayedAt = item.optLong("lastPlayedAt"),
                 )
             )
         }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -95,4 +95,8 @@
     <string name="tag_electronic">Elektronisch</string>
     <string name="tab_home">Start</string>
     <string name="tab_favorites">Favoriten</string>
+    <string name="sort_by">Sortieren nach</string>
+    <string name="sort_az">A bis Z</string>
+    <string name="sort_last_played">Zuletzt gespielt</string>
+    <string name="sort_most_played">Am häufigsten gespielt</string>
 </resources>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -11,4 +11,8 @@
     <string name="search_stations_header">Stations</string>
     <string name="tab_home">Home</string>
     <string name="tab_favorites">Favourites</string>
+    <string name="sort_by">Sort by</string>
+    <string name="sort_az">A to Z</string>
+    <string name="sort_last_played">Last played</string>
+    <string name="sort_most_played">Most played</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -95,4 +95,8 @@
     <string name="tag_electronic">Electrónica</string>
     <string name="tab_home">Inicio</string>
     <string name="tab_favorites">Favoritos</string>
+    <string name="sort_by">Ordenar por</string>
+    <string name="sort_az">De la A a la Z</string>
+    <string name="sort_last_played">Reproducida recientemente</string>
+    <string name="sort_most_played">Más reproducida</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -95,4 +95,8 @@
     <string name="tag_electronic">Électronique</string>
     <string name="tab_home">Accueil</string>
     <string name="tab_favorites">Favoris</string>
+    <string name="sort_by">Trier par</string>
+    <string name="sort_az">De A à Z</string>
+    <string name="sort_last_played">Écoutée récemment</string>
+    <string name="sort_most_played">La plus écoutée</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -95,4 +95,8 @@
     <string name="tag_electronic">Elettronica</string>
     <string name="tab_home">Home</string>
     <string name="tab_favorites">Preferiti</string>
+    <string name="sort_by">Ordina per</string>
+    <string name="sort_az">Dalla A alla Z</string>
+    <string name="sort_last_played">Riprodotta di recente</string>
+    <string name="sort_most_played">Più riprodotta</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -95,4 +95,8 @@
     <string name="tag_electronic">エレクトロニック</string>
     <string name="tab_home">ホーム</string>
     <string name="tab_favorites">お気に入り</string>
+    <string name="sort_by">並べ替え</string>
+    <string name="sort_az">A〜Z順</string>
+    <string name="sort_last_played">最近再生した順</string>
+    <string name="sort_most_played">再生回数順</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -95,4 +95,8 @@
     <string name="tag_electronic">일렉트로닉</string>
     <string name="tab_home">홈</string>
     <string name="tab_favorites">즐겨찾기</string>
+    <string name="sort_by">정렬 기준</string>
+    <string name="sort_az">가나다순</string>
+    <string name="sort_last_played">최근 재생순</string>
+    <string name="sort_most_played">재생 횟수순</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -95,4 +95,8 @@
     <string name="tag_electronic">Elektronisch</string>
     <string name="tab_home">Home</string>
     <string name="tab_favorites">Favorieten</string>
+    <string name="sort_by">Sorteren op</string>
+    <string name="sort_az">A tot Z</string>
+    <string name="sort_last_played">Laatst afgespeeld</string>
+    <string name="sort_most_played">Meest afgespeeld</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -95,4 +95,8 @@
     <string name="tag_electronic">Eletrônica</string>
     <string name="tab_home">Início</string>
     <string name="tab_favorites">Favoritos</string>
+    <string name="sort_by">Ordenar por</string>
+    <string name="sort_az">De A a Z</string>
+    <string name="sort_last_played">Reproduzida recentemente</string>
+    <string name="sort_most_played">Mais reproduzida</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -95,4 +95,8 @@
     <string name="tag_electronic">电子</string>
     <string name="tab_home">首页</string>
     <string name="tab_favorites">收藏</string>
+    <string name="sort_by">排序方式</string>
+    <string name="sort_az">按字母顺序</string>
+    <string name="sort_last_played">最近播放</string>
+    <string name="sort_most_played">播放最多</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,4 +99,8 @@
     <string name="sleep_preset_hours_minutes">%1$dh %2$dm</string>
     <string name="tab_home">Home</string>
     <string name="tab_favorites">Favorites</string>
+    <string name="sort_by">Sort by</string>
+    <string name="sort_az">A to Z</string>
+    <string name="sort_last_played">Last played</string>
+    <string name="sort_most_played">Most played</string>
 </resources>

--- a/app/src/test/java/com/shapeshed/aerial/data/StationRepositoryTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/data/StationRepositoryTest.kt
@@ -168,6 +168,29 @@ class StationRepositoryTest {
     }
 
     @Test
+    fun upsertImportedKeepsNewerLocalPlayStats() = runBlocking {
+        val existing = station(id = 6L, playCount = 12, lastPlayedAt = 2_000L)
+        val dao = FakeStationDao(existing)
+        val repository = StationRepository(dao)
+
+        repository.upsertImported(station(playCount = 3, lastPlayedAt = 1_000L))
+
+        assertEquals(12, dao.stations.single().playCount)
+        assertEquals(2_000L, dao.stations.single().lastPlayedAt)
+    }
+
+    @Test
+    fun upsertImportedRestoresPlayStatsOntoFreshInstall() = runBlocking {
+        val dao = FakeStationDao()
+        val repository = StationRepository(dao)
+
+        repository.upsertImported(station(playCount = 7, lastPlayedAt = 3_000L))
+
+        assertEquals(7, dao.stations.single().playCount)
+        assertEquals(3_000L, dao.stations.single().lastPlayedAt)
+    }
+
+    @Test
     fun searchFavoritesIncludesSavedStationsImportedWithoutFavoriteFlag() = runBlocking {
         val dao = FakeStationDao(
             station(id = 2L, name = "dublab", isFavorite = false),
@@ -209,6 +232,8 @@ class StationRepositoryTest {
         description: String = "",
         country: String = "",
         countryCode: String = "",
+        playCount: Int = 0,
+        lastPlayedAt: Long = 0,
     ) = Station(
         id = id,
         name = name,
@@ -221,6 +246,8 @@ class StationRepositoryTest {
         description = description,
         country = country,
         countryCode = countryCode,
+        playCount = playCount,
+        lastPlayedAt = lastPlayedAt,
     )
 
     private class FakeStationDao(vararg initialStations: Station) : StationDao {

--- a/app/src/test/java/com/shapeshed/aerial/data/StationRepositoryTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/data/StationRepositoryTest.kt
@@ -265,6 +265,12 @@ class StationRepositoryTest {
             }
         }
 
+        override suspend fun recordPlay(id: Long, playedAt: Long) {
+            stations.replaceAll {
+                if (it.id == id) it.copy(playCount = it.playCount + 1, lastPlayedAt = playedAt) else it
+            }
+        }
+
         override suspend fun insert(station: Station): Long {
             insertCount += 1
             val id = station.id.takeIf { it != 0L } ?: nextId++


### PR DESCRIPTION
## Summary

Adds a sort selector to the Favourites tab.

- **Sort options**: A to Z (default), Last played, Most played
- **Picker**: sort button in the favourites header opens a Material 3 modal bottom sheet with radio options — the single-select pattern Google's M3 apps (Drive, Files) use for sort on Android
- **Play stats**: new `playCount` and `lastPlayedAt` columns on `stations` (migration 14→15, additive), incremented when a saved station starts playing
- **Persistence**: the chosen sort is stored in DataStore and restored on relaunch
- Ties within equal play stats fall back to the name sort; labels localised for all 11 locales

## Testing

- Unit tests pass (fake DAO extended with `recordPlay`)
- Manually verified on device: sort button and sheet render correctly, selection applies immediately and persists across cold restarts; migration ran against an existing v14 database without data loss