### PR TITLE
feat(home): curated moods, For you by country, and station artwork plates

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/AerialApp.kt
+++ b/app/src/main/java/com/shapeshed/aerial/AerialApp.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.shapeshed.aerial.data.BauerProvider
 import com.shapeshed.aerial.data.BbcProvider
@@ -29,6 +30,9 @@ import okhttp3.OkHttpClient
 val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
 val ENRICH_METADATA_KEY = booleanPreferencesKey("enrich_metadata")
 val SHOW_STREAM_BITRATE_KEY = booleanPreferencesKey("show_stream_bitrate")
+val FAVORITES_GRID_COLUMNS_KEY = intPreferencesKey("favorites_grid_columns")
+const val FAVORITES_GRID_COLUMNS_DEFAULT = 3
+val FAVORITES_GRID_COLUMNS_RANGE = 2..5
 
 class AerialApp : Application(), SingletonImageLoader.Factory {
     val okHttpClient: OkHttpClient = OkHttpClient.Builder()

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryDao.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryDao.kt
@@ -24,6 +24,9 @@ abstract class RegistryDao {
     @Query("SELECT * FROM registry_stations WHERE LOWER(tags) LIKE '%' || LOWER(:tag) || '%' ORDER BY RANDOM() LIMIT 1")
     abstract suspend fun randomStationByTag(tag: String): RegistryStation?
 
+    @Query("SELECT * FROM registry_stations WHERE LOWER(countryCode) = LOWER(:countryCode) AND logoUrl != '' ORDER BY RANDOM() LIMIT :limit")
+    abstract suspend fun randomByCountryWithLogo(countryCode: String, limit: Int): List<RegistryStation>
+
     @Query("SELECT * FROM registry_stations WHERE providerId IN (:ids)")
     abstract suspend fun getByProviderIds(ids: List<String>): List<RegistryStation>
 

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryDao.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryDao.kt
@@ -27,6 +27,9 @@ abstract class RegistryDao {
     @Query("SELECT * FROM registry_stations WHERE providerId IN (:ids)")
     abstract suspend fun getByProviderIds(ids: List<String>): List<RegistryStation>
 
+    @Query("SELECT * FROM registry_stations WHERE name IN (:names)")
+    abstract suspend fun getByNames(names: List<String>): List<RegistryStation>
+
     @Query("SELECT DISTINCT countryCode FROM registry_stations WHERE countryCode != '' ORDER BY countryCode")
     abstract suspend fun distinctCountryCodes(): List<String>
 

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
@@ -14,6 +14,8 @@ private val FEATURED_STATIONS = listOf(
     FeaturedStation("bauer", "ki1"),             // KISS
 )
 
+private const val FOR_YOU_RANDOM_COUNT = 10
+
 private val UK_FOR_YOU_STATIONS = listOf(
     MoodStationRef("Smooth Radio"),
     MoodStationRef("Heart 80s", "global"),
@@ -121,6 +123,8 @@ class RegistryRepository(private val dao: RegistryDao) {
 
     fun countAsFlow(): Flow<Int> = dao.countAsFlow()
 
+    suspend fun count(): Int = dao.count()
+
     suspend fun isEmpty(): Boolean = dao.count() == 0
 
     suspend fun randomByCategory(tag: String): RegistryStation? = dao.randomStationByTag(tag)
@@ -185,10 +189,16 @@ class RegistryRepository(private val dao: RegistryDao) {
     suspend fun forYouStations(countryCode: String): List<RegistryStation> {
         val refs = when (countryCode.uppercase()) {
             "GB", "UK" -> UK_FOR_YOU_STATIONS
-            else -> return emptyList()
+            else -> emptyList()
         }
-        val candidates = dao.getByNames(refs.map { it.name })
-        return refs.mapNotNull { resolveMoodStation(it, candidates) }
+        if (refs.isNotEmpty()) {
+            val candidates = dao.getByNames(refs.map { it.name })
+            val curated = refs.mapNotNull { resolveMoodStation(it, candidates) }
+            if (curated.isNotEmpty()) return curated
+        }
+        // No curated selection for this country: a random sample of its stations that
+        // have artwork, so the row still feels local.
+        return dao.randomByCountryWithLogo(countryCode, FOR_YOU_RANDOM_COUNT)
     }
 
     suspend fun curatedMoodStations(): Map<String, List<RegistryStation>> {

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
@@ -14,8 +14,98 @@ private val FEATURED_STATIONS = listOf(
     FeaturedStation("bauer", "ki1"),             // KISS
 )
 
+private val UK_FOR_YOU_STATIONS = listOf(
+    MoodStationRef("Smooth Radio"),
+    MoodStationRef("Heart 80s", "global"),
+    MoodStationRef("Heart UK", "global"),
+    MoodStationRef("Capital FM"),
+    MoodStationRef("Heart"),
+    MoodStationRef("Greatest Hits Radio", "bauer"),
+    MoodStationRef("BBC Radio 2", "bbc"),
+    MoodStationRef("KISS", "bauer"),
+    MoodStationRef("Absolute 80s", "bauer"),
+    MoodStationRef("BBC Radio 1", "bbc"),
+)
+
 private val CURATED_TAG_ORDER = listOf(
     "News", "Sport", "Pop", "Rock", "Jazz", "Classical", "Dance", "Soul", "Country", "Electronic"
+)
+
+private data class MoodStationRef(val name: String, val provider: String? = null)
+
+private val CURATED_MOOD_STATIONS = mapOf(
+    "relax" to listOf(
+        MoodStationRef("Café del Mar"),
+        MoodStationRef("Radio Paradise Mellow Mix", "curated"),
+        MoodStationRef("Soma FM Groove Salad", "curated"),
+        MoodStationRef("FIP", "curated"),
+        MoodStationRef("Bossa Jazz Brasil", "curated"),
+        MoodStationRef("Radio Schizoid - Chillout / Ambient"),
+        MoodStationRef("Jazz Sakura (asia dream radio)"),
+        MoodStationRef("KLCBS Tropical"),
+        MoodStationRef("Radio Samui Online"),
+        MoodStationRef("Cape Town Classic"),
+    ),
+    "focus" to listOf(
+        MoodStationRef("BBC Radio 3 Unwind", "bbc"),
+        MoodStationRef("Classic FM Calm", "global"),
+        MoodStationRef("Radio Schizoid - Chillout / Ambient"),
+        MoodStationRef("Ottava", "curated"),
+        MoodStationRef("KBS Classic FM"),
+        MoodStationRef("Radio Swiss Classic", "curated"),
+        MoodStationRef("MDR KLASSIK Livestream", "ard"),
+        MoodStationRef("Ambient Sleeping Pill"),
+        MoodStationRef("SomaFM Drone Zone"),
+        MoodStationRef("WDR 3 Klassik", "ard"),
+    ),
+    "morning" to listOf(
+        MoodStationRef("BBC Radio 6 Music", "bbc"),
+        MoodStationRef("KEXP 90.3 Seattle", "curated"),
+        MoodStationRef("FIP", "curated"),
+        MoodStationRef("Radio Nova", "curated"),
+        MoodStationRef("Antena 1 FM 94.7 São Paulo", "curated"),
+        MoodStationRef("Shonan Beach FM 78.9", "curated"),
+        MoodStationRef("Cool Fahrenheit", "curated"),
+        MoodStationRef("ABC Jazz", "abc"),
+        MoodStationRef("Worldwide FM"),
+        MoodStationRef("1LIVE", "ard"),
+    ),
+    "driving" to listOf(
+        MoodStationRef("Radio Paradise Main Mix", "curated"),
+        MoodStationRef("BBC Radio 6 Music", "bbc"),
+        MoodStationRef("KEXP 90.3 Seattle", "curated"),
+        MoodStationRef("NTS Radio 1", "curated"),
+        MoodStationRef("Radio Nova", "curated"),
+        MoodStationRef("Triple J", "abc"),
+        MoodStationRef("Rinse FM", "rinse"),
+        MoodStationRef("KISS", "bauer"),
+        MoodStationRef("1LIVE", "ard"),
+        MoodStationRef("FIP", "curated"),
+    ),
+    "late_night" to listOf(
+        MoodStationRef("NTS Radio 2", "curated"),
+        MoodStationRef("SomaFM Drone Zone"),
+        MoodStationRef("Nightwave Plaza", "curated"),
+        MoodStationRef("Colombia Lounge"),
+        MoodStationRef("Radio Schizoid - Chillout / Ambient"),
+        MoodStationRef("Ambient Sleeping Pill"),
+        MoodStationRef("FIP Jazz"),
+        MoodStationRef("KLCBS New Age"),
+        MoodStationRef("BBC Radio 3 Unwind", "bbc"),
+        MoodStationRef("Radio Samui Online"),
+    ),
+    "workout" to listOf(
+        MoodStationRef("BBC Radio 1 Dance", "bbc"),
+        MoodStationRef("Capital Dance", "global"),
+        MoodStationRef("Rinse FM", "rinse"),
+        MoodStationRef("FIP Electro"),
+        MoodStationRef("1LIVE DIGGI", "ard"),
+        MoodStationRef("98.8 Kiss FM Clubsets", "curated"),
+        MoodStationRef("Allzic Radio Dance Floor", "curated"),
+        MoodStationRef("Bollywood Dance"),
+        MoodStationRef("CLUB DANCE CHILE"),
+        MoodStationRef("ABC Dance"),
+    ),
 )
 
 // Turn a normalised query into an FTS4 MATCH expression: split into tokens (which also drops FTS
@@ -91,6 +181,34 @@ class RegistryRepository(private val dao: RegistryDao) {
             all.find { it.provider == featured.provider && it.providerId == featured.providerId }
         }
     }
+
+    suspend fun forYouStations(countryCode: String): List<RegistryStation> {
+        val refs = when (countryCode.uppercase()) {
+            "GB", "UK" -> UK_FOR_YOU_STATIONS
+            else -> return emptyList()
+        }
+        val candidates = dao.getByNames(refs.map { it.name })
+        return refs.mapNotNull { resolveMoodStation(it, candidates) }
+    }
+
+    suspend fun curatedMoodStations(): Map<String, List<RegistryStation>> {
+        val allRefs = CURATED_MOOD_STATIONS.values.flatten()
+        val candidates = dao.getByNames(allRefs.map { it.name }.distinct())
+        return CURATED_MOOD_STATIONS.mapValues { (_, refs) ->
+            refs.mapNotNull { target ->
+                resolveMoodStation(target, candidates)
+            }
+        }
+    }
+
+    private fun resolveMoodStation(
+        target: MoodStationRef,
+        candidates: List<RegistryStation>,
+    ): RegistryStation? =
+        target.provider
+            ?.let { provider -> candidates.firstOrNull { it.name == target.name && it.provider == provider } }
+            ?: candidates.firstOrNull { it.name == target.name && it.provider == "curated" }
+            ?: candidates.firstOrNull { it.name == target.name }
 
     // A-Z subsection shown as browse suggestions before the user has typed anything.
     // Capped to match the search query limit.

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
@@ -123,8 +123,6 @@ class RegistryRepository(private val dao: RegistryDao) {
 
     fun countAsFlow(): Flow<Int> = dao.countAsFlow()
 
-    suspend fun count(): Int = dao.count()
-
     suspend fun isEmpty(): Boolean = dao.count() == 0
 
     suspend fun randomByCategory(tag: String): RegistryStation? = dao.randomStationByTag(tag)

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -138,6 +138,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
@@ -158,7 +159,9 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -355,11 +358,12 @@ fun MainScreen(
     val recentSearches by viewModel.recentSearches.collectAsStateWithLifecycle()
     val allTags by viewModel.allTags.collectAsStateWithLifecycle()
     val featuredStations by viewModel.featuredStations.collectAsStateWithLifecycle()
-    val ukForYouStations by viewModel.ukForYouStations.collectAsStateWithLifecycle()
+    val forYouStations by viewModel.forYouStations.collectAsStateWithLifecycle()
     val defaultStations by viewModel.defaultStations.collectAsStateWithLifecycle()
     val curatedMoodStations by viewModel.curatedMoodStations.collectAsStateWithLifecycle()
     val homeViewMode by viewModel.homeViewMode.collectAsStateWithLifecycle()
     val favoritesSort by viewModel.favoritesSort.collectAsStateWithLifecycle()
+    val favoritesGridColumns by viewModel.favoritesGridColumns.collectAsStateWithLifecycle()
     val showStreamBitrate by viewModel.showStreamBitrate.collectAsStateWithLifecycle()
     val selectedCountries: Set<String> by viewModel.selectedCountries.collectAsStateWithLifecycle()
     val selectedTags: Set<String> by viewModel.selectedTags.collectAsStateWithLifecycle()
@@ -565,19 +569,25 @@ fun MainScreen(
                         onPlayStation = { viewModel.playFromRegistry(it) },
                     )
                 } else if (selectedTab == TAB_HOME) {
+                    // The For You row is the locale country's selection (curated or a random
+                    // sample with artwork), headed by the country name; if the registry has
+                    // nothing for that country it falls back to the featured stations under
+                    // a plain "For you" header.
                     val forYouCountryCode = appLocale.country.takeIf { it.isNotBlank() } ?: "GB"
+                    LaunchedEffect(forYouCountryCode) { viewModel.setForYouCountry(forYouCountryCode) }
+                    val hasCountrySelection = forYouStations.isNotEmpty()
                     HomeTabContent(
                         allTags = allTags,
-                        featuredStations = featuredStations,
-                        forYouStations = ukForYouStations.takeIf { forYouCountryCode.equals("GB", ignoreCase = true) }
-                            ?: featuredStations,
-                        forYouCountry = countryName(forYouCountryCode, appLocale),
+                        forYouStations = forYouStations.ifEmpty { featuredStations },
+                        forYouCountry = countryName(forYouCountryCode, appLocale).takeIf { hasCountrySelection },
                         listState = homeListState,
                         bottomPadding = stationContentBottomPadding,
                         onCategoryTap = { viewModel.playRandomFromCategory(it) },
                         onMoodTap = { selectedMoodId = it.id },
                         onFeaturedStationTap = { viewModel.playFromRegistry(it) },
-                        onForYouViewAll = { openCountrySearch(forYouCountryCode) },
+                        onForYouViewAll = {
+                            if (hasCountrySelection) openCountrySearch(forYouCountryCode) else openRegistrySearch()
+                        },
                     )
                 } else {
                     FavoritesTabContent(
@@ -587,6 +597,7 @@ fun MainScreen(
                         isBuffering = isBuffering,
                         homeViewMode = homeViewMode,
                         favoritesSort = favoritesSort,
+                        gridColumns = favoritesGridColumns,
                         listState = favoritesListState,
                         bottomPadding = stationContentBottomPadding,
                         onPlay = { viewModel.play(it) },
@@ -1417,9 +1428,9 @@ private fun HomeEmptyState(
 @Composable
 private fun HomeTabContent(
     allTags: List<String>,
-    featuredStations: List<com.shapeshed.aerial.data.RegistryStation>,
     forYouStations: List<com.shapeshed.aerial.data.RegistryStation>,
-    forYouCountry: String,
+    // Null when the selection isn't country-specific; the header drops the country.
+    forYouCountry: String?,
     listState: LazyListState,
     bottomPadding: androidx.compose.ui.unit.Dp,
     onCategoryTap: (String) -> Unit,
@@ -1440,17 +1451,21 @@ private fun HomeTabContent(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
-                        text = stringResource(R.string.for_you_country, forYouCountry),
+                        // The localized country name is the header; plain "For you" when
+                        // the selection isn't country-specific.
+                        text = forYouCountry ?: stringResource(R.string.for_you),
                         style = MaterialTheme.typography.headlineSmall,
                         color = MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier.weight(1f),
                     )
-                    TextButton(onClick = onForYouViewAll) {
-                        Text(text = stringResource(R.string.view_all))
+                    IconButton(
+                        onClick = onForYouViewAll,
+                        shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
+                    ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Rounded.ArrowForward,
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp),
+                            // The icon carries the action's label for screen readers.
+                            contentDescription = stringResource(R.string.view_all),
                         )
                     }
                 }
@@ -1466,30 +1481,6 @@ private fun HomeTabContent(
                         contentType = { "for-you-station" },
                     ) { station ->
                         ForYouStationCard(
-                            station = station,
-                            onClick = { onFeaturedStationTap(station) },
-                        )
-                    }
-                }
-            }
-        }
-
-        if (featuredStations.isNotEmpty()) {
-            item("get-started-header") {
-                Text(
-                    text = stringResource(R.string.get_started),
-                    style = MaterialTheme.typography.headlineSmall,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 20.dp, bottom = 12.dp),
-                )
-            }
-            item("get-started-row") {
-                LazyRow(
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    contentPadding = PaddingValues(horizontal = 16.dp),
-                ) {
-                    items(featuredStations) { station ->
-                        FeaturedStationCard(
                             station = station,
                             onClick = { onFeaturedStationTap(station) },
                         )
@@ -1566,12 +1557,10 @@ private fun MoodCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // Stock filled card (spec container colour and medium corner radius), matching the
+    // For You tiles; the artwork covers the container so only the shape shows.
     Card(
         onClick = onClick,
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-        ),
-        shape = MaterialTheme.shapes.large,
         modifier = modifier.height(132.dp),
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
@@ -1785,9 +1774,13 @@ private fun MoodStationRow(
             }
         },
         supportingContent = {
-            if (station.country.isNotBlank()) {
+            // Localized country from the ISO code, matching the search result rows.
+            val countryLabel = station.countryCode.takeIf { it.isNotBlank() }
+                ?.let { countryName(it, LocalConfiguration.current.locales[0]) }
+                ?: station.country
+            if (countryLabel.isNotBlank()) {
                 Text(
-                    text = station.country,
+                    text = countryLabel,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
@@ -1845,32 +1838,9 @@ private fun MoodArtwork(
     modifier: Modifier = Modifier,
 ) {
     val scheme = MaterialTheme.colorScheme
-    Canvas(modifier = modifier) {
-        val skyTop = when (artwork) {
-            MoodArtwork.Coast -> lerp(scheme.tertiaryContainer, scheme.primaryContainer, 0.18f)
-            MoodArtwork.Mountains -> lerp(scheme.secondaryContainer, scheme.surfaceVariant, 0.35f)
-            MoodArtwork.Sunrise -> lerp(scheme.tertiaryContainer, Color(0xFFFFC879), 0.32f)
-            MoodArtwork.Road -> lerp(scheme.primaryContainer, scheme.secondaryContainer, 0.36f)
-            MoodArtwork.City -> lerp(scheme.primary, scheme.surface, 0.64f)
-            MoodArtwork.Runner -> lerp(scheme.secondaryContainer, scheme.tertiaryContainer, 0.28f)
-        }
-        val skyBottom = when (artwork) {
-            MoodArtwork.City -> lerp(scheme.surface, scheme.primaryContainer, 0.4f)
-            else -> lerp(scheme.surface, skyTop, 0.58f)
-        }
-        drawRect(
-            brush = Brush.verticalGradient(
-                listOf(skyTop, skyBottom),
-            ),
-        )
-
-        val sunColor = scheme.tertiary.copy(alpha = 0.28f)
-        drawCircle(
-            color = sunColor,
-            radius = size.minDimension * 0.16f,
-            center = Offset(size.width * 0.72f, size.height * 0.35f),
-        )
-
+    // clipToBounds: the scenes draw glows and rotated shapes that may exceed the canvas,
+    // and not every host (e.g. the mood detail header) clips with a shape.
+    Canvas(modifier = modifier.clipToBounds()) {
         when (artwork) {
             MoodArtwork.Coast -> drawCoastMood(scheme)
             MoodArtwork.Mountains -> drawMountainMood(scheme)
@@ -1882,151 +1852,500 @@ private fun MoodArtwork(
     }
 }
 
+// The scenes below are drawn entirely from the Material colour scheme so they re-tint with
+// the wallpaper palette. Each mood owns its sky, light source, and landscape rather than
+// sharing generic layers, and every position is a fixed fraction of the canvas so the art
+// is deterministic across sizes.
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawSky(
+    top: Color,
+    mid: Color,
+    bottom: Color,
+) {
+    drawRect(brush = Brush.verticalGradient(0f to top, 0.55f to mid, 1f to bottom))
+}
+
+// A light source with a soft radial halo fading to nothing around a solid core.
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawGlow(
+    color: Color,
+    center: Offset,
+    coreRadius: Float,
+    glowRadius: Float,
+    coreAlpha: Float = 0.8f,
+    glowAlpha: Float = 0.4f,
+) {
+    drawCircle(
+        brush = Brush.radialGradient(
+            colors = listOf(color.copy(alpha = glowAlpha), color.copy(alpha = 0f)),
+            center = center,
+            radius = glowRadius,
+        ),
+        radius = glowRadius,
+        center = center,
+    )
+    drawCircle(color.copy(alpha = coreAlpha), coreRadius, center)
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawBird(
+    color: Color,
+    center: Offset,
+    span: Float,
+    strokeWidth: Float,
+) {
+    val wing = Path().apply {
+        moveTo(center.x - span, center.y)
+        quadraticTo(center.x - span * 0.5f, center.y - span * 0.7f, center.x, center.y)
+        quadraticTo(center.x + span * 0.5f, center.y - span * 0.7f, center.x + span, center.y)
+    }
+    drawPath(wing, color, style = androidx.compose.ui.graphics.drawscope.Stroke(width = strokeWidth, cap = StrokeCap.Round))
+}
+
+// Calm sea at golden hour: low sun, glitter path on the water, headlands, gulls.
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawCoastMood(
     scheme: androidx.compose.material3.ColorScheme,
 ) {
-    drawLayeredHills(
-        back = scheme.primary.copy(alpha = 0.18f),
-        front = scheme.primary.copy(alpha = 0.34f),
+    val horizon = size.height * 0.55f
+    drawSky(
+        top = lerp(scheme.tertiaryContainer, scheme.primaryContainer, 0.3f),
+        mid = lerp(scheme.tertiaryContainer, scheme.tertiary, 0.15f),
+        bottom = lerp(scheme.surface, scheme.tertiaryContainer, 0.5f),
     )
+    drawGlow(
+        color = scheme.tertiary,
+        center = Offset(size.width * 0.70f, horizon - size.height * 0.13f),
+        coreRadius = size.minDimension * 0.085f,
+        glowRadius = size.minDimension * 0.34f,
+    )
+    // Sea with depth, brightest at the horizon.
     drawRect(
-        color = scheme.primary.copy(alpha = 0.22f),
-        topLeft = Offset(0f, size.height * 0.62f),
-        size = androidx.compose.ui.geometry.Size(size.width, size.height * 0.38f),
+        brush = Brush.verticalGradient(
+            horizon / size.height to lerp(scheme.primaryContainer, scheme.tertiary, 0.25f).copy(alpha = 0.55f),
+            1f to scheme.primary.copy(alpha = 0.35f),
+        ),
+        topLeft = Offset(0f, horizon),
+        size = androidx.compose.ui.geometry.Size(size.width, size.height - horizon),
     )
-    repeat(4) { index ->
-        val y = size.height * (0.68f + index * 0.07f)
+    drawLine(
+        color = scheme.tertiaryContainer.copy(alpha = 0.6f),
+        start = Offset(0f, horizon),
+        end = Offset(size.width, horizon),
+        strokeWidth = 1.5.dp.toPx(),
+    )
+    // Sun glitter: tapering dashes down the water.
+    val glitterX = size.width * 0.70f
+    repeat(5) { index ->
+        val t = index / 4f
+        val y = horizon + size.height * (0.05f + 0.075f * index)
+        val half = size.width * (0.055f - 0.008f * index)
         drawLine(
-            color = scheme.onSurface.copy(alpha = 0.12f),
-            start = Offset(size.width * 0.18f, y),
-            end = Offset(size.width * 0.86f, y + size.height * 0.02f),
-            strokeWidth = 2.dp.toPx(),
+            color = scheme.tertiary.copy(alpha = 0.5f - 0.08f * index),
+            start = Offset(glitterX - half + size.width * 0.01f * t, y),
+            end = Offset(glitterX + half, y),
+            strokeWidth = (2.5f - 0.3f * index).dp.toPx(),
+            cap = StrokeCap.Round,
         )
     }
+    // Headland sliding in from the left.
+    val headland = Path().apply {
+        moveTo(0f, horizon)
+        cubicTo(size.width * 0.10f, horizon - size.height * 0.10f, size.width * 0.22f, horizon - size.height * 0.02f, size.width * 0.34f, horizon)
+        lineTo(0f, horizon)
+        close()
+    }
+    drawPath(headland, scheme.primary.copy(alpha = 0.45f))
+    drawBird(scheme.onSurface.copy(alpha = 0.4f), Offset(size.width * 0.30f, size.height * 0.24f), size.minDimension * 0.035f, 1.8.dp.toPx())
+    drawBird(scheme.onSurface.copy(alpha = 0.3f), Offset(size.width * 0.40f, size.height * 0.18f), size.minDimension * 0.025f, 1.5.dp.toPx())
 }
 
+// Still, hazy ranges receding into mist, with snow on the far peaks.
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawMountainMood(
     scheme: androidx.compose.material3.ColorScheme,
 ) {
-    repeat(3) { index ->
-        val top = size.height * (0.28f + index * 0.11f)
-        val alpha = 0.16f + index * 0.1f
-        val path = Path().apply {
-            moveTo(0f, size.height)
-            lineTo(size.width * 0.22f, top + size.height * 0.18f)
-            lineTo(size.width * 0.48f, top)
-            lineTo(size.width * 0.75f, top + size.height * 0.2f)
-            lineTo(size.width, top + size.height * 0.08f)
-            lineTo(size.width, size.height)
+    val skyTop = lerp(scheme.secondaryContainer, scheme.surfaceVariant, 0.35f)
+    drawSky(
+        top = skyTop,
+        mid = lerp(skyTop, scheme.surface, 0.45f),
+        bottom = lerp(scheme.surface, scheme.secondaryContainer, 0.35f),
+    )
+    drawGlow(
+        color = scheme.secondary,
+        center = Offset(size.width * 0.26f, size.height * 0.20f),
+        coreRadius = size.minDimension * 0.05f,
+        glowRadius = size.minDimension * 0.2f,
+        coreAlpha = 0.35f,
+        glowAlpha = 0.2f,
+    )
+    // Back range, faded into the sky, with snow caps.
+    val backTop = size.height * 0.34f
+    val back = Path().apply {
+        moveTo(0f, size.height * 0.62f)
+        lineTo(size.width * 0.24f, backTop)
+        lineTo(size.width * 0.42f, size.height * 0.56f)
+        lineTo(size.width * 0.62f, size.height * 0.40f)
+        lineTo(size.width * 0.80f, size.height * 0.58f)
+        lineTo(size.width, size.height * 0.48f)
+        lineTo(size.width, size.height)
+        lineTo(0f, size.height)
+        close()
+    }
+    drawPath(back, lerp(skyTop, scheme.secondary, 0.35f).copy(alpha = 0.7f))
+    // Snow caps on the two tallest back peaks.
+    listOf(
+        Offset(size.width * 0.24f, backTop) to size.width * 0.05f,
+        Offset(size.width * 0.62f, size.height * 0.40f) to size.width * 0.04f,
+    ).forEach { (peak, halfWidth) ->
+        val cap = Path().apply {
+            moveTo(peak.x - halfWidth, peak.y + halfWidth * 0.9f)
+            lineTo(peak.x, peak.y)
+            lineTo(peak.x + halfWidth, peak.y + halfWidth * 0.9f)
             close()
         }
-        drawPath(path, scheme.primary.copy(alpha = alpha))
+        drawPath(cap, lerp(scheme.surface, scheme.onSurface, 0.08f).copy(alpha = 0.75f))
     }
+    // Mist band between the ranges.
+    drawRect(
+        brush = Brush.verticalGradient(
+            0.58f to scheme.surface.copy(alpha = 0f),
+            0.68f to scheme.surface.copy(alpha = 0.35f),
+            0.78f to scheme.surface.copy(alpha = 0f),
+        ),
+    )
+    // Front ridge, strongest.
+    val front = Path().apply {
+        moveTo(0f, size.height * 0.86f)
+        lineTo(size.width * 0.20f, size.height * 0.64f)
+        lineTo(size.width * 0.40f, size.height * 0.80f)
+        lineTo(size.width * 0.58f, size.height * 0.62f)
+        lineTo(size.width * 0.78f, size.height * 0.82f)
+        lineTo(size.width, size.height * 0.70f)
+        lineTo(size.width, size.height)
+        lineTo(0f, size.height)
+        close()
+    }
+    drawPath(front, scheme.secondary.copy(alpha = 0.55f))
 }
 
+// Big sun lifting out of rolling hills, halo rings widening into the morning sky.
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawSunriseMood(
     scheme: androidx.compose.material3.ColorScheme,
 ) {
-    drawLayeredHills(
-        back = scheme.tertiary.copy(alpha = 0.18f),
-        front = scheme.primary.copy(alpha = 0.24f),
+    drawSky(
+        top = lerp(scheme.primaryContainer, scheme.surface, 0.25f),
+        mid = lerp(scheme.tertiaryContainer, scheme.tertiary, 0.2f),
+        bottom = lerp(scheme.tertiary, scheme.tertiaryContainer, 0.35f),
     )
-    drawCircle(
-        color = scheme.tertiary.copy(alpha = 0.26f),
-        radius = size.minDimension * 0.22f,
-        center = Offset(size.width * 0.78f, size.height * 0.66f),
+    val sunCenter = Offset(size.width * 0.5f, size.height * 0.60f)
+    // Halo rings around the rising sun.
+    listOf(0.30f to 0.10f, 0.42f to 0.06f).forEach { (radiusFraction, alpha) ->
+        drawCircle(
+            color = scheme.tertiary.copy(alpha = alpha),
+            radius = size.minDimension * radiusFraction,
+            center = sunCenter,
+            style = androidx.compose.ui.graphics.drawscope.Stroke(width = 2.dp.toPx()),
+        )
+    }
+    drawGlow(
+        color = scheme.tertiary,
+        center = sunCenter,
+        coreRadius = size.minDimension * 0.17f,
+        glowRadius = size.minDimension * 0.48f,
+        coreAlpha = 0.85f,
+        glowAlpha = 0.5f,
     )
+    drawBird(scheme.onSurface.copy(alpha = 0.35f), Offset(size.width * 0.76f, size.height * 0.26f), size.minDimension * 0.03f, 1.8.dp.toPx())
+    // Hills drawn after the sun so it rises from behind them.
+    val backHill = Path().apply {
+        moveTo(0f, size.height * 0.72f)
+        cubicTo(size.width * 0.25f, size.height * 0.60f, size.width * 0.45f, size.height * 0.74f, size.width * 0.68f, size.height * 0.66f)
+        cubicTo(size.width * 0.85f, size.height * 0.60f, size.width * 0.94f, size.height * 0.68f, size.width, size.height * 0.64f)
+        lineTo(size.width, size.height)
+        lineTo(0f, size.height)
+        close()
+    }
+    drawPath(backHill, lerp(scheme.tertiary, scheme.primary, 0.55f).copy(alpha = 0.5f))
+    val frontHill = Path().apply {
+        moveTo(0f, size.height * 0.88f)
+        cubicTo(size.width * 0.22f, size.height * 0.76f, size.width * 0.48f, size.height * 0.92f, size.width * 0.72f, size.height * 0.80f)
+        cubicTo(size.width * 0.88f, size.height * 0.73f, size.width * 0.96f, size.height * 0.80f, size.width, size.height * 0.78f)
+        lineTo(size.width, size.height)
+        lineTo(0f, size.height)
+        close()
+    }
+    drawPath(frontHill, scheme.primary.copy(alpha = 0.5f))
 }
 
+// Open road to a vanishing point on the horizon, driving into the light.
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawRoadMood(
     scheme: androidx.compose.material3.ColorScheme,
 ) {
-    drawLayeredHills(
-        back = scheme.secondary.copy(alpha = 0.18f),
-        front = scheme.primary.copy(alpha = 0.28f),
+    val horizon = size.height * 0.52f
+    val vanish = Offset(size.width * 0.60f, horizon)
+    drawSky(
+        top = lerp(scheme.primaryContainer, scheme.secondaryContainer, 0.4f),
+        mid = lerp(scheme.primaryContainer, scheme.tertiaryContainer, 0.45f),
+        bottom = lerp(scheme.surface, scheme.tertiaryContainer, 0.55f),
     )
-    val road = Path().apply {
-        moveTo(size.width * 0.46f, size.height)
-        lineTo(size.width * 0.58f, size.height * 0.55f)
-        lineTo(size.width * 0.68f, size.height * 0.55f)
-        lineTo(size.width * 0.86f, size.height)
+    drawGlow(
+        color = scheme.tertiary,
+        center = vanish.copy(y = horizon - size.height * 0.04f),
+        coreRadius = size.minDimension * 0.06f,
+        glowRadius = size.minDimension * 0.3f,
+        coreAlpha = 0.6f,
+    )
+    // Distant ridge on the skyline.
+    val ridge = Path().apply {
+        moveTo(0f, horizon)
+        lineTo(size.width * 0.18f, horizon - size.height * 0.07f)
+        lineTo(size.width * 0.38f, horizon - size.height * 0.015f)
+        lineTo(size.width * 0.86f, horizon - size.height * 0.09f)
+        lineTo(size.width, horizon - size.height * 0.03f)
+        lineTo(size.width, horizon)
         close()
     }
-    drawPath(road, scheme.onSurface.copy(alpha = 0.16f))
-    drawLine(
-        color = scheme.surface.copy(alpha = 0.72f),
-        start = Offset(size.width * 0.65f, size.height),
-        end = Offset(size.width * 0.62f, size.height * 0.6f),
-        strokeWidth = 2.dp.toPx(),
+    drawPath(ridge, scheme.secondary.copy(alpha = 0.35f))
+    // Ground plane.
+    drawRect(
+        brush = Brush.verticalGradient(
+            horizon / size.height to scheme.secondaryContainer.copy(alpha = 0.5f),
+            1f to scheme.secondary.copy(alpha = 0.45f),
+        ),
+        topLeft = Offset(0f, horizon),
+        size = androidx.compose.ui.geometry.Size(size.width, size.height - horizon),
     )
+    // Road converging on the vanishing point.
+    val road = Path().apply {
+        moveTo(size.width * 0.24f, size.height)
+        lineTo(vanish.x - size.width * 0.012f, vanish.y)
+        lineTo(vanish.x + size.width * 0.012f, vanish.y)
+        lineTo(size.width * 0.88f, size.height)
+        close()
+    }
+    drawPath(
+        road,
+        brush = Brush.verticalGradient(
+            horizon / size.height to scheme.onSurface.copy(alpha = 0.18f),
+            1f to scheme.onSurface.copy(alpha = 0.34f),
+        ),
+    )
+    // Centre line dashes shrinking with distance.
+    val dashes = listOf(0.97f to 0.885f, 0.83f to 0.755f, 0.71f to 0.665f, 0.62f to 0.585f)
+    dashes.forEachIndexed { index, (startT, endT) ->
+        fun along(t: Float): Offset {
+            val bottomCentre = Offset(size.width * 0.56f, size.height)
+            return Offset(
+                bottomCentre.x + (vanish.x - bottomCentre.x) * (1f - t),
+                size.height + (vanish.y - size.height) * (1f - t),
+            )
+        }
+        drawLine(
+            color = lerp(scheme.surface, scheme.tertiaryContainer, 0.4f).copy(alpha = 0.85f - 0.12f * index),
+            start = along(startT),
+            end = along(endT),
+            strokeWidth = (3.5f - 0.7f * index).dp.toPx(),
+            cap = StrokeCap.Round,
+        )
+    }
 }
 
+// Night skyline: stars, a haloed moon, two building rows, and lit windows.
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawCityMood(
     scheme: androidx.compose.material3.ColorScheme,
 ) {
-    drawRect(
-        color = scheme.primary.copy(alpha = 0.22f),
-        topLeft = Offset(0f, size.height * 0.52f),
-        size = androidx.compose.ui.geometry.Size(size.width, size.height * 0.48f),
+    drawSky(
+        top = lerp(scheme.surface, scheme.primary, 0.10f),
+        mid = lerp(scheme.surface, scheme.primary, 0.22f),
+        bottom = lerp(scheme.surface, scheme.primaryContainer, 0.5f),
     )
-    val widths = listOf(0.12f, 0.18f, 0.1f, 0.16f, 0.14f, 0.2f)
-    var x = size.width * 0.06f
-    widths.forEachIndexed { index, widthFraction ->
-        val buildingWidth = size.width * widthFraction
-        val top = size.height * (0.42f + (index % 3) * 0.08f)
-        drawRect(
-            color = scheme.onSurface.copy(alpha = 0.22f),
-            topLeft = Offset(x, top),
-            size = androidx.compose.ui.geometry.Size(buildingWidth, size.height - top),
+    // Stars: fixed constellation, brighter high up.
+    listOf(
+        Offset(0.10f, 0.14f), Offset(0.22f, 0.08f), Offset(0.33f, 0.20f), Offset(0.45f, 0.10f),
+        Offset(0.55f, 0.24f), Offset(0.63f, 0.07f), Offset(0.87f, 0.12f), Offset(0.94f, 0.26f),
+        Offset(0.16f, 0.30f), Offset(0.50f, 0.33f),
+    ).forEachIndexed { index, fraction ->
+        drawCircle(
+            color = lerp(scheme.surface, scheme.onSurface, 0.85f).copy(alpha = if (index % 3 == 0) 0.6f else 0.35f),
+            radius = (if (index % 4 == 0) 1.6f else 1.1f).dp.toPx(),
+            center = Offset(size.width * fraction.x, size.height * fraction.y),
         )
-        x += buildingWidth + size.width * 0.035f
     }
-    drawCircle(
-        color = scheme.tertiary.copy(alpha = 0.34f),
-        radius = size.minDimension * 0.08f,
-        center = Offset(size.width * 0.76f, size.height * 0.24f),
+    drawGlow(
+        color = lerp(scheme.tertiaryContainer, scheme.tertiary, 0.3f),
+        center = Offset(size.width * 0.76f, size.height * 0.20f),
+        coreRadius = size.minDimension * 0.07f,
+        glowRadius = size.minDimension * 0.22f,
+        coreAlpha = 0.9f,
+        glowAlpha = 0.3f,
+    )
+    // Back row of towers, faded into the night haze.
+    val backTowers = listOf(0.00f to 0.48f, 0.14f to 0.38f, 0.30f to 0.52f, 0.47f to 0.42f, 0.66f to 0.55f, 0.84f to 0.44f)
+    backTowers.forEach { (leftFraction, topFraction) ->
+        drawRect(
+            color = lerp(scheme.surface, scheme.primary, 0.28f).copy(alpha = 0.55f),
+            topLeft = Offset(size.width * leftFraction, size.height * topFraction),
+            size = androidx.compose.ui.geometry.Size(size.width * 0.12f, size.height * (1f - topFraction)),
+        )
+    }
+    // Front skyline with an antenna beacon, plus gridded lit windows.
+    val frontBuildings = listOf(
+        Triple(0.04f, 0.14f, 0.58f),
+        Triple(0.21f, 0.17f, 0.48f),
+        Triple(0.41f, 0.12f, 0.64f),
+        Triple(0.56f, 0.18f, 0.52f),
+        Triple(0.77f, 0.16f, 0.60f),
+    )
+    val buildingColor = lerp(scheme.surface, scheme.primary, 0.14f)
+    frontBuildings.forEachIndexed { buildingIndex, (leftFraction, widthFraction, topFraction) ->
+        val left = size.width * leftFraction
+        val towerWidth = size.width * widthFraction
+        val top = size.height * topFraction
+        drawRect(
+            color = buildingColor,
+            topLeft = Offset(left, top),
+            size = androidx.compose.ui.geometry.Size(towerWidth, size.height - top),
+        )
+        if (buildingIndex == 1) {
+            val mastX = left + towerWidth * 0.5f
+            val mastTop = top - size.height * 0.09f
+            drawLine(
+                color = buildingColor,
+                start = Offset(mastX, top),
+                end = Offset(mastX, mastTop),
+                strokeWidth = 2.dp.toPx(),
+            )
+            drawCircle(
+                color = scheme.tertiary.copy(alpha = 0.9f),
+                radius = 1.8.dp.toPx(),
+                center = Offset(mastX, mastTop),
+            )
+        }
+        // Windows: a regular grid of small panes in the tower's upper half — mostly lit,
+        // a deterministic few dark — leaving the base calm behind the card text.
+        val columns = if (widthFraction > 0.15f) 3 else 2
+        val rows = 4
+        val paneWidth = towerWidth * 0.14f
+        val paneHeight = size.height * 0.022f
+        repeat(columns * rows) { windowIndex ->
+            if ((windowIndex * 7 + buildingIndex * 5) % 5 == 0) return@repeat
+            val column = windowIndex % columns
+            val row = windowIndex / columns
+            drawRect(
+                color = scheme.tertiary.copy(alpha = 0.6f),
+                topLeft = Offset(
+                    left + towerWidth * (0.16f + column * (0.68f / columns)),
+                    top + size.height * (0.035f + row * 0.055f),
+                ),
+                size = androidx.compose.ui.geometry.Size(paneWidth, paneHeight),
+            )
+        }
+    }
+    // Grounding band so the skyline settles into a dark street level.
+    drawRect(
+        brush = Brush.verticalGradient(
+            0.82f to scheme.surface.copy(alpha = 0f),
+            1f to scheme.surface.copy(alpha = 0.85f),
+        ),
     )
 }
 
+// Runner at first light: leaning silhouette mid-stride with motion trails.
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawRunnerMood(
     scheme: androidx.compose.material3.ColorScheme,
 ) {
-    drawLayeredHills(
-        back = scheme.secondary.copy(alpha = 0.18f),
-        front = scheme.tertiary.copy(alpha = 0.2f),
+    drawSky(
+        top = lerp(scheme.secondaryContainer, scheme.tertiaryContainer, 0.3f),
+        mid = lerp(scheme.tertiaryContainer, scheme.tertiary, 0.12f),
+        bottom = lerp(scheme.surface, scheme.tertiaryContainer, 0.5f),
     )
-    val bodyColor = scheme.onSurface.copy(alpha = 0.28f)
-    val center = Offset(size.width * 0.74f, size.height * 0.48f)
-    drawCircle(bodyColor, size.minDimension * 0.05f, center.copy(y = center.y - size.height * 0.12f))
-    drawLine(bodyColor, center.copy(y = center.y - size.height * 0.06f), center.copy(x = center.x - size.width * 0.04f, y = center.y + size.height * 0.1f), 4.dp.toPx())
-    drawLine(bodyColor, center, center.copy(x = center.x - size.width * 0.13f, y = center.y + size.height * 0.02f), 4.dp.toPx())
-    drawLine(bodyColor, center, center.copy(x = center.x + size.width * 0.1f, y = center.y + size.height * 0.06f), 4.dp.toPx())
-    drawLine(bodyColor, center.copy(x = center.x - size.width * 0.04f, y = center.y + size.height * 0.1f), center.copy(x = center.x - size.width * 0.15f, y = center.y + size.height * 0.24f), 4.dp.toPx())
-    drawLine(bodyColor, center.copy(x = center.x - size.width * 0.04f, y = center.y + size.height * 0.1f), center.copy(x = center.x + size.width * 0.1f, y = center.y + size.height * 0.24f), 4.dp.toPx())
-}
-
-private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawLayeredHills(
-    back: Color,
-    front: Color,
-) {
-    val backPath = Path().apply {
-        moveTo(0f, size.height * 0.66f)
-        cubicTo(size.width * 0.2f, size.height * 0.48f, size.width * 0.38f, size.height * 0.72f, size.width * 0.56f, size.height * 0.55f)
-        cubicTo(size.width * 0.75f, size.height * 0.38f, size.width * 0.88f, size.height * 0.58f, size.width, size.height * 0.45f)
+    drawGlow(
+        color = scheme.tertiary,
+        center = Offset(size.width * 0.22f, size.height * 0.38f),
+        coreRadius = size.minDimension * 0.10f,
+        glowRadius = size.minDimension * 0.32f,
+        coreAlpha = 0.7f,
+    )
+    // Rolling ground.
+    val ground = Path().apply {
+        moveTo(0f, size.height * 0.80f)
+        cubicTo(size.width * 0.3f, size.height * 0.72f, size.width * 0.6f, size.height * 0.82f, size.width, size.height * 0.74f)
         lineTo(size.width, size.height)
         lineTo(0f, size.height)
         close()
     }
-    drawPath(backPath, back)
-    val frontPath = Path().apply {
-        moveTo(0f, size.height * 0.78f)
-        cubicTo(size.width * 0.18f, size.height * 0.62f, size.width * 0.32f, size.height * 0.84f, size.width * 0.5f, size.height * 0.68f)
-        cubicTo(size.width * 0.7f, size.height * 0.5f, size.width * 0.83f, size.height * 0.78f, size.width, size.height * 0.62f)
-        lineTo(size.width, size.height)
-        lineTo(0f, size.height)
-        close()
+    drawPath(ground, scheme.secondary.copy(alpha = 0.4f))
+    // A running shoe mid-flight, toe kicked up, with motion trails behind the heel.
+    val body = lerp(scheme.onSurface, scheme.primary, 0.25f).copy(alpha = 0.8f)
+    val midsoleColor = lerp(scheme.surface, scheme.onSurface, 0.12f).copy(alpha = 0.9f)
+    val m = size.minDimension
+    val c = Offset(size.width * 0.63f, size.height * 0.50f)
+    rotate(degrees = -12f, pivot = c) {
+        val heelX = c.x - m * 0.175f
+        val toeX = c.x + m * 0.185f
+        val soleTop = c.y + m * 0.035f
+        // Midsole then outsole beneath it.
+        drawRoundRect(
+            color = midsoleColor,
+            topLeft = Offset(heelX, soleTop),
+            size = androidx.compose.ui.geometry.Size(toeX - heelX, m * 0.035f),
+            cornerRadius = androidx.compose.ui.geometry.CornerRadius(m * 0.018f),
+        )
+        drawRoundRect(
+            color = body,
+            topLeft = Offset(heelX, soleTop + m * 0.030f),
+            size = androidx.compose.ui.geometry.Size(toeX - heelX, m * 0.022f),
+            cornerRadius = androidx.compose.ui.geometry.CornerRadius(m * 0.011f),
+        )
+        // Upper: tall heel collar sweeping down to a low toe box.
+        val upper = Path().apply {
+            moveTo(heelX, soleTop)
+            lineTo(heelX, c.y - m * 0.075f)
+            quadraticTo(heelX + m * 0.015f, c.y - m * 0.105f, heelX + m * 0.06f, c.y - m * 0.10f)
+            quadraticTo(heelX + m * 0.13f, c.y - m * 0.09f, c.x + m * 0.04f, c.y - m * 0.035f)
+            quadraticTo(c.x + m * 0.115f, c.y + m * 0.005f, toeX, soleTop - m * 0.002f)
+            lineTo(heelX, soleTop)
+            close()
+        }
+        drawPath(upper, body)
+        // Collar opening.
+        drawLine(
+            color = midsoleColor.copy(alpha = 0.7f),
+            start = Offset(heelX + m * 0.055f, c.y - m * 0.092f),
+            end = Offset(heelX + m * 0.105f, c.y - m * 0.062f),
+            strokeWidth = 2.dp.toPx(),
+            cap = StrokeCap.Round,
+        )
+        // Laces across the instep.
+        repeat(3) { index ->
+            val t = index * m * 0.038f
+            drawLine(
+                color = midsoleColor,
+                start = Offset(c.x - m * 0.035f + t, c.y - m * 0.070f + t * 0.55f),
+                end = Offset(c.x + m * 0.005f + t, c.y - m * 0.098f + t * 0.55f),
+                strokeWidth = 2.2.dp.toPx(),
+                cap = StrokeCap.Round,
+            )
+        }
+        // Side accent stripe.
+        val accent = Path().apply {
+            moveTo(heelX + m * 0.03f, c.y - m * 0.005f)
+            quadraticTo(c.x - m * 0.02f, c.y + m * 0.028f, c.x + m * 0.09f, c.y - m * 0.012f)
+        }
+        drawPath(
+            accent,
+            scheme.tertiary.copy(alpha = 0.85f),
+            style = androidx.compose.ui.graphics.drawscope.Stroke(width = 2.5.dp.toPx(), cap = StrokeCap.Round),
+        )
     }
-    drawPath(frontPath, front)
+    // Motion trails behind the heel.
+    repeat(3) { index ->
+        val y = c.y - m * (0.055f - 0.05f * index)
+        drawLine(
+            color = body.copy(alpha = 0.35f - 0.08f * index),
+            start = Offset(c.x - m * (0.34f + 0.045f * index), y),
+            end = Offset(c.x - m * (0.21f + 0.02f * index), y),
+            strokeWidth = (3.2f - 0.5f * index).dp.toPx(),
+            cap = StrokeCap.Round,
+        )
+    }
 }
 
 @Composable
@@ -2047,6 +2366,7 @@ private fun FavoritesTabContent(
     isBuffering: Boolean,
     homeViewMode: HomeViewMode,
     favoritesSort: FavoritesSort,
+    gridColumns: Int,
     listState: LazyListState,
     bottomPadding: androidx.compose.ui.unit.Dp,
     onPlay: (Station) -> Unit,
@@ -2058,7 +2378,9 @@ private fun FavoritesTabContent(
     val tileColor = MaterialTheme.colorScheme.surfaceContainerHigh
     val activeTileColor = MaterialTheme.colorScheme.primaryContainer
     val tileContentColor = MaterialTheme.colorScheme.onPrimaryContainer
-    val favoriteRows = remember(stations) { (0 until stations.size + 1).toList().chunked(3) }
+    val favoriteRows = remember(stations, gridColumns) {
+        (0 until stations.size + 1).toList().chunked(gridColumns)
+    }
     val showFavoriteActivityIndicators by remember {
         derivedStateOf { !listState.isScrollInProgress }
     }
@@ -2119,6 +2441,7 @@ private fun FavoritesTabContent(
             ) { rowIndices ->
                 FavoriteStationCardRow(
                     rowIndices = rowIndices,
+                    columns = gridColumns,
                     isLastRow = rowIndices == favoriteRows.last(),
                     stations = stations,
                     currentStation = currentStation,
@@ -2259,6 +2582,7 @@ private fun HomeViewModeToggle(
 @Composable
 private fun FavoriteStationCardRow(
     rowIndices: List<Int>,
+    columns: Int,
     isLastRow: Boolean,
     stations: List<Station>,
     currentStation: Station?,
@@ -2303,7 +2627,7 @@ private fun FavoriteStationCardRow(
                 AddTile(onClick = onAddTapped, modifier = Modifier.weight(1f))
             }
         }
-        repeat(3 - rowIndices.size) {
+        repeat(columns - rowIndices.size) {
             Spacer(modifier = Modifier.weight(1f))
         }
     }
@@ -2425,10 +2749,16 @@ private fun StationTile(
             else -> null
         }
         var logoFailed by remember(logoModel) { mutableStateOf(false) }
+        val showLogo = logoModel != null && !logoFailed
 
         Surface(
-            color = tileColor,
-            shape = MaterialTheme.shapes.extraLarge,
+            // Same plate treatment as the other artwork surfaces: the light adaptive plate
+            // behind rendered logos (visible only through transparency), tonal otherwise.
+            color = if (showLogo) stationLogoPlateColor() else tileColor,
+            // Medium card radius like the other cards: a fixed 28dp reads far rounder on
+            // the small tiles of a 4-5 column grid, so keep the modest spec radius at
+            // every grid width.
+            shape = MaterialTheme.shapes.medium,
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(1f)
@@ -2441,19 +2771,21 @@ private fun StationTile(
                 ),
         ) {
             Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-                Icon(
-                    imageVector = Icons.Rounded.Radio,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(48.dp),
-                )
+                if (!showLogo) {
+                    Icon(
+                        imageVector = Icons.Rounded.Radio,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(48.dp),
+                    )
+                }
                 if (logoModel != null && !logoFailed) {
                     AsyncImage(
                         model = logoModel,
                         contentDescription = null,
                         contentScale = ContentScale.Fit,
                         onError = { logoFailed = true },
-                        modifier = Modifier.fillMaxSize().padding(14.dp),
+                        modifier = Modifier.fillMaxSize(),
                     )
                     if (isActive) {
                         Box(
@@ -2500,7 +2832,7 @@ private fun AddTile(onClick: () -> Unit, modifier: Modifier = Modifier) {
         Surface(
             onClick = onClick,
             color = MaterialTheme.colorScheme.surfaceContainerHigh,
-            shape = MaterialTheme.shapes.extraLarge,
+            shape = MaterialTheme.shapes.medium,
             border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
             modifier = Modifier.fillMaxWidth().aspectRatio(1f),
         ) {
@@ -2747,64 +3079,16 @@ private fun FilterPickerSheetContent(
 }
 
 @Composable
-private fun FeaturedStationCard(
-    station: com.shapeshed.aerial.data.RegistryStation,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier.width(96.dp),
-    ) {
-        Surface(
-            onClick = onClick,
-            shape = MaterialTheme.shapes.extraLarge,
-            color = MaterialTheme.colorScheme.surfaceContainerHigh,
-            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
-            modifier = Modifier.fillMaxWidth().aspectRatio(1f),
-        ) {
-            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-                if (station.logoUrl.isNotBlank()) {
-                    AsyncImage(
-                        model = station.logoUrl,
-                        contentDescription = null,
-                        contentScale = ContentScale.Fit,
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                } else {
-                    Text(
-                        text = station.name.take(1).uppercase(),
-                        style = MaterialTheme.typography.headlineMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-        }
-        Text(
-            text = station.name,
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.padding(top = 6.dp),
-        )
-    }
-}
-
-@Composable
 private fun ForYouStationCard(
     station: com.shapeshed.aerial.data.RegistryStation,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Surface(
+    // Filled card per the M3 card spec — surfaceContainerHighest container on the medium
+    // corner radius, no outline or elevation — the spec's type for tappable content tiles.
+    Card(
         onClick = onClick,
-        // Tonal, border-less container on the expressive extra-large radius, matching the
-        // app's other tiles.
-        shape = MaterialTheme.shapes.extraLarge,
-        color = MaterialTheme.colorScheme.surfaceContainerHigh,
-        modifier = modifier.width(140.dp).height(132.dp),
+        modifier = modifier.width(140.dp).height(116.dp),
     ) {
         Column(
             verticalArrangement = Arrangement.SpaceBetween,
@@ -2820,33 +3104,31 @@ private fun ForYouStationCard(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                Text(
-                    text = station.name,
-                    style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                val genre = station.tags.split(" ").firstOrNull { it.isNotBlank() } ?: station.country
-                if (genre.isNotBlank()) {
-                    Text(
-                        text = genre.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-            }
+            Text(
+                text = station.name,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
         }
     }
 }
 
-// Circular station logo on a white plate. The plate shows through transparent regions of
+// Plate behind station artwork: near-white for legibility of arbitrary third-party logos
+// (a dark tonal plate would swallow dark transparent marks), tinted toward the dynamic
+// palette so it follows the system theme like the rest of the app.
+@Composable
+fun stationLogoPlateColor(): androidx.compose.ui.graphics.Color = lerp(
+    androidx.compose.ui.graphics.Color.White,
+    MaterialTheme.colorScheme.primaryContainer,
+    0.22f,
+)
+
+// Circular station logo on a light plate. The plate shows through transparent regions of
 // third-party artwork so every logo sits on a consistent background, and it is never a
 // visible ring because the artwork fills the circle. Stations without a usable logo keep a
-// tonal circle behind the fallback content instead of the white plate.
+// tonal circle behind the fallback content instead of the plate.
 @Composable
 fun StationLogoCircle(
     logoModel: Any?,
@@ -2862,7 +3144,7 @@ fun StationLogoCircle(
         modifier = modifier
             .size(size)
             .clip(CircleShape)
-            .background(if (showLogo) androidx.compose.ui.graphics.Color.White else fallbackBackground),
+            .background(if (showLogo) stationLogoPlateColor() else fallbackBackground),
     ) {
         if (showLogo) {
             AsyncImage(

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.combinedClickable
@@ -41,6 +42,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowForward
 import androidx.compose.material.icons.automirrored.rounded.Article
 import androidx.compose.material.icons.automirrored.rounded.Sort
 import androidx.compose.material.icons.automirrored.rounded.ViewList
@@ -131,6 +133,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -143,6 +146,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.traversalIndex
@@ -150,7 +154,13 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
@@ -200,6 +210,77 @@ private val CATEGORY_ICONS = mapOf(
     "Electronic" to Icons.Rounded.GraphicEq,
 )
 
+private enum class MoodArtwork {
+    Coast,
+    Mountains,
+    Sunrise,
+    Road,
+    City,
+    Runner,
+}
+
+private data class CuratedMood(
+    val id: String,
+    val titleRes: Int,
+    val descriptionRes: Int,
+    val detailDescriptionRes: Int = descriptionRes,
+    val tags: List<String>,
+    val icon: ImageVector,
+    val artwork: MoodArtwork,
+)
+
+private val CURATED_MOODS = listOf(
+    CuratedMood(
+        id = "relax",
+        titleRes = R.string.mood_relax,
+        descriptionRes = R.string.mood_relax_desc,
+        detailDescriptionRes = R.string.mood_relax_detail_desc,
+        tags = listOf("Jazz", "Soul", "Classical"),
+        icon = Icons.Rounded.Spa,
+        artwork = MoodArtwork.Coast,
+    ),
+    CuratedMood(
+        id = "focus",
+        titleRes = R.string.mood_focus,
+        descriptionRes = R.string.mood_focus_desc,
+        tags = listOf("Classical", "Electronic", "Jazz"),
+        icon = Icons.Rounded.GraphicEq,
+        artwork = MoodArtwork.Mountains,
+    ),
+    CuratedMood(
+        id = "morning",
+        titleRes = R.string.mood_morning,
+        descriptionRes = R.string.mood_morning_desc,
+        tags = listOf("Pop", "Soul", "News"),
+        icon = Icons.Rounded.Star,
+        artwork = MoodArtwork.Sunrise,
+    ),
+    CuratedMood(
+        id = "driving",
+        titleRes = R.string.mood_driving,
+        descriptionRes = R.string.mood_driving_desc,
+        tags = listOf("Rock", "Pop", "Country"),
+        icon = Icons.Rounded.Landscape,
+        artwork = MoodArtwork.Road,
+    ),
+    CuratedMood(
+        id = "late_night",
+        titleRes = R.string.mood_late_night,
+        descriptionRes = R.string.mood_late_night_desc,
+        tags = listOf("Jazz", "Electronic", "Soul"),
+        icon = Icons.Rounded.Nightlife,
+        artwork = MoodArtwork.City,
+    ),
+    CuratedMood(
+        id = "workout",
+        titleRes = R.string.mood_workout,
+        descriptionRes = R.string.mood_workout_desc,
+        tags = listOf("Dance", "Electronic", "Rock"),
+        icon = Icons.Rounded.ElectricBolt,
+        artwork = MoodArtwork.Runner,
+    ),
+)
+
 private data class RegistryStationKey(
     val provider: String,
     val providerId: String,
@@ -214,6 +295,25 @@ private fun Station.savedKey(): RegistryStationKey? =
     RegistryStationKey(provider, providerId).takeIf {
         it.provider.isNotBlank() && it.providerId.isNotBlank()
     }
+
+private fun RegistryStation.toPlaybackStation(): Station = Station(
+    name = name,
+    streamUrl = streamUrl,
+    logoPath = logoUrl,
+    provider = provider,
+    providerId = providerId,
+    tags = tags,
+    description = description,
+    country = country,
+    countryCode = countryCode,
+)
+
+private fun Station.matchesStation(other: Station): Boolean =
+    streamUrl == other.streamUrl ||
+        (provider.isNotBlank() &&
+            providerId.isNotBlank() &&
+            provider == other.provider &&
+            providerId == other.providerId)
 
 enum class HomeViewMode {
     Cards,
@@ -255,7 +355,9 @@ fun MainScreen(
     val recentSearches by viewModel.recentSearches.collectAsStateWithLifecycle()
     val allTags by viewModel.allTags.collectAsStateWithLifecycle()
     val featuredStations by viewModel.featuredStations.collectAsStateWithLifecycle()
+    val ukForYouStations by viewModel.ukForYouStations.collectAsStateWithLifecycle()
     val defaultStations by viewModel.defaultStations.collectAsStateWithLifecycle()
+    val curatedMoodStations by viewModel.curatedMoodStations.collectAsStateWithLifecycle()
     val homeViewMode by viewModel.homeViewMode.collectAsStateWithLifecycle()
     val favoritesSort by viewModel.favoritesSort.collectAsStateWithLifecycle()
     val showStreamBitrate by viewModel.showStreamBitrate.collectAsStateWithLifecycle()
@@ -273,6 +375,7 @@ fun MainScreen(
     var showGenreSheet by remember { mutableStateOf(false) }
     var contextStation by remember { mutableStateOf<Station?>(null) }
     var stationToDelete by remember { mutableStateOf<Station?>(null) }
+    var selectedMoodId by rememberSaveable { mutableStateOf<String?>(null) }
     val countrySheetState = rememberBottomSheetState(
         initialValue = SheetValue.Hidden,
         enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
@@ -297,9 +400,15 @@ fun MainScreen(
     var miniPlayerHeightPx by remember { mutableIntStateOf(0) }
     val density = LocalDensity.current
     val stationContentBottomPadding = if (currentStation != null) with(density) { miniPlayerHeightPx.toDp() } else 0.dp
+    val selectedMood = selectedMoodId?.let { id -> CURATED_MOODS.firstOrNull { it.id == id } }
+    val selectedMoodStations = selectedMoodId?.let { curatedMoodStations[it] }.orEmpty()
     val activeNowPlayingInfo = nowPlayingInfo?.takeIf { it.stationId == currentStation?.id }
+    val moodSwipeStations = remember(selectedMoodStations) {
+        selectedMoodStations.map { it.toPlaybackStation() }
+    }
 
     BackHandler(enabled = showNowPlaying) { viewModel.setShowNowPlaying(false) }
+    BackHandler(enabled = selectedMood != null && !showNowPlaying) { selectedMoodId = null }
     BackHandler(enabled = isSearchExpanded && !showCountrySheet && !showGenreSheet) {
         textFieldState.edit { replace(0, length, "") }
         scope.launch { searchBarState.animateToCollapsed() }
@@ -317,6 +426,13 @@ fun MainScreen(
         viewModel.clearRecentlyAddedStation(stationId)
     }
     fun openRegistrySearch() {
+        scope.launch { searchBarState.animateToExpanded() }
+    }
+
+    fun openCountrySearch(countryCode: String) {
+        textFieldState.edit { replace(0, length, "") }
+        viewModel.searchRegistry("")
+        viewModel.setCountryFilter(countryCode)
         scope.launch { searchBarState.animateToExpanded() }
     }
 
@@ -378,7 +494,10 @@ fun MainScreen(
                 ShortNavigationBar(containerColor = MaterialTheme.colorScheme.surfaceContainerLow) {
                     ShortNavigationBarItem(
                         selected = selectedTab == TAB_HOME,
-                        onClick = { viewModel.setSelectedHomeTab(TAB_HOME) },
+                        onClick = {
+                            selectedMoodId = null
+                            viewModel.setSelectedHomeTab(TAB_HOME)
+                        },
                         icon = {
                             Icon(
                                 imageVector = if (selectedTab == TAB_HOME) Icons.Rounded.Home else Icons.Outlined.Home,
@@ -389,7 +508,10 @@ fun MainScreen(
                     )
                     ShortNavigationBarItem(
                         selected = selectedTab == TAB_FAVORITES,
-                        onClick = { viewModel.setSelectedHomeTab(TAB_FAVORITES) },
+                        onClick = {
+                            selectedMoodId = null
+                            viewModel.setSelectedHomeTab(TAB_FAVORITES)
+                        },
                         icon = {
                             Icon(
                                 imageVector = if (selectedTab == TAB_FAVORITES) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
@@ -409,27 +531,53 @@ fun MainScreen(
                     .padding(bottom = padding.calculateBottomPadding()),
             ) {
             Column(Modifier.fillMaxSize()) {
-                SearchBar(
-                    state = searchBarState,
-                    inputField = searchInputField,
-                    colors = SearchBarDefaults.containedColors(searchBarState),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
-                        .windowInsetsPadding(WindowInsets.statusBars)
-                        .padding(top = 8.dp, bottom = 8.dp),
-                )
+                if (selectedMood == null) {
+                    SearchBar(
+                        state = searchBarState,
+                        inputField = searchInputField,
+                        colors = SearchBarDefaults.containedColors(searchBarState),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp)
+                            .windowInsetsPadding(WindowInsets.statusBars)
+                            .padding(top = 8.dp, bottom = 8.dp),
+                    )
+                }
 
                 if (!isOnline) {
                     NoNetworkState()
+                } else if (selectedMood != null) {
+                    MoodDetailScreen(
+                        mood = selectedMood,
+                        stations = selectedMoodStations,
+                        currentStation = currentStation,
+                        isPlaying = isPlaying,
+                        isBuffering = isBuffering,
+                        savedStreamUrls = savedStreamUrls,
+                        savedRegistryKeys = savedRegistryKeys,
+                        bottomPadding = stationContentBottomPadding,
+                        onBack = { selectedMoodId = null },
+                        onPlay = { selectedMoodStations.firstOrNull()?.let(viewModel::playFromRegistry) },
+                        onSave = { selectedMoodStations.forEach(viewModel::addFromRegistry) },
+                        onTogglePlayback = { viewModel.togglePlayback() },
+                        onAddStation = { viewModel.addFromRegistry(it) },
+                        onRemoveStation = { viewModel.removeFromRegistry(it) },
+                        onPlayStation = { viewModel.playFromRegistry(it) },
+                    )
                 } else if (selectedTab == TAB_HOME) {
+                    val forYouCountryCode = appLocale.country.takeIf { it.isNotBlank() } ?: "GB"
                     HomeTabContent(
                         allTags = allTags,
                         featuredStations = featuredStations,
+                        forYouStations = ukForYouStations.takeIf { forYouCountryCode.equals("GB", ignoreCase = true) }
+                            ?: featuredStations,
+                        forYouCountry = countryName(forYouCountryCode, appLocale),
                         listState = homeListState,
                         bottomPadding = stationContentBottomPadding,
                         onCategoryTap = { viewModel.playRandomFromCategory(it) },
+                        onMoodTap = { selectedMoodId = it.id },
                         onFeaturedStationTap = { viewModel.playFromRegistry(it) },
+                        onForYouViewAll = { openCountrySearch(forYouCountryCode) },
                     )
                 } else {
                     FavoritesTabContent(
@@ -596,7 +744,11 @@ fun MainScreen(
                 // Swipe order frozen for the lifetime of the pane: under the Last/Most played
                 // sorts, playing a station immediately re-sorts the live list, which would make
                 // consecutive swipes ping-pong between the same two stations.
-                val swipeStations = remember { viewModel.stations.value }
+                val favoriteSwipeStations = remember { viewModel.stations.value }
+                val useMoodSwipeStations = selectedMood != null &&
+                    moodSwipeStations.size > 1 &&
+                    moodSwipeStations.any { moodStation -> station.matchesStation(moodStation) }
+                val swipeStations = if (useMoodSwipeStations) moodSwipeStations else favoriteSwipeStations
                 NowPlayingScreen(
                     station = station,
                     isPlaying = isPlaying,
@@ -1162,15 +1314,62 @@ private fun HomeEmptyState(
 private fun HomeTabContent(
     allTags: List<String>,
     featuredStations: List<com.shapeshed.aerial.data.RegistryStation>,
+    forYouStations: List<com.shapeshed.aerial.data.RegistryStation>,
+    forYouCountry: String,
     listState: LazyListState,
     bottomPadding: androidx.compose.ui.unit.Dp,
     onCategoryTap: (String) -> Unit,
+    onMoodTap: (CuratedMood) -> Unit,
     onFeaturedStationTap: (com.shapeshed.aerial.data.RegistryStation) -> Unit,
+    onForYouViewAll: () -> Unit,
 ) {
     LazyColumn(
         state = listState,
         contentPadding = PaddingValues(bottom = bottomPadding + 16.dp),
     ) {
+        if (forYouStations.isNotEmpty()) {
+            item("for-you-header") {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 20.dp, end = 20.dp, top = 20.dp, bottom = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stringResource(R.string.for_you_country, forYouCountry),
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.weight(1f),
+                    )
+                    TextButton(onClick = onForYouViewAll) {
+                        Text(text = stringResource(R.string.view_all))
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Rounded.ArrowForward,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
+                }
+            }
+            item("for-you-row") {
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    contentPadding = PaddingValues(horizontal = 16.dp),
+                ) {
+                    items(
+                        items = forYouStations,
+                        key = { "for-you-${it.provider}-${it.providerId}-${it.name}-${it.streamUrl}" },
+                        contentType = { "for-you-station" },
+                    ) { station ->
+                        ForYouStationCard(
+                            station = station,
+                            onClick = { onFeaturedStationTap(station) },
+                        )
+                    }
+                }
+            }
+        }
+
         if (featuredStations.isNotEmpty()) {
             item("get-started-header") {
                 Text(
@@ -1195,6 +1394,22 @@ private fun HomeTabContent(
             }
         }
 
+        item("moods-header") {
+            Text(
+                text = stringResource(R.string.listen_by_mood),
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 24.dp, bottom = 12.dp),
+            )
+        }
+        item("moods-grid") {
+            MoodGrid(
+                moods = CURATED_MOODS,
+                onMoodTap = onMoodTap,
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+        }
+
         item("just-listen-header") {
             Text(
                 text = stringResource(R.string.just_listen),
@@ -1211,6 +1426,514 @@ private fun HomeTabContent(
             )
         }
     }
+}
+
+@Composable
+private fun MoodGrid(
+    moods: List<CuratedMood>,
+    onMoodTap: (CuratedMood) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+        modifier = modifier,
+    ) {
+        moods.chunked(2).forEach { pair ->
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                pair.forEach { mood ->
+                    MoodCard(
+                        mood = mood,
+                        onClick = { onMoodTap(mood) },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                if (pair.size == 1) Spacer(Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun MoodCard(
+    mood: CuratedMood,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        onClick = onClick,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        shape = MaterialTheme.shapes.large,
+        modifier = modifier.height(132.dp),
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            MoodArtwork(
+                artwork = mood.artwork,
+                modifier = Modifier.fillMaxSize(),
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        Brush.verticalGradient(
+                            0f to MaterialTheme.colorScheme.surface.copy(alpha = 0.08f),
+                            1f to MaterialTheme.colorScheme.surface.copy(alpha = 0.44f),
+                        ),
+                    ),
+            )
+            Column(
+                verticalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(14.dp),
+            ) {
+                Surface(
+                    color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.9f),
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    shape = CircleShape,
+                    modifier = Modifier.size(36.dp),
+                ) {
+                    Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                        Icon(
+                            imageVector = mood.icon,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                }
+                Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                    Text(
+                        text = stringResource(mood.titleRes),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = stringResource(mood.descriptionRes),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MoodDetailScreen(
+    mood: CuratedMood,
+    stations: List<RegistryStation>,
+    currentStation: Station?,
+    isPlaying: Boolean,
+    isBuffering: Boolean,
+    savedStreamUrls: Set<String>,
+    savedRegistryKeys: Set<RegistryStationKey>,
+    bottomPadding: Dp,
+    onBack: () -> Unit,
+    onPlay: () -> Unit,
+    onSave: () -> Unit,
+    onTogglePlayback: () -> Unit,
+    onAddStation: (RegistryStation) -> Unit,
+    onRemoveStation: (RegistryStation) -> Unit,
+    onPlayStation: (RegistryStation) -> Unit,
+) {
+    LazyColumn(
+        contentPadding = PaddingValues(bottom = bottomPadding + 16.dp),
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        item("mood-hero") {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(360.dp),
+            ) {
+                MoodArtwork(
+                    artwork = mood.artwork,
+                    modifier = Modifier.fillMaxSize(),
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(
+                            Brush.verticalGradient(
+                                0f to MaterialTheme.colorScheme.surface.copy(alpha = 0.08f),
+                                1f to MaterialTheme.colorScheme.surface.copy(alpha = 0.42f),
+                            ),
+                        ),
+                )
+                IconButton(
+                    onClick = onBack,
+                    shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
+                    modifier = Modifier
+                        .windowInsetsPadding(WindowInsets.statusBars)
+                        .padding(start = 12.dp, top = 8.dp),
+                ) {
+                    Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = stringResource(R.string.action_back))
+                }
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(14.dp),
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(horizontal = 24.dp, vertical = 28.dp),
+                ) {
+                    Text(
+                        text = stringResource(mood.titleRes),
+                        style = MaterialTheme.typography.displaySmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = stringResource(mood.detailDescriptionRes),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.fillMaxWidth(0.72f),
+                    )
+                }
+            }
+        }
+        item("mood-actions") {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 24.dp),
+            ) {
+                Button(
+                    onClick = onPlay,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(Icons.Rounded.PlayArrow, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text(stringResource(R.string.play))
+                }
+                OutlinedButton(
+                    onClick = onSave,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(Icons.Rounded.FavoriteBorder, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text(stringResource(R.string.save_all))
+                }
+            }
+        }
+        items(
+            items = stations,
+            key = { "${it.provider}-${it.providerId}-${it.name}-${it.streamUrl}" },
+            contentType = { "mood-station" },
+        ) { station ->
+            val isActive = currentStation?.let { active ->
+                active.streamUrl == station.streamUrl ||
+                    (active.provider.isNotBlank() &&
+                        active.providerId.isNotBlank() &&
+                        active.provider == station.provider &&
+                        active.providerId == station.providerId)
+            } ?: false
+            val isSaved = station.streamUrl in savedStreamUrls || station.savedKey() in savedRegistryKeys
+            MoodStationRow(
+                station = station,
+                isActive = isActive,
+                isPlaying = isPlaying && isActive,
+                isBuffering = isBuffering && isActive,
+                onPlay = { onPlayStation(station) },
+                onTogglePlayback = onTogglePlayback,
+                isSaved = isSaved,
+                onToggleFavorite = {
+                    if (isSaved) onRemoveStation(station) else onAddStation(station)
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun MoodStationRow(
+    station: RegistryStation,
+    isActive: Boolean,
+    isPlaying: Boolean,
+    isBuffering: Boolean,
+    onPlay: () -> Unit,
+    onTogglePlayback: () -> Unit,
+    isSaved: Boolean,
+    onToggleFavorite: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val pauseLabel = stringResource(R.string.pause)
+    ListItem(
+        modifier = modifier.fillMaxWidth().clickable(onClick = onPlay),
+        leadingContent = {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .size(64.dp)
+                    .clip(MaterialTheme.shapes.large)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+            ) {
+                if (station.logoUrl.isNotBlank()) {
+                    AsyncImage(
+                        model = station.logoUrl,
+                        contentDescription = null,
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Rounded.Radio,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(28.dp),
+                    )
+                }
+            }
+        },
+        supportingContent = {
+            if (station.country.isNotBlank()) {
+                Text(
+                    text = station.country,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        },
+        trailingContent = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                IconButton(
+                    onClick = if (isPlaying) onTogglePlayback else onPlay,
+                    shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
+                ) {
+                    when {
+                        isBuffering -> CircularWavyProgressIndicator(
+                            modifier = Modifier.size(24.dp),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            trackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+                        )
+                        isPlaying -> EqualizerBars(
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier
+                                .size(width = 28.dp, height = 22.dp)
+                                .semantics { contentDescription = pauseLabel },
+                            barCount = 3,
+                        )
+                        else -> Icon(Icons.Rounded.PlayArrow, contentDescription = stringResource(R.string.play))
+                    }
+                }
+                IconButton(
+                    onClick = onToggleFavorite,
+                    shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
+                ) {
+                    Icon(
+                        imageVector = if (isSaved) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
+                        contentDescription = stringResource(if (isSaved) R.string.remove_from_favorites else R.string.save_to_favorites),
+                        tint = if (isSaved) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        },
+    ) {
+        Text(
+            text = station.name,
+            style = MaterialTheme.typography.titleMedium,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Composable
+private fun MoodArtwork(
+    artwork: MoodArtwork,
+    modifier: Modifier = Modifier,
+) {
+    val scheme = MaterialTheme.colorScheme
+    Canvas(modifier = modifier) {
+        val skyTop = when (artwork) {
+            MoodArtwork.Coast -> lerp(scheme.tertiaryContainer, scheme.primaryContainer, 0.18f)
+            MoodArtwork.Mountains -> lerp(scheme.secondaryContainer, scheme.surfaceVariant, 0.35f)
+            MoodArtwork.Sunrise -> lerp(scheme.tertiaryContainer, Color(0xFFFFC879), 0.32f)
+            MoodArtwork.Road -> lerp(scheme.primaryContainer, scheme.secondaryContainer, 0.36f)
+            MoodArtwork.City -> lerp(scheme.primary, scheme.surface, 0.64f)
+            MoodArtwork.Runner -> lerp(scheme.secondaryContainer, scheme.tertiaryContainer, 0.28f)
+        }
+        val skyBottom = when (artwork) {
+            MoodArtwork.City -> lerp(scheme.surface, scheme.primaryContainer, 0.4f)
+            else -> lerp(scheme.surface, skyTop, 0.58f)
+        }
+        drawRect(
+            brush = Brush.verticalGradient(
+                listOf(skyTop, skyBottom),
+            ),
+        )
+
+        val sunColor = scheme.tertiary.copy(alpha = 0.28f)
+        drawCircle(
+            color = sunColor,
+            radius = size.minDimension * 0.16f,
+            center = Offset(size.width * 0.72f, size.height * 0.35f),
+        )
+
+        when (artwork) {
+            MoodArtwork.Coast -> drawCoastMood(scheme)
+            MoodArtwork.Mountains -> drawMountainMood(scheme)
+            MoodArtwork.Sunrise -> drawSunriseMood(scheme)
+            MoodArtwork.Road -> drawRoadMood(scheme)
+            MoodArtwork.City -> drawCityMood(scheme)
+            MoodArtwork.Runner -> drawRunnerMood(scheme)
+        }
+    }
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawCoastMood(
+    scheme: androidx.compose.material3.ColorScheme,
+) {
+    drawLayeredHills(
+        back = scheme.primary.copy(alpha = 0.18f),
+        front = scheme.primary.copy(alpha = 0.34f),
+    )
+    drawRect(
+        color = scheme.primary.copy(alpha = 0.22f),
+        topLeft = Offset(0f, size.height * 0.62f),
+        size = androidx.compose.ui.geometry.Size(size.width, size.height * 0.38f),
+    )
+    repeat(4) { index ->
+        val y = size.height * (0.68f + index * 0.07f)
+        drawLine(
+            color = scheme.onSurface.copy(alpha = 0.12f),
+            start = Offset(size.width * 0.18f, y),
+            end = Offset(size.width * 0.86f, y + size.height * 0.02f),
+            strokeWidth = 2.dp.toPx(),
+        )
+    }
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawMountainMood(
+    scheme: androidx.compose.material3.ColorScheme,
+) {
+    repeat(3) { index ->
+        val top = size.height * (0.28f + index * 0.11f)
+        val alpha = 0.16f + index * 0.1f
+        val path = Path().apply {
+            moveTo(0f, size.height)
+            lineTo(size.width * 0.22f, top + size.height * 0.18f)
+            lineTo(size.width * 0.48f, top)
+            lineTo(size.width * 0.75f, top + size.height * 0.2f)
+            lineTo(size.width, top + size.height * 0.08f)
+            lineTo(size.width, size.height)
+            close()
+        }
+        drawPath(path, scheme.primary.copy(alpha = alpha))
+    }
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawSunriseMood(
+    scheme: androidx.compose.material3.ColorScheme,
+) {
+    drawLayeredHills(
+        back = scheme.tertiary.copy(alpha = 0.18f),
+        front = scheme.primary.copy(alpha = 0.24f),
+    )
+    drawCircle(
+        color = scheme.tertiary.copy(alpha = 0.26f),
+        radius = size.minDimension * 0.22f,
+        center = Offset(size.width * 0.78f, size.height * 0.66f),
+    )
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawRoadMood(
+    scheme: androidx.compose.material3.ColorScheme,
+) {
+    drawLayeredHills(
+        back = scheme.secondary.copy(alpha = 0.18f),
+        front = scheme.primary.copy(alpha = 0.28f),
+    )
+    val road = Path().apply {
+        moveTo(size.width * 0.46f, size.height)
+        lineTo(size.width * 0.58f, size.height * 0.55f)
+        lineTo(size.width * 0.68f, size.height * 0.55f)
+        lineTo(size.width * 0.86f, size.height)
+        close()
+    }
+    drawPath(road, scheme.onSurface.copy(alpha = 0.16f))
+    drawLine(
+        color = scheme.surface.copy(alpha = 0.72f),
+        start = Offset(size.width * 0.65f, size.height),
+        end = Offset(size.width * 0.62f, size.height * 0.6f),
+        strokeWidth = 2.dp.toPx(),
+    )
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawCityMood(
+    scheme: androidx.compose.material3.ColorScheme,
+) {
+    drawRect(
+        color = scheme.primary.copy(alpha = 0.22f),
+        topLeft = Offset(0f, size.height * 0.52f),
+        size = androidx.compose.ui.geometry.Size(size.width, size.height * 0.48f),
+    )
+    val widths = listOf(0.12f, 0.18f, 0.1f, 0.16f, 0.14f, 0.2f)
+    var x = size.width * 0.06f
+    widths.forEachIndexed { index, widthFraction ->
+        val buildingWidth = size.width * widthFraction
+        val top = size.height * (0.42f + (index % 3) * 0.08f)
+        drawRect(
+            color = scheme.onSurface.copy(alpha = 0.22f),
+            topLeft = Offset(x, top),
+            size = androidx.compose.ui.geometry.Size(buildingWidth, size.height - top),
+        )
+        x += buildingWidth + size.width * 0.035f
+    }
+    drawCircle(
+        color = scheme.tertiary.copy(alpha = 0.34f),
+        radius = size.minDimension * 0.08f,
+        center = Offset(size.width * 0.76f, size.height * 0.24f),
+    )
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawRunnerMood(
+    scheme: androidx.compose.material3.ColorScheme,
+) {
+    drawLayeredHills(
+        back = scheme.secondary.copy(alpha = 0.18f),
+        front = scheme.tertiary.copy(alpha = 0.2f),
+    )
+    val bodyColor = scheme.onSurface.copy(alpha = 0.28f)
+    val center = Offset(size.width * 0.74f, size.height * 0.48f)
+    drawCircle(bodyColor, size.minDimension * 0.05f, center.copy(y = center.y - size.height * 0.12f))
+    drawLine(bodyColor, center.copy(y = center.y - size.height * 0.06f), center.copy(x = center.x - size.width * 0.04f, y = center.y + size.height * 0.1f), 4.dp.toPx())
+    drawLine(bodyColor, center, center.copy(x = center.x - size.width * 0.13f, y = center.y + size.height * 0.02f), 4.dp.toPx())
+    drawLine(bodyColor, center, center.copy(x = center.x + size.width * 0.1f, y = center.y + size.height * 0.06f), 4.dp.toPx())
+    drawLine(bodyColor, center.copy(x = center.x - size.width * 0.04f, y = center.y + size.height * 0.1f), center.copy(x = center.x - size.width * 0.15f, y = center.y + size.height * 0.24f), 4.dp.toPx())
+    drawLine(bodyColor, center.copy(x = center.x - size.width * 0.04f, y = center.y + size.height * 0.1f), center.copy(x = center.x + size.width * 0.1f, y = center.y + size.height * 0.24f), 4.dp.toPx())
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawLayeredHills(
+    back: Color,
+    front: Color,
+) {
+    val backPath = Path().apply {
+        moveTo(0f, size.height * 0.66f)
+        cubicTo(size.width * 0.2f, size.height * 0.48f, size.width * 0.38f, size.height * 0.72f, size.width * 0.56f, size.height * 0.55f)
+        cubicTo(size.width * 0.75f, size.height * 0.38f, size.width * 0.88f, size.height * 0.58f, size.width, size.height * 0.45f)
+        lineTo(size.width, size.height)
+        lineTo(0f, size.height)
+        close()
+    }
+    drawPath(backPath, back)
+    val frontPath = Path().apply {
+        moveTo(0f, size.height * 0.78f)
+        cubicTo(size.width * 0.18f, size.height * 0.62f, size.width * 0.32f, size.height * 0.84f, size.width * 0.5f, size.height * 0.68f)
+        cubicTo(size.width * 0.7f, size.height * 0.5f, size.width * 0.83f, size.height * 0.78f, size.width, size.height * 0.62f)
+        lineTo(size.width, size.height)
+        lineTo(0f, size.height)
+        close()
+    }
+    drawPath(frontPath, front)
 }
 
 @Composable
@@ -1973,6 +2696,68 @@ private fun FeaturedStationCard(
             textAlign = TextAlign.Center,
             modifier = Modifier.padding(top = 6.dp),
         )
+    }
+}
+
+@Composable
+private fun ForYouStationCard(
+    station: com.shapeshed.aerial.data.RegistryStation,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        onClick = onClick,
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        modifier = modifier.width(112.dp).height(144.dp),
+    ) {
+        Column(
+            verticalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.padding(12.dp).fillMaxSize(),
+        ) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .size(60.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surface),
+            ) {
+                if (station.logoUrl.isNotBlank()) {
+                    AsyncImage(
+                        model = station.logoUrl,
+                        contentDescription = null,
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                } else {
+                    Text(
+                        text = station.name.take(1).uppercase(),
+                        style = MaterialTheme.typography.headlineMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                Text(
+                    text = station.name,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                val genre = station.tags.split(" ").firstOrNull { it.isNotBlank() } ?: station.country
+                if (genre.isNotBlank()) {
+                    Text(
+                        text = genre.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -808,11 +808,16 @@ fun MainScreen(
                             stations = defaultStations,
                             savedStreamUrls = savedStreamUrls,
                             savedRegistryKeys = savedRegistryKeys,
+                            currentStation = currentStation,
+                            isPlaying = isPlaying,
+                            isBuffering = isBuffering,
                             onPlay = { station ->
                                 viewModel.playFromRegistry(station)
                                 textFieldState.edit { replace(0, length, "") }
                                 scope.launch { searchBarState.animateToCollapsed() }
                             },
+                            onPreviewPlay = { viewModel.playFromRegistry(it) },
+                            onTogglePlayback = { viewModel.togglePlayback() },
                             onAdd = { viewModel.addFromRegistry(it) },
                             onRemove = { viewModel.removeFromRegistry(it) },
                         )
@@ -823,11 +828,18 @@ fun MainScreen(
                         results = registrySearchResults,
                         savedStreamUrls = savedStreamUrls,
                         savedRegistryKeys = savedRegistryKeys,
+                        currentStation = currentStation,
+                        isPlaying = isPlaying,
+                        isBuffering = isBuffering,
                         onFavoritePlay = { station ->
                             viewModel.saveRecentSearch(searchQueryText)
                             viewModel.play(station)
                             textFieldState.edit { replace(0, length, "") }
                             scope.launch { searchBarState.animateToCollapsed() }
+                        },
+                        onFavoritePreviewPlay = { station ->
+                            viewModel.saveRecentSearch(searchQueryText)
+                            viewModel.play(station)
                         },
                         onPlay = { station ->
                             viewModel.saveRecentSearch(searchQueryText)
@@ -835,6 +847,11 @@ fun MainScreen(
                             textFieldState.edit { replace(0, length, "") }
                             scope.launch { searchBarState.animateToCollapsed() }
                         },
+                        onPreviewPlay = { station ->
+                            viewModel.saveRecentSearch(searchQueryText)
+                            viewModel.playFromRegistry(station)
+                        },
+                        onTogglePlayback = { viewModel.togglePlayback() },
                         onAdd = { viewModel.addFromRegistry(it) },
                         onRemove = { viewModel.removeFromRegistry(it) },
                         bottomPadding = 0.dp,
@@ -944,7 +961,12 @@ private fun DefaultSearchResults(
     stations: List<RegistryStation>,
     savedStreamUrls: Set<String>,
     savedRegistryKeys: Set<RegistryStationKey>,
+    currentStation: Station?,
+    isPlaying: Boolean,
+    isBuffering: Boolean,
     onPlay: (RegistryStation) -> Unit,
+    onPreviewPlay: (RegistryStation) -> Unit,
+    onTogglePlayback: () -> Unit,
     onAdd: (RegistryStation) -> Unit,
     onRemove: (RegistryStation) -> Unit,
 ) {
@@ -955,15 +977,29 @@ private fun DefaultSearchResults(
             key = { it.id },
             contentType = { "registry-result" },
         ) { station ->
+            val isActive = currentStation.matches(station)
             RegistryResultItem(
                 station = station,
                 alreadySaved = station.streamUrl in savedStreamUrls || station.savedKey() in savedRegistryKeys,
+                isPlaying = isPlaying && isActive,
+                isBuffering = isBuffering && isActive,
                 onTap = { onPlay(station) },
+                onPreviewPlay = { onPreviewPlay(station) },
+                onTogglePlayback = onTogglePlayback,
                 onAdd = { onAdd(station) },
                 onRemove = { onRemove(station) },
             )
         }
     }
+}
+
+// Whether the playing station is this registry entry, matching by stream URL with a
+// provider-key fallback for saved stations whose URL was corrected locally.
+private fun Station?.matches(registryStation: RegistryStation): Boolean {
+    if (this == null) return false
+    if (streamUrl == registryStation.streamUrl) return true
+    val key = registryStation.savedKey() ?: return false
+    return savedKey() == key
 }
 
 @Composable
@@ -1005,8 +1041,14 @@ private fun RegistrySearchResults(
     results: List<RegistryStation>,
     savedStreamUrls: Set<String>,
     savedRegistryKeys: Set<RegistryStationKey>,
+    currentStation: Station?,
+    isPlaying: Boolean,
+    isBuffering: Boolean,
     onFavoritePlay: (Station) -> Unit,
+    onFavoritePreviewPlay: (Station) -> Unit,
     onPlay: (RegistryStation) -> Unit,
+    onPreviewPlay: (RegistryStation) -> Unit,
+    onTogglePlayback: () -> Unit,
     onAdd: (RegistryStation) -> Unit,
     onRemove: (RegistryStation) -> Unit,
     bottomPadding: androidx.compose.ui.unit.Dp,
@@ -1079,9 +1121,15 @@ private fun RegistrySearchResults(
                     key = { "favorite-${it.id}" },
                     contentType = { "favorite-result" },
                 ) { station ->
+                    val isActive = currentStation != null &&
+                        (currentStation.id == station.id || currentStation.streamUrl == station.streamUrl)
                     FavoriteResultItem(
                         station = station,
+                        isPlaying = isPlaying && isActive,
+                        isBuffering = isBuffering && isActive,
                         onTap = { onFavoritePlay(station) },
+                        onPreviewPlay = { onFavoritePreviewPlay(station) },
+                        onTogglePlayback = onTogglePlayback,
                     )
                 }
                 if (results.isNotEmpty()) {
@@ -1101,10 +1149,15 @@ private fun RegistrySearchResults(
                 contentType = { "registry-result" },
             ) { station ->
                 val alreadySaved = station.streamUrl in savedStreamUrls || station.savedKey() in savedRegistryKeys
+                val isActive = currentStation.matches(station)
                 RegistryResultItem(
                     station = station,
                     alreadySaved = alreadySaved,
+                    isPlaying = isPlaying && isActive,
+                    isBuffering = isBuffering && isActive,
                     onTap = { onPlay(station) },
+                    onPreviewPlay = { onPreviewPlay(station) },
+                    onTogglePlayback = onTogglePlayback,
                     onAdd = { onAdd(station) },
                     onRemove = { onRemove(station) },
                 )
@@ -1116,8 +1169,13 @@ private fun RegistrySearchResults(
 @Composable
 private fun FavoriteResultItem(
     station: Station,
+    isPlaying: Boolean,
+    isBuffering: Boolean,
     onTap: () -> Unit,
+    onPreviewPlay: () -> Unit,
+    onTogglePlayback: () -> Unit,
 ) {
+    val pauseLabel = stringResource(R.string.pause)
     val countryLabel = station.countryCode.takeIf { it.isNotBlank() }
         ?.let { countryName(it, LocalConfiguration.current.locales[0]) }
         ?: station.country
@@ -1138,12 +1196,41 @@ private fun FavoriteResultItem(
             }
         } else null,
         trailingContent = {
-            Icon(
-                imageVector = Icons.Rounded.Favorite,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(20.dp),
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                IconButton(
+                    onClick = if (isPlaying) onTogglePlayback else onPreviewPlay,
+                    shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
+                ) {
+                    when {
+                        isBuffering -> CircularWavyProgressIndicator(
+                            modifier = Modifier.size(24.dp),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            trackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+                        )
+                        isPlaying -> EqualizerBars(
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier
+                                .size(width = 28.dp, height = 22.dp)
+                                .semantics { contentDescription = pauseLabel },
+                            barCount = 3,
+                        )
+                        else -> Icon(Icons.Rounded.PlayArrow, contentDescription = stringResource(R.string.play))
+                    }
+                }
+                // Static badge, but sized like the icon buttons in the registry rows so the
+                // play/heart columns align across the whole results list.
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.size(48.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Favorite,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+            }
         },
     ) {
         Text(
@@ -1159,10 +1246,15 @@ private fun FavoriteResultItem(
 private fun RegistryResultItem(
     station: RegistryStation,
     alreadySaved: Boolean,
+    isPlaying: Boolean,
+    isBuffering: Boolean,
     onTap: () -> Unit,
+    onPreviewPlay: () -> Unit,
+    onTogglePlayback: () -> Unit,
     onAdd: () -> Unit,
     onRemove: () -> Unit,
 ) {
+    val pauseLabel = stringResource(R.string.pause)
     // Localize the country from its ISO code (falling back to the registry's own name).
     val countryLabel = station.countryCode.takeIf { it.isNotBlank() }
         ?.let { countryName(it, LocalConfiguration.current.locales[0]) }
@@ -1186,6 +1278,29 @@ private fun RegistryResultItem(
             { Text(countryLabel, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant) }
         } else null,
         trailingContent = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+            // Preview control (mood-row style): plays in place without closing the search
+            // sheet so the station can be auditioned before saving it.
+            IconButton(
+                onClick = if (isPlaying) onTogglePlayback else onPreviewPlay,
+                shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
+            ) {
+                when {
+                    isBuffering -> CircularWavyProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        trackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+                    )
+                    isPlaying -> EqualizerBars(
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .size(width = 28.dp, height = 22.dp)
+                            .semantics { contentDescription = pauseLabel },
+                        barCount = 3,
+                    )
+                    else -> Icon(Icons.Rounded.PlayArrow, contentDescription = stringResource(R.string.play))
+                }
+            }
             IconButton(
                 onClick = if (alreadySaved) onRemove else onAdd,
                 shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
@@ -1196,6 +1311,7 @@ private fun RegistryResultItem(
                     tint = if (alreadySaved) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.size(20.dp),
                 )
+            }
             }
         },
     ) {

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -1170,28 +1170,16 @@ private fun RegistryResultItem(
     ListItem(
         modifier = Modifier.fillMaxWidth().clickable(onClick = onTap),
         leadingContent = {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .size(50.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+            StationLogoCircle(
+                logoModel = station.logoUrl.takeIf { it.isNotBlank() },
+                size = 50.dp,
             ) {
-                if (station.logoUrl.isNotBlank()) {
-                    AsyncImage(
-                        model = station.logoUrl,
-                        contentDescription = null,
-                        contentScale = ContentScale.Fit,
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                } else {
-                    Icon(
-                        imageVector = Icons.Rounded.Radio,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(26.dp),
-                    )
-                }
+                Icon(
+                    imageVector = Icons.Rounded.Radio,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(26.dp),
+                )
             }
         },
         supportingContent = if (countryLabel.isNotBlank()) {
@@ -1353,7 +1341,7 @@ private fun HomeTabContent(
             }
             item("for-you-row") {
                 LazyRow(
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
                     contentPadding = PaddingValues(horizontal = 16.dp),
                 ) {
                     items(
@@ -1667,28 +1655,17 @@ private fun MoodStationRow(
     ListItem(
         modifier = modifier.fillMaxWidth().clickable(onClick = onPlay),
         leadingContent = {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .size(64.dp)
-                    .clip(MaterialTheme.shapes.large)
-                    .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+            // Circle rather than a rounded square, matching the search and favourites rows.
+            StationLogoCircle(
+                logoModel = station.logoUrl.takeIf { it.isNotBlank() },
+                size = 56.dp,
             ) {
-                if (station.logoUrl.isNotBlank()) {
-                    AsyncImage(
-                        model = station.logoUrl,
-                        contentDescription = null,
-                        contentScale = ContentScale.Fit,
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                } else {
-                    Icon(
-                        imageVector = Icons.Rounded.Radio,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(28.dp),
-                    )
-                }
+                Icon(
+                    imageVector = Icons.Rounded.Radio,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(26.dp),
+                )
             }
         },
         supportingContent = {
@@ -2707,43 +2684,32 @@ private fun ForYouStationCard(
 ) {
     Surface(
         onClick = onClick,
-        shape = MaterialTheme.shapes.large,
+        // Tonal, border-less container on the expressive extra-large radius, matching the
+        // app's other tiles.
+        shape = MaterialTheme.shapes.extraLarge,
         color = MaterialTheme.colorScheme.surfaceContainerHigh,
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
-        modifier = modifier.width(112.dp).height(144.dp),
+        modifier = modifier.width(140.dp).height(132.dp),
     ) {
         Column(
             verticalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier.padding(12.dp).fillMaxSize(),
         ) {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .size(60.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surface),
+            StationLogoCircle(
+                logoModel = station.logoUrl.takeIf { it.isNotBlank() },
+                size = 60.dp,
             ) {
-                if (station.logoUrl.isNotBlank()) {
-                    AsyncImage(
-                        model = station.logoUrl,
-                        contentDescription = null,
-                        contentScale = ContentScale.Fit,
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                } else {
-                    Text(
-                        text = station.name.take(1).uppercase(),
-                        style = MaterialTheme.typography.headlineMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
+                Text(
+                    text = station.name.take(1).uppercase(),
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
             Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
                 Text(
                     text = station.name,
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 2,
+                    maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
                 val genre = station.tags.split(" ").firstOrNull { it.isNotBlank() } ?: station.country
@@ -2761,8 +2727,42 @@ private fun ForYouStationCard(
     }
 }
 
+// Circular station logo on a white plate. The plate shows through transparent regions of
+// third-party artwork so every logo sits on a consistent background, and it is never a
+// visible ring because the artwork fills the circle. Stations without a usable logo keep a
+// tonal circle behind the fallback content instead of the white plate.
 @Composable
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+fun StationLogoCircle(
+    logoModel: Any?,
+    size: Dp,
+    modifier: Modifier = Modifier,
+    fallbackBackground: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.surfaceContainerHigh,
+    fallback: @Composable () -> Unit,
+) {
+    var logoFailed by remember(logoModel) { mutableStateOf(false) }
+    val showLogo = logoModel != null && !logoFailed
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(if (showLogo) androidx.compose.ui.graphics.Color.White else fallbackBackground),
+    ) {
+        if (showLogo) {
+            AsyncImage(
+                model = logoModel,
+                contentDescription = null,
+                contentScale = ContentScale.Fit,
+                onError = { logoFailed = true },
+                modifier = Modifier.fillMaxSize(),
+            )
+        } else {
+            fallback()
+        }
+    }
+}
+
+@Composable
 fun StationAvatar(
     station: Station,
     isActive: Boolean,
@@ -2776,36 +2776,22 @@ fun StationAvatar(
         logoPath.isNotEmpty() -> File(logoPath)
         else -> null
     }
-    var logoFailed by remember(logoModel) { mutableStateOf(false) }
-
-    val iconTint = if (isActive) MaterialTheme.colorScheme.onPrimaryContainer
-                   else MaterialTheme.colorScheme.onSurfaceVariant
-
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = modifier
-            .size(size)
-            .clip(CircleShape)
-            .background(
-                if (isActive) MaterialTheme.colorScheme.primaryContainer
-                else MaterialTheme.colorScheme.surfaceContainerHigh,
-            ),
+    val imageRequest = logoModel?.let {
+        remember(context, it) { ImageRequest.Builder(context).data(it).build() }
+    }
+    StationLogoCircle(
+        logoModel = imageRequest,
+        size = size,
+        modifier = modifier,
+        fallbackBackground = if (isActive) MaterialTheme.colorScheme.primaryContainer
+        else MaterialTheme.colorScheme.surfaceContainerHigh,
     ) {
         Icon(
             imageVector = Icons.Rounded.Radio,
             contentDescription = null,
-            tint = iconTint,
+            tint = if (isActive) MaterialTheme.colorScheme.onPrimaryContainer
+            else MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.size(size * 0.55f),
         )
-        if (logoModel != null && !logoFailed) {
-            val imageRequest = remember(context, logoModel) { ImageRequest.Builder(context).data(logoModel).build() }
-            AsyncImage(
-                model = imageRequest,
-                contentDescription = null,
-                contentScale = ContentScale.Fit,
-                onError = { logoFailed = true },
-                modifier = Modifier.fillMaxSize(),
-            )
-        }
     }
 }

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -105,8 +105,14 @@ class MainViewModel(
     private val _featuredStations = MutableStateFlow<List<RegistryStation>>(emptyList())
     val featuredStations: StateFlow<List<RegistryStation>> = _featuredStations.asStateFlow()
 
+    private val _ukForYouStations = MutableStateFlow<List<RegistryStation>>(emptyList())
+    val ukForYouStations: StateFlow<List<RegistryStation>> = _ukForYouStations.asStateFlow()
+
     private val _defaultStations = MutableStateFlow<List<RegistryStation>>(emptyList())
     val defaultStations: StateFlow<List<RegistryStation>> = _defaultStations.asStateFlow()
+
+    private val _curatedMoodStations = MutableStateFlow<Map<String, List<RegistryStation>>>(emptyMap())
+    val curatedMoodStations: StateFlow<Map<String, List<RegistryStation>>> = _curatedMoodStations.asStateFlow()
 
     init {
         viewModelScope.launch {
@@ -122,7 +128,9 @@ class MainViewModel(
                 .distinctUntilChanged()
                 .collect {
                     _featuredStations.value = registryRepository.featuredStations()
+                    _ukForYouStations.value = registryRepository.forYouStations("GB")
                     _defaultStations.value = registryRepository.defaultStations()
+                    _curatedMoodStations.value = registryRepository.curatedMoodStations()
                     _availableCountries.value = registryRepository.availableCountryCodes()
                     _allTags.value = registryRepository.availableTags()
                 }
@@ -330,6 +338,12 @@ class MainViewModel(
         runSearch(_lastSearchQuery)
     }
 
+    fun setCountryFilter(country: String) {
+        _selectedCountries.value = setOf(country)
+        persistFilters()
+        runSearch(_lastSearchQuery)
+    }
+
     fun toggleTagFilter(tag: String) {
         _selectedTags.value = _selectedTags.value.let {
             if (it.contains(tag)) it - tag else it + tag
@@ -386,6 +400,17 @@ class MainViewModel(
         viewModelScope.launch {
             val station = withContext(Dispatchers.IO) {
                 registryRepository.randomByCategory(tag.lowercase())
+            } ?: return@launch
+            playFromRegistry(station)
+        }
+    }
+
+    fun playRandomFromMood(tags: List<String>) {
+        viewModelScope.launch {
+            val station = withContext(Dispatchers.IO) {
+                tags.shuffled().firstNotNullOfOrNull { tag ->
+                    registryRepository.randomByCategory(tag.lowercase())
+                }
             } ?: return@launch
             playFromRegistry(station)
         }

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -34,6 +34,9 @@ import androidx.core.content.ContextCompat
 import com.shapeshed.aerial.AerialApp
 import com.shapeshed.aerial.PlayerService
 import com.shapeshed.aerial.R
+import com.shapeshed.aerial.FAVORITES_GRID_COLUMNS_DEFAULT
+import com.shapeshed.aerial.FAVORITES_GRID_COLUMNS_KEY
+import com.shapeshed.aerial.FAVORITES_GRID_COLUMNS_RANGE
 import com.shapeshed.aerial.SHOW_STREAM_BITRATE_KEY
 import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_CANCEL
 import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_SET
@@ -105,8 +108,16 @@ class MainViewModel(
     private val _featuredStations = MutableStateFlow<List<RegistryStation>>(emptyList())
     val featuredStations: StateFlow<List<RegistryStation>> = _featuredStations.asStateFlow()
 
-    private val _ukForYouStations = MutableStateFlow<List<RegistryStation>>(emptyList())
-    val ukForYouStations: StateFlow<List<RegistryStation>> = _ukForYouStations.asStateFlow()
+    // For You is loaded for the device locale's country: a curated selection where one
+    // exists, otherwise a random sample of that country's stations with artwork. Keyed by
+    // country (distinctUntilChanged below) so the random pick stays stable for the session.
+    private val _forYouCountry = MutableStateFlow("GB")
+    private val _forYouStations = MutableStateFlow<List<RegistryStation>>(emptyList())
+    val forYouStations: StateFlow<List<RegistryStation>> = _forYouStations.asStateFlow()
+
+    fun setForYouCountry(countryCode: String) {
+        if (countryCode.isNotBlank()) _forYouCountry.value = countryCode
+    }
 
     private val _defaultStations = MutableStateFlow<List<RegistryStation>>(emptyList())
     val defaultStations: StateFlow<List<RegistryStation>> = _defaultStations.asStateFlow()
@@ -128,11 +139,20 @@ class MainViewModel(
                 .distinctUntilChanged()
                 .collect {
                     _featuredStations.value = registryRepository.featuredStations()
-                    _ukForYouStations.value = registryRepository.forYouStations("GB")
                     _defaultStations.value = registryRepository.defaultStations()
                     _curatedMoodStations.value = registryRepository.curatedMoodStations()
                     _availableCountries.value = registryRepository.availableCountryCodes()
                     _allTags.value = registryRepository.availableTags()
+                }
+        }
+        viewModelScope.launch {
+            combine(
+                registryRepository.countAsFlow().filter { it > 0 }.distinctUntilChanged(),
+                _forYouCountry,
+            ) { _, country -> country }
+                .distinctUntilChanged()
+                .collect { country ->
+                    _forYouStations.value = registryRepository.forYouStations(country)
                 }
         }
         viewModelScope.launch {
@@ -296,6 +316,13 @@ class MainViewModel(
     val showStreamBitrate: StateFlow<Boolean> = dataStore.data
         .map { prefs -> prefs[SHOW_STREAM_BITRATE_KEY] ?: false }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    val favoritesGridColumns: StateFlow<Int> = dataStore.data
+        .map { prefs ->
+            (prefs[FAVORITES_GRID_COLUMNS_KEY] ?: FAVORITES_GRID_COLUMNS_DEFAULT)
+                .coerceIn(FAVORITES_GRID_COLUMNS_RANGE)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FAVORITES_GRID_COLUMNS_DEFAULT)
 
     fun setHomeViewMode(mode: HomeViewMode) {
         viewModelScope.launch {

--- a/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
@@ -477,12 +477,17 @@ fun NowPlayingScreen(
                             modifier = Modifier.size(52.dp),
                         ) {
                             if (trackArtworkModel != null && !trackArtworkFailed) {
+                                // Same light adaptive plate as the other artwork surfaces,
+                                // visible only through transparent artwork.
                                 AsyncImage(
                                     model = trackArtworkModel,
                                     contentDescription = null,
                                     contentScale = ContentScale.Crop,
                                     onError = { trackArtworkFailed = true },
-                                    modifier = Modifier.fillMaxSize(),
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .clip(MaterialTheme.shapes.small)
+                                        .background(stationLogoPlateColor()),
                                 )
                             } else {
                                 Surface(
@@ -594,7 +599,12 @@ fun NowPlayingScreen(
             ) {
                 Surface(
                     shape = MaterialTheme.shapes.extraLarge,
-                    color = MaterialTheme.colorScheme.primaryContainer,
+                    // Plate behind rendered artwork, matching the main artwork surface.
+                    color = if (trackArtworkModel != null && !trackArtworkFailed) {
+                        stationLogoPlateColor()
+                    } else {
+                        MaterialTheme.colorScheme.primaryContainer
+                    },
                     tonalElevation = 4.dp,
                     modifier = Modifier
                         .fillMaxWidth()
@@ -690,11 +700,11 @@ private fun StationArtworkSurface(
 ) {
     Surface(
         shape = shape,
-        // White behind rendered artwork so transparent station logos (and letterboxed
-        // images) sit on a consistent plate; the tonal container shows only for the
-        // avatar fallback.
+        // Light palette-tinted plate behind rendered artwork so transparent station logos
+        // (and letterboxed images) sit on a consistent background; the tonal container
+        // shows only for the avatar fallback.
         color = if (artworkModel != null) {
-            androidx.compose.ui.graphics.Color.White
+            stationLogoPlateColor()
         } else {
             MaterialTheme.colorScheme.primaryContainer
         },

--- a/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
@@ -86,6 +86,17 @@ import com.shapeshed.aerial.R
 import com.shapeshed.aerial.data.NowPlayingInfo
 import com.shapeshed.aerial.data.SleepTimerState
 import com.shapeshed.aerial.data.Station
+import kotlin.math.abs
+
+private fun Station.matchesStation(other: Station): Boolean =
+    (id != 0L && id == other.id) ||
+        streamUrl == other.streamUrl ||
+        (provider.isNotBlank() &&
+            providerId.isNotBlank() &&
+            provider == other.provider &&
+            providerId == other.providerId)
+
+private fun circularPageIndex(page: Int, size: Int): Int = ((page % size) + size) % size
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -115,8 +126,8 @@ fun NowPlayingScreen(
     var dragOffsetY by remember { mutableFloatStateOf(0f) }
     // Horizontal paging steps through swipeStations (the favourites in their selected sort
     // order). A non-favourite station isn't in the list, so the artwork stays static for it.
-    val swipeIndex = remember(swipeStations, station.id) {
-        swipeStations.indexOfFirst { it.id == station.id }
+    val swipeIndex = remember(swipeStations, station) {
+        swipeStations.indexOfFirst { it.matchesStation(station) }
     }
     var showTrackDetail by remember { mutableStateOf(false) }
     var showSleepTimer by remember { mutableStateOf(false) }
@@ -247,27 +258,36 @@ fun NowPlayingScreen(
                     // Real pager over the frozen favourites order: the neighbour's artwork is a
                     // prepared page that slides in with the finger; settling switches playback.
                     // The rest of the pane stays static.
-                    val pagerState = rememberPagerState(initialPage = swipeIndex) { swipeStations.size }
+                    val virtualPageCount = Int.MAX_VALUE
+                    val initialPage = remember(swipeStations, swipeIndex) {
+                        val midpoint = virtualPageCount / 2
+                        midpoint - circularPageIndex(midpoint, swipeStations.size) + swipeIndex
+                    }
+                    val pagerState = rememberPagerState(initialPage = initialPage) { virtualPageCount }
                     LaunchedEffect(pagerState.settledPage) {
-                        val target = swipeStations.getOrNull(pagerState.settledPage) ?: return@LaunchedEffect
-                        if (target.id != station.id) onPlayStation(target)
+                        val target = swipeStations[circularPageIndex(pagerState.settledPage, swipeStations.size)]
+                        if (!target.matchesStation(station)) onPlayStation(target)
                     }
                     // Keep the pager in step when the station changes some other way (e.g. the
                     // media notification or a tap on the favourites grid behind the pane).
                     LaunchedEffect(swipeIndex) {
-                        if (pagerState.currentPage != swipeIndex && !pagerState.isScrollInProgress) {
-                            pagerState.animateScrollToPage(swipeIndex)
+                        val currentIndex = circularPageIndex(pagerState.currentPage, swipeStations.size)
+                        if (currentIndex != swipeIndex && !pagerState.isScrollInProgress) {
+                            val forwardDelta = circularPageIndex(swipeIndex - currentIndex, swipeStations.size)
+                            val backwardDelta = forwardDelta - swipeStations.size
+                            val delta = if (abs(backwardDelta) < forwardDelta) backwardDelta else forwardDelta
+                            pagerState.animateScrollToPage(pagerState.currentPage + delta)
                         }
                     }
                     HorizontalPager(
                         state = pagerState,
                         pageSpacing = 24.dp,
                     ) { page ->
-                        val pageStation = swipeStations[page]
+                        val pageStation = swipeStations[circularPageIndex(page, swipeStations.size)]
                         StationArtworkSurface(
                             station = pageStation,
                             shape = artworkShape,
-                            artworkModel = mainArtworkModel.takeIf { pageStation.id == station.id && !mainArtworkFailed },
+                            artworkModel = mainArtworkModel.takeIf { pageStation.matchesStation(station) && !mainArtworkFailed },
                             onArtworkError = { mainArtworkFailed = true },
                         )
                     }

--- a/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
@@ -690,7 +690,14 @@ private fun StationArtworkSurface(
 ) {
     Surface(
         shape = shape,
-        color = MaterialTheme.colorScheme.primaryContainer,
+        // White behind rendered artwork so transparent station logos (and letterboxed
+        // images) sit on a consistent plate; the tonal container shows only for the
+        // avatar fallback.
+        color = if (artworkModel != null) {
+            androidx.compose.ui.graphics.Color.White
+        } else {
+            MaterialTheme.colorScheme.primaryContainer
+        },
         tonalElevation = 8.dp,
         modifier = modifier
             .fillMaxWidth()

--- a/app/src/main/java/com/shapeshed/aerial/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/SettingsScreen.kt
@@ -3,8 +3,12 @@ package com.shapeshed.aerial.ui
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
@@ -20,11 +24,15 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.IconButtonShapes
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ButtonGroup
+import androidx.compose.material3.ButtonGroupDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.ToggleButton
+import androidx.compose.material3.ToggleButtonDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -38,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import android.os.Build
 import com.shapeshed.aerial.BuildConfig
+import com.shapeshed.aerial.FAVORITES_GRID_COLUMNS_RANGE
 import com.shapeshed.aerial.R
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -49,6 +58,9 @@ fun SettingsScreen(
     val context = LocalContext.current
     val enrichMetadata by viewModel.enrichMetadata.collectAsStateWithLifecycle()
     val showStreamBitrate by viewModel.showStreamBitrate.collectAsStateWithLifecycle()
+    val registryStationCount by viewModel.registryStationCount.collectAsStateWithLifecycle()
+    val registryCountryCount by viewModel.registryCountryCount.collectAsStateWithLifecycle()
+    val favoritesGridColumns by viewModel.favoritesGridColumns.collectAsStateWithLifecycle()
     val versionName = BuildConfig.VERSION_NAME
     val snackbarHostState = remember { SnackbarHostState() }
     val exportLauncher = rememberLauncherForActivityResult(
@@ -117,6 +129,46 @@ fun SettingsScreen(
                 }
                 HorizontalDivider()
             }
+            item(contentType = "setting") {
+                ListItem(
+                    supportingContent = {
+                        Column {
+                            Text(stringResource(R.string.favorites_grid_columns_desc))
+                            Spacer(Modifier.height(10.dp))
+                            // Connected button group — the expressive successor to segmented
+                            // buttons, and the same component as the cards/list switcher.
+                            ButtonGroup(
+                                overflowIndicator = {},
+                                horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween),
+                            ) {
+                                val options = FAVORITES_GRID_COLUMNS_RANGE.toList()
+                                options.forEachIndexed { index, columns ->
+                                    customItem(
+                                        buttonGroupContent = {
+                                            ToggleButton(
+                                                checked = favoritesGridColumns == columns,
+                                                onCheckedChange = { if (it) viewModel.setFavoritesGridColumns(columns) },
+                                                shapes = when (index) {
+                                                    0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
+                                                    options.lastIndex -> ButtonGroupDefaults.connectedTrailingButtonShapes()
+                                                    else -> ButtonGroupDefaults.connectedMiddleButtonShapes()
+                                                },
+                                                colors = ToggleButtonDefaults.tonalToggleButtonColors(),
+                                            ) {
+                                                Text(columns.toString())
+                                            }
+                                        },
+                                        menuContent = {},
+                                    )
+                                }
+                            }
+                        }
+                    },
+                ) {
+                    Text(stringResource(R.string.favorites_grid_columns))
+                }
+                HorizontalDivider()
+            }
             // In-app language picker only for pre-Android-13; 13+ uses the system per-app setting.
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
                 item(contentType = "setting") {
@@ -161,6 +213,21 @@ fun SettingsScreen(
                 HorizontalDivider()
             }
             item(contentType = "footer") {
+                val numberFormat = remember { java.text.NumberFormat.getIntegerInstance() }
+                Text(
+                    text = stringResource(
+                        R.string.stats_summary,
+                        numberFormat.format(registryStationCount),
+                        numberFormat.format(registryCountryCount),
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp)
+                        .padding(top = 24.dp),
+                )
                 Text(
                     text = stringResource(R.string.version_format, versionName),
                     style = MaterialTheme.typography.bodySmall,
@@ -168,7 +235,7 @@ fun SettingsScreen(
                     textAlign = TextAlign.Center,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(vertical = 24.dp),
+                        .padding(top = 12.dp, bottom = 24.dp),
                 )
             }
         }

--- a/app/src/main/java/com/shapeshed/aerial/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/SettingsScreen.kt
@@ -58,8 +58,6 @@ fun SettingsScreen(
     val context = LocalContext.current
     val enrichMetadata by viewModel.enrichMetadata.collectAsStateWithLifecycle()
     val showStreamBitrate by viewModel.showStreamBitrate.collectAsStateWithLifecycle()
-    val registryStationCount by viewModel.registryStationCount.collectAsStateWithLifecycle()
-    val registryCountryCount by viewModel.registryCountryCount.collectAsStateWithLifecycle()
     val favoritesGridColumns by viewModel.favoritesGridColumns.collectAsStateWithLifecycle()
     val versionName = BuildConfig.VERSION_NAME
     val snackbarHostState = remember { SnackbarHostState() }
@@ -213,21 +211,6 @@ fun SettingsScreen(
                 HorizontalDivider()
             }
             item(contentType = "footer") {
-                val numberFormat = remember { java.text.NumberFormat.getIntegerInstance() }
-                Text(
-                    text = stringResource(
-                        R.string.stats_summary,
-                        numberFormat.format(registryStationCount),
-                        numberFormat.format(registryCountryCount),
-                    ),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 24.dp)
-                        .padding(top = 24.dp),
-                )
                 Text(
                     text = stringResource(R.string.version_format, versionName),
                     style = MaterialTheme.typography.bodySmall,
@@ -235,7 +218,7 @@ fun SettingsScreen(
                     textAlign = TextAlign.Center,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(top = 12.dp, bottom = 24.dp),
+                        .padding(vertical = 24.dp),
                 )
             }
         }

--- a/app/src/main/java/com/shapeshed/aerial/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/SettingsViewModel.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.shapeshed.aerial.AerialApp
 import com.shapeshed.aerial.ENRICH_METADATA_KEY
 import com.shapeshed.aerial.FAVORITES_GRID_COLUMNS_DEFAULT
 import com.shapeshed.aerial.FAVORITES_GRID_COLUMNS_KEY
@@ -28,10 +27,7 @@ import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -67,24 +63,6 @@ class SettingsViewModel(
 
     private val _messages = MutableSharedFlow<String>()
     val messages: SharedFlow<String> = _messages
-
-    // Registry statistics for the settings screen; loaded once, the bundled registry
-    // doesn't change within a session.
-    private val _registryStationCount = MutableStateFlow(0)
-    val registryStationCount: StateFlow<Int> = _registryStationCount.asStateFlow()
-
-    private val _registryCountryCount = MutableStateFlow(0)
-    val registryCountryCount: StateFlow<Int> = _registryCountryCount.asStateFlow()
-
-    init {
-        viewModelScope.launch {
-            val registryRepository = getApplication<AerialApp>().registryRepository
-            withContext(Dispatchers.IO) {
-                _registryStationCount.value = registryRepository.count()
-                _registryCountryCount.value = registryRepository.availableCountryCodes().size
-            }
-        }
-    }
 
     fun setEnrichMetadata(enabled: Boolean) {
         viewModelScope.launch {

--- a/app/src/main/java/com/shapeshed/aerial/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/SettingsViewModel.kt
@@ -10,7 +10,11 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.shapeshed.aerial.AerialApp
 import com.shapeshed.aerial.ENRICH_METADATA_KEY
+import com.shapeshed.aerial.FAVORITES_GRID_COLUMNS_DEFAULT
+import com.shapeshed.aerial.FAVORITES_GRID_COLUMNS_KEY
+import com.shapeshed.aerial.FAVORITES_GRID_COLUMNS_RANGE
 import com.shapeshed.aerial.SHOW_STREAM_BITRATE_KEY
 import com.shapeshed.aerial.data.Station
 import com.shapeshed.aerial.data.StationRepository
@@ -24,7 +28,10 @@ import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -48,8 +55,36 @@ class SettingsViewModel(
         .map { it[SHOW_STREAM_BITRATE_KEY] ?: false }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
+    val favoritesGridColumns = dataStore.data
+        .map { (it[FAVORITES_GRID_COLUMNS_KEY] ?: FAVORITES_GRID_COLUMNS_DEFAULT).coerceIn(FAVORITES_GRID_COLUMNS_RANGE) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FAVORITES_GRID_COLUMNS_DEFAULT)
+
+    fun setFavoritesGridColumns(columns: Int) {
+        viewModelScope.launch {
+            dataStore.edit { it[FAVORITES_GRID_COLUMNS_KEY] = columns.coerceIn(FAVORITES_GRID_COLUMNS_RANGE) }
+        }
+    }
+
     private val _messages = MutableSharedFlow<String>()
     val messages: SharedFlow<String> = _messages
+
+    // Registry statistics for the settings screen; loaded once, the bundled registry
+    // doesn't change within a session.
+    private val _registryStationCount = MutableStateFlow(0)
+    val registryStationCount: StateFlow<Int> = _registryStationCount.asStateFlow()
+
+    private val _registryCountryCount = MutableStateFlow(0)
+    val registryCountryCount: StateFlow<Int> = _registryCountryCount.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            val registryRepository = getApplication<AerialApp>().registryRepository
+            withContext(Dispatchers.IO) {
+                _registryStationCount.value = registryRepository.count()
+                _registryCountryCount.value = registryRepository.availableCountryCodes().size
+            }
+        }
+    }
 
     fun setEnrichMetadata(enabled: Boolean) {
         viewModelScope.launch {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -9,6 +9,7 @@
     <string name="action_clear">Löschen</string>
     <string name="action_save">Speichern</string>
     <string name="action_edit">Bearbeiten</string>
+    <string name="save_all">Alle speichern</string>
 
     <!-- Search / home -->
     <string name="search_hint">Sender suchen</string>
@@ -35,12 +36,28 @@
     <string name="home_view_cards">Karten</string>
     <string name="home_view_list">Liste</string>
     <string name="search_stations_header">Stationen</string>
+    <string name="for_you_country">Für dich — %1$s</string>
+    <string name="view_all">Alle anzeigen</string>
     <string name="get_started">Loslegen</string>
     <string name="just_listen">Einfach zuhören</string>
     <string name="find_a_station">Sender finden</string>
     <string name="find_one_to_listen">Finde einen zum Anhören</string>
     <string name="no_matches">Keine Treffer</string>
     <string name="no_matches_desc">Versuche eine andere Suche.</string>
+    <string name="listen_by_mood">Nach Stimmung hören</string>
+    <string name="mood_relax">Entspannen</string>
+    <string name="mood_relax_desc">Abschalten und loslassen</string>
+    <string name="mood_relax_detail_desc">Entschleunige mit Ambient, Jazz und sanfter Musik aus aller Welt.</string>
+    <string name="mood_focus">Fokus</string>
+    <string name="mood_focus_desc">Konzentriert und produktiv bleiben</string>
+    <string name="mood_morning">Morgen</string>
+    <string name="mood_morning_desc">Positiv in den Tag starten</string>
+    <string name="mood_driving">Fahren</string>
+    <string name="mood_driving_desc">Gute Begleitung für unterwegs</string>
+    <string name="mood_late_night">Späte Nacht</string>
+    <string name="mood_late_night_desc">Musik für ruhige Stunden</string>
+    <string name="mood_workout">Workout</string>
+    <string name="mood_workout_desc">Energie zum Weitermachen</string>
 
     <!-- Now playing -->
     <string name="close_player">Player schließen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Aerial</string>
-
     <!-- Common actions -->
     <string name="action_back">Zurück</string>
     <string name="action_remove">Entfernen</string>
@@ -10,7 +9,6 @@
     <string name="action_save">Speichern</string>
     <string name="action_edit">Bearbeiten</string>
     <string name="save_all">Alle speichern</string>
-
     <!-- Search / home -->
     <string name="search_hint">Sender suchen</string>
     <string name="clear_search">Suche löschen</string>
@@ -36,15 +34,13 @@
     <string name="home_view_cards">Karten</string>
     <string name="home_view_list">Liste</string>
     <string name="search_stations_header">Stationen</string>
-    <string name="for_you_country">Für dich — %1$s</string>
     <string name="view_all">Alle anzeigen</string>
-    <string name="get_started">Loslegen</string>
     <string name="just_listen">Einfach zuhören</string>
     <string name="find_a_station">Sender finden</string>
     <string name="find_one_to_listen">Finde einen zum Anhören</string>
     <string name="no_matches">Keine Treffer</string>
     <string name="no_matches_desc">Versuche eine andere Suche.</string>
-    <string name="listen_by_mood">Nach Stimmung hören</string>
+    <string name="listen_by_mood">Passend zu deiner Stimmung</string>
     <string name="mood_relax">Entspannen</string>
     <string name="mood_relax_desc">Abschalten und loslassen</string>
     <string name="mood_relax_detail_desc">Entschleunige mit Ambient, Jazz und sanfter Musik aus aller Welt.</string>
@@ -58,14 +54,12 @@
     <string name="mood_late_night_desc">Musik für ruhige Stunden</string>
     <string name="mood_workout">Workout</string>
     <string name="mood_workout_desc">Energie zum Weitermachen</string>
-
     <!-- Now playing -->
     <string name="close_player">Player schließen</string>
     <string name="add_to_favorites">Zu Favoriten hinzufügen</string>
     <string name="share_station">Sender teilen</string>
     <string name="copy_track_info">Titelinfo kopieren</string>
     <string name="stream_bitrate_format">%1$d kbps</string>
-
     <!-- Settings -->
     <string name="show_whats_playing">Aktuellen Titel anzeigen</string>
     <string name="show_whats_playing_desc">Zeigt Titel, Interpret und Cover an, falls verfügbar</string>
@@ -79,7 +73,6 @@
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Sprache</string>
     <string name="language_system_default">Systemstandard</string>
-
     <!-- Station edit -->
     <string name="edit_station">Sender bearbeiten</string>
     <string name="add_station">Sender hinzufügen</string>
@@ -90,7 +83,6 @@
     <string name="remove_icon_message">Das Sendersymbol wird entfernt.</string>
     <string name="field_name">Name</string>
     <string name="field_stream_url">Stream-URL</string>
-
     <!-- Sleep timer -->
     <string name="sleep_timer">Sleep-Timer</string>
     <string name="sleep_add_15">+15 Min</string>
@@ -116,4 +108,8 @@
     <string name="sort_az">A bis Z</string>
     <string name="sort_last_played">Zuletzt gespielt</string>
     <string name="sort_most_played">Am häufigsten gespielt</string>
+    <string name="for_you">Für dich</string>
+    <string name="favorites_grid_columns">Rasterbreite der Favoriten</string>
+    <string name="favorites_grid_columns_desc">Spalten in der Kartenansicht</string>
+    <string name="stats_summary">%1$s Sender aus %2$s Ländern. Senderdaten stammen von radio-browser.info und weiteren Anbietern.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -111,5 +111,4 @@
     <string name="for_you">Für dich</string>
     <string name="favorites_grid_columns">Rasterbreite der Favoriten</string>
     <string name="favorites_grid_columns_desc">Spalten in der Kartenansicht</string>
-    <string name="stats_summary">%1$s Sender aus %2$s Ländern. Senderdaten stammen von radio-browser.info und weiteren Anbietern.</string>
 </resources>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -15,4 +15,7 @@
     <string name="sort_az">A to Z</string>
     <string name="sort_last_played">Last played</string>
     <string name="sort_most_played">Most played</string>
+    <string name="for_you">For you</string>
+    <string name="favorites_grid_columns">Favourites grid width</string>
+    <string name="favorites_grid_columns_desc">Columns shown in the cards view</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -111,5 +111,4 @@
     <string name="for_you">Para ti</string>
     <string name="favorites_grid_columns">Ancho de la cuadrícula de favoritos</string>
     <string name="favorites_grid_columns_desc">Columnas en la vista de tarjetas</string>
-    <string name="stats_summary">%1$s emisoras de %2$s países. Los datos provienen de radio-browser.info y otros proveedores de emisoras.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Aerial</string>
-
     <!-- Common actions -->
     <string name="action_back">Atrás</string>
     <string name="action_remove">Quitar</string>
@@ -10,7 +9,6 @@
     <string name="action_save">Guardar</string>
     <string name="action_edit">Editar</string>
     <string name="save_all">Guardar todo</string>
-
     <!-- Search / home -->
     <string name="search_hint">Buscar emisoras</string>
     <string name="clear_search">Borrar búsqueda</string>
@@ -36,15 +34,13 @@
     <string name="home_view_cards">Tarjetas</string>
     <string name="home_view_list">Lista</string>
     <string name="search_stations_header">Emisoras</string>
-    <string name="for_you_country">Para ti — %1$s</string>
     <string name="view_all">Ver todo</string>
-    <string name="get_started">Empezar</string>
     <string name="just_listen">Solo escucha</string>
     <string name="find_a_station">Buscar una emisora</string>
     <string name="find_one_to_listen">Encuentra una para escuchar</string>
     <string name="no_matches">Sin resultados</string>
     <string name="no_matches_desc">Prueba otra búsqueda.</string>
-    <string name="listen_by_mood">Escuchar según el ánimo</string>
+    <string name="listen_by_mood">Según tu estado de ánimo</string>
     <string name="mood_relax">Relajarse</string>
     <string name="mood_relax_desc">Desconecta y déjate llevar</string>
     <string name="mood_relax_detail_desc">Baja el ritmo con ambient, jazz y música suave de todo el mundo.</string>
@@ -58,14 +54,12 @@
     <string name="mood_late_night_desc">Música para las horas tranquilas</string>
     <string name="mood_workout">Entreno</string>
     <string name="mood_workout_desc">Energía para seguir</string>
-
     <!-- Now playing -->
     <string name="close_player">Cerrar reproductor</string>
     <string name="add_to_favorites">Añadir a favoritos</string>
     <string name="share_station">Compartir emisora</string>
     <string name="copy_track_info">Copiar info de la pista</string>
     <string name="stream_bitrate_format">%1$d kbps</string>
-
     <!-- Settings -->
     <string name="show_whats_playing">Mostrar qué suena</string>
     <string name="show_whats_playing_desc">Muestra la canción, el artista y la portada cuando estén disponibles</string>
@@ -79,7 +73,6 @@
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Idioma</string>
     <string name="language_system_default">Predeterminado del sistema</string>
-
     <!-- Station edit -->
     <string name="edit_station">Editar emisora</string>
     <string name="add_station">Añadir emisora</string>
@@ -90,7 +83,6 @@
     <string name="remove_icon_message">Se quitará el icono de la emisora.</string>
     <string name="field_name">Nombre</string>
     <string name="field_stream_url">URL de emisión</string>
-
     <!-- Sleep timer -->
     <string name="sleep_timer">Temporizador</string>
     <string name="sleep_add_15">+15 min</string>
@@ -116,4 +108,8 @@
     <string name="sort_az">De la A a la Z</string>
     <string name="sort_last_played">Reproducida recientemente</string>
     <string name="sort_most_played">Más reproducida</string>
+    <string name="for_you">Para ti</string>
+    <string name="favorites_grid_columns">Ancho de la cuadrícula de favoritos</string>
+    <string name="favorites_grid_columns_desc">Columnas en la vista de tarjetas</string>
+    <string name="stats_summary">%1$s emisoras de %2$s países. Los datos provienen de radio-browser.info y otros proveedores de emisoras.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -9,6 +9,7 @@
     <string name="action_clear">Borrar</string>
     <string name="action_save">Guardar</string>
     <string name="action_edit">Editar</string>
+    <string name="save_all">Guardar todo</string>
 
     <!-- Search / home -->
     <string name="search_hint">Buscar emisoras</string>
@@ -35,12 +36,28 @@
     <string name="home_view_cards">Tarjetas</string>
     <string name="home_view_list">Lista</string>
     <string name="search_stations_header">Emisoras</string>
+    <string name="for_you_country">Para ti — %1$s</string>
+    <string name="view_all">Ver todo</string>
     <string name="get_started">Empezar</string>
     <string name="just_listen">Solo escucha</string>
     <string name="find_a_station">Buscar una emisora</string>
     <string name="find_one_to_listen">Encuentra una para escuchar</string>
     <string name="no_matches">Sin resultados</string>
     <string name="no_matches_desc">Prueba otra búsqueda.</string>
+    <string name="listen_by_mood">Escuchar según el ánimo</string>
+    <string name="mood_relax">Relajarse</string>
+    <string name="mood_relax_desc">Desconecta y déjate llevar</string>
+    <string name="mood_relax_detail_desc">Baja el ritmo con ambient, jazz y música suave de todo el mundo.</string>
+    <string name="mood_focus">Concentración</string>
+    <string name="mood_focus_desc">Concéntrate y sé productivo</string>
+    <string name="mood_morning">Mañana</string>
+    <string name="mood_morning_desc">Empieza el día con energía</string>
+    <string name="mood_driving">Conduciendo</string>
+    <string name="mood_driving_desc">Buena compañía para la ruta</string>
+    <string name="mood_late_night">Noche</string>
+    <string name="mood_late_night_desc">Música para las horas tranquilas</string>
+    <string name="mood_workout">Entreno</string>
+    <string name="mood_workout_desc">Energía para seguir</string>
 
     <!-- Now playing -->
     <string name="close_player">Cerrar reproductor</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Aerial</string>
-
     <!-- Common actions -->
     <string name="action_back">Retour</string>
     <string name="action_remove">Supprimer</string>
@@ -10,7 +9,6 @@
     <string name="action_save">Enregistrer</string>
     <string name="action_edit">Modifier</string>
     <string name="save_all">Tout enregistrer</string>
-
     <!-- Search / home -->
     <string name="search_hint">Rechercher des stations</string>
     <string name="clear_search">Effacer la recherche</string>
@@ -36,15 +34,13 @@
     <string name="home_view_cards">Cartes</string>
     <string name="home_view_list">Liste</string>
     <string name="search_stations_header">Stations</string>
-    <string name="for_you_country">Pour vous — %1$s</string>
     <string name="view_all">Tout voir</string>
-    <string name="get_started">Commencer</string>
     <string name="just_listen">Écoutez, tout simplement</string>
     <string name="find_a_station">Trouver une station</string>
     <string name="find_one_to_listen">Trouvez-en une à écouter</string>
     <string name="no_matches">Aucun résultat</string>
     <string name="no_matches_desc">Essayez une autre recherche.</string>
-    <string name="listen_by_mood">Écouter selon l’humeur</string>
+    <string name="listen_by_mood">Selon votre humeur</string>
     <string name="mood_relax">Détente</string>
     <string name="mood_relax_desc">Décompressez et lâchez prise</string>
     <string name="mood_relax_detail_desc">Ralentissez avec de l’ambient, du jazz et des musiques douces du monde entier.</string>
@@ -58,14 +54,12 @@
     <string name="mood_late_night_desc">Musique pour les heures calmes</string>
     <string name="mood_workout">Entraînement</string>
     <string name="mood_workout_desc">De l’énergie pour continuer</string>
-
     <!-- Now playing -->
     <string name="close_player">Fermer le lecteur</string>
     <string name="add_to_favorites">Ajouter aux favoris</string>
     <string name="share_station">Partager la station</string>
     <string name="copy_track_info">Copier les infos du titre</string>
     <string name="stream_bitrate_format">%1$d kbps</string>
-
     <!-- Settings -->
     <string name="show_whats_playing">Afficher le titre en cours</string>
     <string name="show_whats_playing_desc">Affiche le morceau, l\'artiste et la pochette lorsque disponibles</string>
@@ -79,7 +73,6 @@
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Langue</string>
     <string name="language_system_default">Par défaut du système</string>
-
     <!-- Station edit -->
     <string name="edit_station">Modifier la station</string>
     <string name="add_station">Ajouter une station</string>
@@ -90,7 +83,6 @@
     <string name="remove_icon_message">L\'icône de la station sera supprimée.</string>
     <string name="field_name">Nom</string>
     <string name="field_stream_url">URL du flux</string>
-
     <!-- Sleep timer -->
     <string name="sleep_timer">Minuteur de veille</string>
     <string name="sleep_add_15">+15 min</string>
@@ -116,4 +108,8 @@
     <string name="sort_az">De A à Z</string>
     <string name="sort_last_played">Écoutée récemment</string>
     <string name="sort_most_played">La plus écoutée</string>
+    <string name="for_you">Pour vous</string>
+    <string name="favorites_grid_columns">Largeur de la grille des favoris</string>
+    <string name="favorites_grid_columns_desc">Colonnes dans la vue en cartes</string>
+    <string name="stats_summary">%1$s stations de %2$s pays. Les données proviennent de radio-browser.info et d\'autres fournisseurs de stations.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -111,5 +111,4 @@
     <string name="for_you">Pour vous</string>
     <string name="favorites_grid_columns">Largeur de la grille des favoris</string>
     <string name="favorites_grid_columns_desc">Colonnes dans la vue en cartes</string>
-    <string name="stats_summary">%1$s stations de %2$s pays. Les données proviennent de radio-browser.info et d\'autres fournisseurs de stations.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -9,6 +9,7 @@
     <string name="action_clear">Effacer</string>
     <string name="action_save">Enregistrer</string>
     <string name="action_edit">Modifier</string>
+    <string name="save_all">Tout enregistrer</string>
 
     <!-- Search / home -->
     <string name="search_hint">Rechercher des stations</string>
@@ -35,12 +36,28 @@
     <string name="home_view_cards">Cartes</string>
     <string name="home_view_list">Liste</string>
     <string name="search_stations_header">Stations</string>
+    <string name="for_you_country">Pour vous — %1$s</string>
+    <string name="view_all">Tout voir</string>
     <string name="get_started">Commencer</string>
     <string name="just_listen">Écoutez, tout simplement</string>
     <string name="find_a_station">Trouver une station</string>
     <string name="find_one_to_listen">Trouvez-en une à écouter</string>
     <string name="no_matches">Aucun résultat</string>
     <string name="no_matches_desc">Essayez une autre recherche.</string>
+    <string name="listen_by_mood">Écouter selon l’humeur</string>
+    <string name="mood_relax">Détente</string>
+    <string name="mood_relax_desc">Décompressez et lâchez prise</string>
+    <string name="mood_relax_detail_desc">Ralentissez avec de l’ambient, du jazz et des musiques douces du monde entier.</string>
+    <string name="mood_focus">Concentration</string>
+    <string name="mood_focus_desc">Restez concentré et productif</string>
+    <string name="mood_morning">Matin</string>
+    <string name="mood_morning_desc">Commencez la journée positivement</string>
+    <string name="mood_driving">Route</string>
+    <string name="mood_driving_desc">De bons compagnons de voyage</string>
+    <string name="mood_late_night">Tard le soir</string>
+    <string name="mood_late_night_desc">Musique pour les heures calmes</string>
+    <string name="mood_workout">Entraînement</string>
+    <string name="mood_workout_desc">De l’énergie pour continuer</string>
 
     <!-- Now playing -->
     <string name="close_player">Fermer le lecteur</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -9,6 +9,7 @@
     <string name="action_clear">Cancella</string>
     <string name="action_save">Salva</string>
     <string name="action_edit">Modifica</string>
+    <string name="save_all">Salva tutto</string>
 
     <!-- Search / home -->
     <string name="search_hint">Cerca stazioni</string>
@@ -35,12 +36,28 @@
     <string name="home_view_cards">Schede</string>
     <string name="home_view_list">Elenco</string>
     <string name="search_stations_header">Stazioni</string>
+    <string name="for_you_country">Per te — %1$s</string>
+    <string name="view_all">Vedi tutto</string>
     <string name="get_started">Inizia</string>
     <string name="just_listen">Ascolta e basta</string>
     <string name="find_a_station">Trova una stazione</string>
     <string name="find_one_to_listen">Trovane una da ascoltare</string>
     <string name="no_matches">Nessun risultato</string>
     <string name="no_matches_desc">Prova un\'altra ricerca.</string>
+    <string name="listen_by_mood">Ascolta in base all’umore</string>
+    <string name="mood_relax">Relax</string>
+    <string name="mood_relax_desc">Rilassati e lascia andare</string>
+    <string name="mood_relax_detail_desc">Rallenta con ambient, jazz e musica morbida da tutto il mondo.</string>
+    <string name="mood_focus">Concentrazione</string>
+    <string name="mood_focus_desc">Concentrati e resta produttivo</string>
+    <string name="mood_morning">Mattina</string>
+    <string name="mood_morning_desc">Inizia la giornata con positività</string>
+    <string name="mood_driving">In viaggio</string>
+    <string name="mood_driving_desc">Ottima compagnia per la strada</string>
+    <string name="mood_late_night">Notte fonda</string>
+    <string name="mood_late_night_desc">Musica per le ore tranquille</string>
+    <string name="mood_workout">Allenamento</string>
+    <string name="mood_workout_desc">Energia per continuare</string>
 
     <!-- Now playing -->
     <string name="close_player">Chiudi player</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Aerial</string>
-
     <!-- Common actions -->
     <string name="action_back">Indietro</string>
     <string name="action_remove">Rimuovi</string>
@@ -10,7 +9,6 @@
     <string name="action_save">Salva</string>
     <string name="action_edit">Modifica</string>
     <string name="save_all">Salva tutto</string>
-
     <!-- Search / home -->
     <string name="search_hint">Cerca stazioni</string>
     <string name="clear_search">Cancella ricerca</string>
@@ -36,15 +34,13 @@
     <string name="home_view_cards">Schede</string>
     <string name="home_view_list">Elenco</string>
     <string name="search_stations_header">Stazioni</string>
-    <string name="for_you_country">Per te — %1$s</string>
     <string name="view_all">Vedi tutto</string>
-    <string name="get_started">Inizia</string>
     <string name="just_listen">Ascolta e basta</string>
     <string name="find_a_station">Trova una stazione</string>
     <string name="find_one_to_listen">Trovane una da ascoltare</string>
     <string name="no_matches">Nessun risultato</string>
     <string name="no_matches_desc">Prova un\'altra ricerca.</string>
-    <string name="listen_by_mood">Ascolta in base all’umore</string>
+    <string name="listen_by_mood">In base al tuo umore</string>
     <string name="mood_relax">Relax</string>
     <string name="mood_relax_desc">Rilassati e lascia andare</string>
     <string name="mood_relax_detail_desc">Rallenta con ambient, jazz e musica morbida da tutto il mondo.</string>
@@ -58,14 +54,12 @@
     <string name="mood_late_night_desc">Musica per le ore tranquille</string>
     <string name="mood_workout">Allenamento</string>
     <string name="mood_workout_desc">Energia per continuare</string>
-
     <!-- Now playing -->
     <string name="close_player">Chiudi player</string>
     <string name="add_to_favorites">Aggiungi ai preferiti</string>
     <string name="share_station">Condividi stazione</string>
     <string name="copy_track_info">Copia info brano</string>
     <string name="stream_bitrate_format">%1$d kbps</string>
-
     <!-- Settings -->
     <string name="show_whats_playing">Mostra cosa è in onda</string>
     <string name="show_whats_playing_desc">Mostra brano, artista e copertina quando disponibili</string>
@@ -79,7 +73,6 @@
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Lingua</string>
     <string name="language_system_default">Predefinita di sistema</string>
-
     <!-- Station edit -->
     <string name="edit_station">Modifica stazione</string>
     <string name="add_station">Aggiungi stazione</string>
@@ -90,7 +83,6 @@
     <string name="remove_icon_message">L\'icona della stazione verrà rimossa.</string>
     <string name="field_name">Nome</string>
     <string name="field_stream_url">URL streaming</string>
-
     <!-- Sleep timer -->
     <string name="sleep_timer">Timer di spegnimento</string>
     <string name="sleep_add_15">+15 min</string>
@@ -116,4 +108,8 @@
     <string name="sort_az">Dalla A alla Z</string>
     <string name="sort_last_played">Riprodotta di recente</string>
     <string name="sort_most_played">Più riprodotta</string>
+    <string name="for_you">Per te</string>
+    <string name="favorites_grid_columns">Larghezza della griglia dei preferiti</string>
+    <string name="favorites_grid_columns_desc">Colonne nella vista a schede</string>
+    <string name="stats_summary">%1$s stazioni da %2$s paesi. I dati provengono da radio-browser.info e da altri fornitori di stazioni.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -111,5 +111,4 @@
     <string name="for_you">Per te</string>
     <string name="favorites_grid_columns">Larghezza della griglia dei preferiti</string>
     <string name="favorites_grid_columns_desc">Colonne nella vista a schede</string>
-    <string name="stats_summary">%1$s stazioni da %2$s paesi. I dati provengono da radio-browser.info e da altri fornitori di stazioni.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -9,6 +9,7 @@
     <string name="action_clear">クリア</string>
     <string name="action_save">保存</string>
     <string name="action_edit">編集</string>
+    <string name="save_all">すべて保存</string>
 
     <!-- Search / home -->
     <string name="search_hint">放送局を検索</string>
@@ -35,12 +36,28 @@
     <string name="home_view_cards">カード</string>
     <string name="home_view_list">リスト</string>
     <string name="search_stations_header">放送局</string>
+    <string name="for_you_country">あなたへのおすすめ — %1$s</string>
+    <string name="view_all">すべて表示</string>
     <string name="get_started">はじめる</string>
     <string name="just_listen">ただ聴くだけ</string>
     <string name="find_a_station">放送局を探す</string>
     <string name="find_one_to_listen">聴きたい放送局を見つけよう</string>
     <string name="no_matches">一致するものがありません</string>
     <string name="no_matches_desc">別のキーワードで検索してください。</string>
+    <string name="listen_by_mood">気分で聴く</string>
+    <string name="mood_relax">リラックス</string>
+    <string name="mood_relax_desc">肩の力を抜いてくつろぐ</string>
+    <string name="mood_relax_detail_desc">アンビエント、ジャズ、世界の穏やかな音楽でゆっくり過ごしましょう。</string>
+    <string name="mood_focus">集中</string>
+    <string name="mood_focus_desc">集中して生産的に</string>
+    <string name="mood_morning">朝</string>
+    <string name="mood_morning_desc">前向きに一日を始める</string>
+    <string name="mood_driving">ドライブ</string>
+    <string name="mood_driving_desc">道中にぴったりの相棒</string>
+    <string name="mood_late_night">深夜</string>
+    <string name="mood_late_night_desc">静かな時間のための音楽</string>
+    <string name="mood_workout">ワークアウト</string>
+    <string name="mood_workout_desc">続けるための高いエネルギー</string>
 
     <!-- Now playing -->
     <string name="close_player">プレーヤーを閉じる</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -111,5 +111,4 @@
     <string name="for_you">あなたへのおすすめ</string>
     <string name="favorites_grid_columns">お気に入りのグリッド幅</string>
     <string name="favorites_grid_columns_desc">カード表示の列数</string>
-    <string name="stats_summary">%2$sか国の%1$sステーション。データは radio-browser.info などの提供元から取得しています。</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Aerial</string>
-
     <!-- Common actions -->
     <string name="action_back">戻る</string>
     <string name="action_remove">削除</string>
@@ -10,7 +9,6 @@
     <string name="action_save">保存</string>
     <string name="action_edit">編集</string>
     <string name="save_all">すべて保存</string>
-
     <!-- Search / home -->
     <string name="search_hint">放送局を検索</string>
     <string name="clear_search">検索をクリア</string>
@@ -36,15 +34,13 @@
     <string name="home_view_cards">カード</string>
     <string name="home_view_list">リスト</string>
     <string name="search_stations_header">放送局</string>
-    <string name="for_you_country">あなたへのおすすめ — %1$s</string>
     <string name="view_all">すべて表示</string>
-    <string name="get_started">はじめる</string>
     <string name="just_listen">ただ聴くだけ</string>
     <string name="find_a_station">放送局を探す</string>
     <string name="find_one_to_listen">聴きたい放送局を見つけよう</string>
     <string name="no_matches">一致するものがありません</string>
     <string name="no_matches_desc">別のキーワードで検索してください。</string>
-    <string name="listen_by_mood">気分で聴く</string>
+    <string name="listen_by_mood">気分に合わせて</string>
     <string name="mood_relax">リラックス</string>
     <string name="mood_relax_desc">肩の力を抜いてくつろぐ</string>
     <string name="mood_relax_detail_desc">アンビエント、ジャズ、世界の穏やかな音楽でゆっくり過ごしましょう。</string>
@@ -58,14 +54,12 @@
     <string name="mood_late_night_desc">静かな時間のための音楽</string>
     <string name="mood_workout">ワークアウト</string>
     <string name="mood_workout_desc">続けるための高いエネルギー</string>
-
     <!-- Now playing -->
     <string name="close_player">プレーヤーを閉じる</string>
     <string name="add_to_favorites">お気に入りに追加</string>
     <string name="share_station">放送局を共有</string>
     <string name="copy_track_info">曲情報をコピー</string>
     <string name="stream_bitrate_format">%1$d kbps</string>
-
     <!-- Settings -->
     <string name="show_whats_playing">再生中の曲を表示</string>
     <string name="show_whats_playing_desc">利用可能な場合、曲名・アーティスト・アートワークを表示</string>
@@ -79,7 +73,6 @@
     <string name="version_format">Aerial %1$s</string>
     <string name="language">言語</string>
     <string name="language_system_default">システムのデフォルト</string>
-
     <!-- Station edit -->
     <string name="edit_station">放送局を編集</string>
     <string name="add_station">放送局を追加</string>
@@ -90,7 +83,6 @@
     <string name="remove_icon_message">放送局のアイコンを削除します。</string>
     <string name="field_name">名前</string>
     <string name="field_stream_url">ストリームURL</string>
-
     <!-- Sleep timer -->
     <string name="sleep_timer">スリープタイマー</string>
     <string name="sleep_add_15">+15分</string>
@@ -116,4 +108,8 @@
     <string name="sort_az">A〜Z順</string>
     <string name="sort_last_played">最近再生した順</string>
     <string name="sort_most_played">再生回数順</string>
+    <string name="for_you">あなたへのおすすめ</string>
+    <string name="favorites_grid_columns">お気に入りのグリッド幅</string>
+    <string name="favorites_grid_columns_desc">カード表示の列数</string>
+    <string name="stats_summary">%2$sか国の%1$sステーション。データは radio-browser.info などの提供元から取得しています。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -9,6 +9,7 @@
     <string name="action_clear">지우기</string>
     <string name="action_save">저장</string>
     <string name="action_edit">편집</string>
+    <string name="save_all">모두 저장</string>
 
     <!-- Search / home -->
     <string name="search_hint">방송국 검색</string>
@@ -35,12 +36,28 @@
     <string name="home_view_cards">카드</string>
     <string name="home_view_list">목록</string>
     <string name="search_stations_header">방송국</string>
+    <string name="for_you_country">맞춤 추천 — %1$s</string>
+    <string name="view_all">모두 보기</string>
     <string name="get_started">시작하기</string>
     <string name="just_listen">그냥 들어보세요</string>
     <string name="find_a_station">방송국 찾기</string>
     <string name="find_one_to_listen">들을 방송국을 찾아보세요</string>
     <string name="no_matches">일치하는 항목 없음</string>
     <string name="no_matches_desc">다른 검색어를 시도하세요.</string>
+    <string name="listen_by_mood">분위기별 듣기</string>
+    <string name="mood_relax">휴식</string>
+    <string name="mood_relax_desc">긴장을 풀고 여유를 느껴보세요</string>
+    <string name="mood_relax_detail_desc">앰비언트, 재즈, 세계의 부드러운 음악으로 천천히 쉬어보세요.</string>
+    <string name="mood_focus">집중</string>
+    <string name="mood_focus_desc">집중하고 생산적으로 보내기</string>
+    <string name="mood_morning">아침</string>
+    <string name="mood_morning_desc">긍정적으로 하루를 시작하세요</string>
+    <string name="mood_driving">드라이브</string>
+    <string name="mood_driving_desc">길 위의 좋은 동반자</string>
+    <string name="mood_late_night">늦은 밤</string>
+    <string name="mood_late_night_desc">조용한 시간을 위한 음악</string>
+    <string name="mood_workout">운동</string>
+    <string name="mood_workout_desc">계속 움직이게 하는 에너지</string>
 
     <!-- Now playing -->
     <string name="close_player">플레이어 닫기</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -111,5 +111,4 @@
     <string name="for_you">맞춤 추천</string>
     <string name="favorites_grid_columns">즐겨찾기 그리드 너비</string>
     <string name="favorites_grid_columns_desc">카드 보기의 열 수</string>
-    <string name="stats_summary">%2$s개국의 방송국 %1$s개. 데이터는 radio-browser.info 및 기타 제공자로부터 제공받습니다.</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Aerial</string>
-
     <!-- Common actions -->
     <string name="action_back">뒤로</string>
     <string name="action_remove">삭제</string>
@@ -10,7 +9,6 @@
     <string name="action_save">저장</string>
     <string name="action_edit">편집</string>
     <string name="save_all">모두 저장</string>
-
     <!-- Search / home -->
     <string name="search_hint">방송국 검색</string>
     <string name="clear_search">검색어 지우기</string>
@@ -36,15 +34,13 @@
     <string name="home_view_cards">카드</string>
     <string name="home_view_list">목록</string>
     <string name="search_stations_header">방송국</string>
-    <string name="for_you_country">맞춤 추천 — %1$s</string>
     <string name="view_all">모두 보기</string>
-    <string name="get_started">시작하기</string>
     <string name="just_listen">그냥 들어보세요</string>
     <string name="find_a_station">방송국 찾기</string>
     <string name="find_one_to_listen">들을 방송국을 찾아보세요</string>
     <string name="no_matches">일치하는 항목 없음</string>
     <string name="no_matches_desc">다른 검색어를 시도하세요.</string>
-    <string name="listen_by_mood">분위기별 듣기</string>
+    <string name="listen_by_mood">기분에 맞게</string>
     <string name="mood_relax">휴식</string>
     <string name="mood_relax_desc">긴장을 풀고 여유를 느껴보세요</string>
     <string name="mood_relax_detail_desc">앰비언트, 재즈, 세계의 부드러운 음악으로 천천히 쉬어보세요.</string>
@@ -58,14 +54,12 @@
     <string name="mood_late_night_desc">조용한 시간을 위한 음악</string>
     <string name="mood_workout">운동</string>
     <string name="mood_workout_desc">계속 움직이게 하는 에너지</string>
-
     <!-- Now playing -->
     <string name="close_player">플레이어 닫기</string>
     <string name="add_to_favorites">즐겨찾기에 추가</string>
     <string name="share_station">방송국 공유</string>
     <string name="copy_track_info">트랙 정보 복사</string>
     <string name="stream_bitrate_format">%1$d kbps</string>
-
     <!-- Settings -->
     <string name="show_whats_playing">재생 중인 곡 표시</string>
     <string name="show_whats_playing_desc">가능한 경우 곡, 아티스트, 아트워크를 표시</string>
@@ -79,7 +73,6 @@
     <string name="version_format">Aerial %1$s</string>
     <string name="language">언어</string>
     <string name="language_system_default">시스템 기본값</string>
-
     <!-- Station edit -->
     <string name="edit_station">방송국 편집</string>
     <string name="add_station">방송국 추가</string>
@@ -90,7 +83,6 @@
     <string name="remove_icon_message">방송국 아이콘이 삭제됩니다.</string>
     <string name="field_name">이름</string>
     <string name="field_stream_url">스트림 URL</string>
-
     <!-- Sleep timer -->
     <string name="sleep_timer">취침 타이머</string>
     <string name="sleep_add_15">+15분</string>
@@ -116,4 +108,8 @@
     <string name="sort_az">가나다순</string>
     <string name="sort_last_played">최근 재생순</string>
     <string name="sort_most_played">재생 횟수순</string>
+    <string name="for_you">맞춤 추천</string>
+    <string name="favorites_grid_columns">즐겨찾기 그리드 너비</string>
+    <string name="favorites_grid_columns_desc">카드 보기의 열 수</string>
+    <string name="stats_summary">%2$s개국의 방송국 %1$s개. 데이터는 radio-browser.info 및 기타 제공자로부터 제공받습니다.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Aerial</string>
-
     <!-- Common actions -->
     <string name="action_back">Terug</string>
     <string name="action_remove">Verwijderen</string>
@@ -10,7 +9,6 @@
     <string name="action_save">Opslaan</string>
     <string name="action_edit">Bewerken</string>
     <string name="save_all">Alles opslaan</string>
-
     <!-- Search / home -->
     <string name="search_hint">Zenders zoeken</string>
     <string name="clear_search">Zoekopdracht wissen</string>
@@ -36,15 +34,13 @@
     <string name="home_view_cards">Kaarten</string>
     <string name="home_view_list">Lijst</string>
     <string name="search_stations_header">Stations</string>
-    <string name="for_you_country">Voor jou — %1$s</string>
     <string name="view_all">Alles bekijken</string>
-    <string name="get_started">Aan de slag</string>
     <string name="just_listen">Gewoon luisteren</string>
     <string name="find_a_station">Zoek een zender</string>
     <string name="find_one_to_listen">Zoek er een om naar te luisteren</string>
     <string name="no_matches">Geen resultaten</string>
     <string name="no_matches_desc">Probeer een andere zoekopdracht.</string>
-    <string name="listen_by_mood">Luisteren op stemming</string>
+    <string name="listen_by_mood">Passend bij je stemming</string>
     <string name="mood_relax">Ontspannen</string>
     <string name="mood_relax_desc">Ontspan en laat los</string>
     <string name="mood_relax_detail_desc">Kom tot rust met ambient, jazz en zachte muziek van over de hele wereld.</string>
@@ -58,14 +54,12 @@
     <string name="mood_late_night_desc">Muziek voor stille uren</string>
     <string name="mood_workout">Workout</string>
     <string name="mood_workout_desc">Energie om door te gaan</string>
-
     <!-- Now playing -->
     <string name="close_player">Speler sluiten</string>
     <string name="add_to_favorites">Aan favorieten toevoegen</string>
     <string name="share_station">Zender delen</string>
     <string name="copy_track_info">Nummerinfo kopiëren</string>
     <string name="stream_bitrate_format">%1$d kbps</string>
-
     <!-- Settings -->
     <string name="show_whats_playing">Toon wat er speelt</string>
     <string name="show_whats_playing_desc">Toont nummer, artiest en albumhoes indien beschikbaar</string>
@@ -79,7 +73,6 @@
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Taal</string>
     <string name="language_system_default">Systeemstandaard</string>
-
     <!-- Station edit -->
     <string name="edit_station">Zender bewerken</string>
     <string name="add_station">Zender toevoegen</string>
@@ -90,7 +83,6 @@
     <string name="remove_icon_message">Het zenderpictogram wordt verwijderd.</string>
     <string name="field_name">Naam</string>
     <string name="field_stream_url">Stream-URL</string>
-
     <!-- Sleep timer -->
     <string name="sleep_timer">Slaaptimer</string>
     <string name="sleep_add_15">+15 min</string>
@@ -116,4 +108,8 @@
     <string name="sort_az">A tot Z</string>
     <string name="sort_last_played">Laatst afgespeeld</string>
     <string name="sort_most_played">Meest afgespeeld</string>
+    <string name="for_you">Voor jou</string>
+    <string name="favorites_grid_columns">Rasterbreedte van favorieten</string>
+    <string name="favorites_grid_columns_desc">Kolommen in de kaartweergave</string>
+    <string name="stats_summary">%1$s zenders uit %2$s landen. Gegevens zijn afkomstig van radio-browser.info en andere aanbieders.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -9,6 +9,7 @@
     <string name="action_clear">Wissen</string>
     <string name="action_save">Opslaan</string>
     <string name="action_edit">Bewerken</string>
+    <string name="save_all">Alles opslaan</string>
 
     <!-- Search / home -->
     <string name="search_hint">Zenders zoeken</string>
@@ -35,12 +36,28 @@
     <string name="home_view_cards">Kaarten</string>
     <string name="home_view_list">Lijst</string>
     <string name="search_stations_header">Stations</string>
+    <string name="for_you_country">Voor jou — %1$s</string>
+    <string name="view_all">Alles bekijken</string>
     <string name="get_started">Aan de slag</string>
     <string name="just_listen">Gewoon luisteren</string>
     <string name="find_a_station">Zoek een zender</string>
     <string name="find_one_to_listen">Zoek er een om naar te luisteren</string>
     <string name="no_matches">Geen resultaten</string>
     <string name="no_matches_desc">Probeer een andere zoekopdracht.</string>
+    <string name="listen_by_mood">Luisteren op stemming</string>
+    <string name="mood_relax">Ontspannen</string>
+    <string name="mood_relax_desc">Ontspan en laat los</string>
+    <string name="mood_relax_detail_desc">Kom tot rust met ambient, jazz en zachte muziek van over de hele wereld.</string>
+    <string name="mood_focus">Focus</string>
+    <string name="mood_focus_desc">Concentreer je en blijf productief</string>
+    <string name="mood_morning">Ochtend</string>
+    <string name="mood_morning_desc">Begin je dag positief</string>
+    <string name="mood_driving">Onderweg</string>
+    <string name="mood_driving_desc">Goede begeleiding voor onderweg</string>
+    <string name="mood_late_night">Late avond</string>
+    <string name="mood_late_night_desc">Muziek voor stille uren</string>
+    <string name="mood_workout">Workout</string>
+    <string name="mood_workout_desc">Energie om door te gaan</string>
 
     <!-- Now playing -->
     <string name="close_player">Speler sluiten</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -111,5 +111,4 @@
     <string name="for_you">Voor jou</string>
     <string name="favorites_grid_columns">Rasterbreedte van favorieten</string>
     <string name="favorites_grid_columns_desc">Kolommen in de kaartweergave</string>
-    <string name="stats_summary">%1$s zenders uit %2$s landen. Gegevens zijn afkomstig van radio-browser.info en andere aanbieders.</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Aerial</string>
-
     <!-- Common actions -->
     <string name="action_back">Voltar</string>
     <string name="action_remove">Remover</string>
@@ -10,7 +9,6 @@
     <string name="action_save">Salvar</string>
     <string name="action_edit">Editar</string>
     <string name="save_all">Salvar tudo</string>
-
     <!-- Search / home -->
     <string name="search_hint">Buscar estações</string>
     <string name="clear_search">Limpar busca</string>
@@ -36,15 +34,13 @@
     <string name="home_view_cards">Cartões</string>
     <string name="home_view_list">Lista</string>
     <string name="search_stations_header">Estações</string>
-    <string name="for_you_country">Para você — %1$s</string>
     <string name="view_all">Ver tudo</string>
-    <string name="get_started">Começar</string>
     <string name="just_listen">É só ouvir</string>
     <string name="find_a_station">Encontrar uma estação</string>
     <string name="find_one_to_listen">Encontre uma para ouvir</string>
     <string name="no_matches">Nenhum resultado</string>
     <string name="no_matches_desc">Tente outra busca.</string>
-    <string name="listen_by_mood">Ouvir por humor</string>
+    <string name="listen_by_mood">Combine com seu humor</string>
     <string name="mood_relax">Relaxar</string>
     <string name="mood_relax_desc">Desacelere e deixe ir</string>
     <string name="mood_relax_detail_desc">Desacelere com ambient, jazz e música suave do mundo todo.</string>
@@ -58,14 +54,12 @@
     <string name="mood_late_night_desc">Música para horas tranquilas</string>
     <string name="mood_workout">Treino</string>
     <string name="mood_workout_desc">Energia para continuar</string>
-
     <!-- Now playing -->
     <string name="close_player">Fechar player</string>
     <string name="add_to_favorites">Adicionar aos favoritos</string>
     <string name="share_station">Compartilhar estação</string>
     <string name="copy_track_info">Copiar info da faixa</string>
     <string name="stream_bitrate_format">%1$d kbps</string>
-
     <!-- Settings -->
     <string name="show_whats_playing">Mostrar o que está tocando</string>
     <string name="show_whats_playing_desc">Exibe música, artista e capa quando disponíveis</string>
@@ -79,7 +73,6 @@
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Idioma</string>
     <string name="language_system_default">Padrão do sistema</string>
-
     <!-- Station edit -->
     <string name="edit_station">Editar estação</string>
     <string name="add_station">Adicionar estação</string>
@@ -90,7 +83,6 @@
     <string name="remove_icon_message">O ícone da estação será removido.</string>
     <string name="field_name">Nome</string>
     <string name="field_stream_url">URL do stream</string>
-
     <!-- Sleep timer -->
     <string name="sleep_timer">Temporizador</string>
     <string name="sleep_add_15">+15 min</string>
@@ -116,4 +108,8 @@
     <string name="sort_az">De A a Z</string>
     <string name="sort_last_played">Reproduzida recentemente</string>
     <string name="sort_most_played">Mais reproduzida</string>
+    <string name="for_you">Para você</string>
+    <string name="favorites_grid_columns">Largura da grade de favoritos</string>
+    <string name="favorites_grid_columns_desc">Colunas na visualização de cartões</string>
+    <string name="stats_summary">%1$s estações de %2$s países. Os dados vêm de radio-browser.info e de outros provedores.</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -9,6 +9,7 @@
     <string name="action_clear">Limpar</string>
     <string name="action_save">Salvar</string>
     <string name="action_edit">Editar</string>
+    <string name="save_all">Salvar tudo</string>
 
     <!-- Search / home -->
     <string name="search_hint">Buscar estações</string>
@@ -35,12 +36,28 @@
     <string name="home_view_cards">Cartões</string>
     <string name="home_view_list">Lista</string>
     <string name="search_stations_header">Estações</string>
+    <string name="for_you_country">Para você — %1$s</string>
+    <string name="view_all">Ver tudo</string>
     <string name="get_started">Começar</string>
     <string name="just_listen">É só ouvir</string>
     <string name="find_a_station">Encontrar uma estação</string>
     <string name="find_one_to_listen">Encontre uma para ouvir</string>
     <string name="no_matches">Nenhum resultado</string>
     <string name="no_matches_desc">Tente outra busca.</string>
+    <string name="listen_by_mood">Ouvir por humor</string>
+    <string name="mood_relax">Relaxar</string>
+    <string name="mood_relax_desc">Desacelere e deixe ir</string>
+    <string name="mood_relax_detail_desc">Desacelere com ambient, jazz e música suave do mundo todo.</string>
+    <string name="mood_focus">Foco</string>
+    <string name="mood_focus_desc">Concentre-se e seja produtivo</string>
+    <string name="mood_morning">Manhã</string>
+    <string name="mood_morning_desc">Comece o dia com positividade</string>
+    <string name="mood_driving">Dirigindo</string>
+    <string name="mood_driving_desc">Boa companhia para a estrada</string>
+    <string name="mood_late_night">Noite adentro</string>
+    <string name="mood_late_night_desc">Música para horas tranquilas</string>
+    <string name="mood_workout">Treino</string>
+    <string name="mood_workout_desc">Energia para continuar</string>
 
     <!-- Now playing -->
     <string name="close_player">Fechar player</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -111,5 +111,4 @@
     <string name="for_you">Para você</string>
     <string name="favorites_grid_columns">Largura da grade de favoritos</string>
     <string name="favorites_grid_columns_desc">Colunas na visualização de cartões</string>
-    <string name="stats_summary">%1$s estações de %2$s países. Os dados vêm de radio-browser.info e de outros provedores.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -111,5 +111,4 @@
     <string name="for_you">为你推荐</string>
     <string name="favorites_grid_columns">收藏网格宽度</string>
     <string name="favorites_grid_columns_desc">卡片视图的列数</string>
-    <string name="stats_summary">来自 %2$s 个国家/地区的 %1$s 个电台。数据来自 radio-browser.info 及其他电台提供方。</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -9,6 +9,7 @@
     <string name="action_clear">清除</string>
     <string name="action_save">保存</string>
     <string name="action_edit">编辑</string>
+    <string name="save_all">全部保存</string>
 
     <!-- Search / home -->
     <string name="search_hint">搜索电台</string>
@@ -35,12 +36,28 @@
     <string name="home_view_cards">卡片</string>
     <string name="home_view_list">列表</string>
     <string name="search_stations_header">电台</string>
+    <string name="for_you_country">为你推荐 — %1$s</string>
+    <string name="view_all">查看全部</string>
     <string name="get_started">开始使用</string>
     <string name="just_listen">尽情聆听</string>
     <string name="find_a_station">查找电台</string>
     <string name="find_one_to_listen">找一个来收听</string>
     <string name="no_matches">无匹配结果</string>
     <string name="no_matches_desc">请尝试其他搜索。</string>
+    <string name="listen_by_mood">按心情收听</string>
+    <string name="mood_relax">放松</string>
+    <string name="mood_relax_desc">放慢节奏，释放压力</string>
+    <string name="mood_relax_detail_desc">用来自世界各地的氛围、爵士和柔和音乐放慢节奏。</string>
+    <string name="mood_focus">专注</string>
+    <string name="mood_focus_desc">保持专注和高效</string>
+    <string name="mood_morning">清晨</string>
+    <string name="mood_morning_desc">积极开启新的一天</string>
+    <string name="mood_driving">驾驶</string>
+    <string name="mood_driving_desc">路上的好伙伴</string>
+    <string name="mood_late_night">深夜</string>
+    <string name="mood_late_night_desc">适合安静时光的音乐</string>
+    <string name="mood_workout">锻炼</string>
+    <string name="mood_workout_desc">保持前进的高能量</string>
 
     <!-- Now playing -->
     <string name="close_player">关闭播放器</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Aerial</string>
-
     <!-- Common actions -->
     <string name="action_back">返回</string>
     <string name="action_remove">移除</string>
@@ -10,7 +9,6 @@
     <string name="action_save">保存</string>
     <string name="action_edit">编辑</string>
     <string name="save_all">全部保存</string>
-
     <!-- Search / home -->
     <string name="search_hint">搜索电台</string>
     <string name="clear_search">清除搜索</string>
@@ -36,15 +34,13 @@
     <string name="home_view_cards">卡片</string>
     <string name="home_view_list">列表</string>
     <string name="search_stations_header">电台</string>
-    <string name="for_you_country">为你推荐 — %1$s</string>
     <string name="view_all">查看全部</string>
-    <string name="get_started">开始使用</string>
     <string name="just_listen">尽情聆听</string>
     <string name="find_a_station">查找电台</string>
     <string name="find_one_to_listen">找一个来收听</string>
     <string name="no_matches">无匹配结果</string>
     <string name="no_matches_desc">请尝试其他搜索。</string>
-    <string name="listen_by_mood">按心情收听</string>
+    <string name="listen_by_mood">匹配你的心情</string>
     <string name="mood_relax">放松</string>
     <string name="mood_relax_desc">放慢节奏，释放压力</string>
     <string name="mood_relax_detail_desc">用来自世界各地的氛围、爵士和柔和音乐放慢节奏。</string>
@@ -58,14 +54,12 @@
     <string name="mood_late_night_desc">适合安静时光的音乐</string>
     <string name="mood_workout">锻炼</string>
     <string name="mood_workout_desc">保持前进的高能量</string>
-
     <!-- Now playing -->
     <string name="close_player">关闭播放器</string>
     <string name="add_to_favorites">添加到收藏</string>
     <string name="share_station">分享电台</string>
     <string name="copy_track_info">复制曲目信息</string>
     <string name="stream_bitrate_format">%1$d kbps</string>
-
     <!-- Settings -->
     <string name="show_whats_playing">显示正在播放</string>
     <string name="show_whats_playing_desc">在可用时显示歌曲、艺人和封面</string>
@@ -79,7 +73,6 @@
     <string name="version_format">Aerial %1$s</string>
     <string name="language">语言</string>
     <string name="language_system_default">系统默认</string>
-
     <!-- Station edit -->
     <string name="edit_station">编辑电台</string>
     <string name="add_station">添加电台</string>
@@ -90,7 +83,6 @@
     <string name="remove_icon_message">将移除电台图标。</string>
     <string name="field_name">名称</string>
     <string name="field_stream_url">流媒体地址</string>
-
     <!-- Sleep timer -->
     <string name="sleep_timer">睡眠定时器</string>
     <string name="sleep_add_15">+15 分钟</string>
@@ -116,4 +108,8 @@
     <string name="sort_az">按字母顺序</string>
     <string name="sort_last_played">最近播放</string>
     <string name="sort_most_played">播放最多</string>
+    <string name="for_you">为你推荐</string>
+    <string name="favorites_grid_columns">收藏网格宽度</string>
+    <string name="favorites_grid_columns_desc">卡片视图的列数</string>
+    <string name="stats_summary">来自 %2$s 个国家/地区的 %1$s 个电台。数据来自 radio-browser.info 及其他电台提供方。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="action_clear">Clear</string>
     <string name="action_save">Save</string>
     <string name="action_edit">Edit</string>
+    <string name="save_all">Save all</string>
 
     <!-- Search / home -->
     <string name="search_hint">Search stations</string>
@@ -35,12 +36,28 @@
     <string name="home_view_cards">Cards</string>
     <string name="home_view_list">List</string>
     <string name="search_stations_header">Stations</string>
+    <string name="for_you_country">For you — %1$s</string>
+    <string name="view_all">View all</string>
     <string name="get_started">Get started</string>
     <string name="just_listen">Just listen</string>
     <string name="find_a_station">Find a station</string>
     <string name="find_one_to_listen">Find one to listen to</string>
     <string name="no_matches">No matches</string>
     <string name="no_matches_desc">Try a different search.</string>
+    <string name="listen_by_mood">Listen by mood</string>
+    <string name="mood_relax">Relax</string>
+    <string name="mood_relax_desc">Unwind and let go</string>
+    <string name="mood_relax_detail_desc">Slow down with ambient, jazz and mellow music from around the world.</string>
+    <string name="mood_focus">Focus</string>
+    <string name="mood_focus_desc">Concentrate and be productive</string>
+    <string name="mood_morning">Morning</string>
+    <string name="mood_morning_desc">Start your day positively</string>
+    <string name="mood_driving">Driving</string>
+    <string name="mood_driving_desc">Great companions for the road</string>
+    <string name="mood_late_night">Late night</string>
+    <string name="mood_late_night_desc">Music for the quiet hours</string>
+    <string name="mood_workout">Workout</string>
+    <string name="mood_workout_desc">High energy to keep going</string>
 
     <!-- Now playing -->
     <string name="close_player">Close player</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:locale="en">
     <string name="app_name">Aerial</string>
-
     <!-- Common actions -->
     <string name="action_back">Back</string>
     <string name="action_remove">Remove</string>
@@ -10,7 +9,6 @@
     <string name="action_save">Save</string>
     <string name="action_edit">Edit</string>
     <string name="save_all">Save all</string>
-
     <!-- Search / home -->
     <string name="search_hint">Search stations</string>
     <string name="clear_search">Clear search</string>
@@ -36,15 +34,13 @@
     <string name="home_view_cards">Cards</string>
     <string name="home_view_list">List</string>
     <string name="search_stations_header">Stations</string>
-    <string name="for_you_country">For you — %1$s</string>
     <string name="view_all">View all</string>
-    <string name="get_started">Get started</string>
     <string name="just_listen">Just listen</string>
     <string name="find_a_station">Find a station</string>
     <string name="find_one_to_listen">Find one to listen to</string>
     <string name="no_matches">No matches</string>
     <string name="no_matches_desc">Try a different search.</string>
-    <string name="listen_by_mood">Listen by mood</string>
+    <string name="listen_by_mood">Match your mood</string>
     <string name="mood_relax">Relax</string>
     <string name="mood_relax_desc">Unwind and let go</string>
     <string name="mood_relax_detail_desc">Slow down with ambient, jazz and mellow music from around the world.</string>
@@ -58,14 +54,12 @@
     <string name="mood_late_night_desc">Music for the quiet hours</string>
     <string name="mood_workout">Workout</string>
     <string name="mood_workout_desc">High energy to keep going</string>
-
     <!-- Now playing -->
     <string name="close_player">Close player</string>
     <string name="add_to_favorites">Add to favorites</string>
     <string name="share_station">Share station</string>
     <string name="copy_track_info">Copy track info</string>
     <string name="stream_bitrate_format">%1$d kbps</string>
-
     <!-- Settings -->
     <string name="show_whats_playing">Show what\'s playing</string>
     <string name="show_whats_playing_desc">Display song, artist, and artwork when available</string>
@@ -79,7 +73,6 @@
     <string name="version_format">Aerial %1$s</string>
     <string name="language">Language</string>
     <string name="language_system_default">System default</string>
-
     <!-- Station edit -->
     <string name="edit_station">Edit station</string>
     <string name="add_station">Add station</string>
@@ -90,10 +83,8 @@
     <string name="remove_icon_message">The station icon will be removed.</string>
     <string name="field_name">Name</string>
     <string name="field_stream_url">Stream URL</string>
-
     <!-- Playback -->
     <string name="live_radio">Live Radio</string>
-
     <!-- Curated genre/category tags. Display only — the English tag is the matching key. -->
     <string name="tag_news">News</string>
     <string name="tag_sport">Sport</string>
@@ -105,7 +96,6 @@
     <string name="tag_soul">Soul</string>
     <string name="tag_country">Country</string>
     <string name="tag_electronic">Electronic</string>
-
     <!-- Sleep timer -->
     <string name="sleep_timer">Sleep timer</string>
     <string name="sleep_add_15">+15 min</string>
@@ -120,4 +110,8 @@
     <string name="sort_az">A to Z</string>
     <string name="sort_last_played">Last played</string>
     <string name="sort_most_played">Most played</string>
+    <string name="for_you">For you</string>
+    <string name="favorites_grid_columns">Favorites grid width</string>
+    <string name="favorites_grid_columns_desc">Columns shown in the cards view</string>
+    <string name="stats_summary">%1$s stations from %2$s countries. Station data is sourced from radio-browser.info and other station providers.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,5 +113,4 @@
     <string name="for_you">For you</string>
     <string name="favorites_grid_columns">Favorites grid width</string>
     <string name="favorites_grid_columns_desc">Columns shown in the cards view</string>
-    <string name="stats_summary">%1$s stations from %2$s countries. Station data is sourced from radio-browser.info and other station providers.</string>
 </resources>


### PR DESCRIPTION
## Summary

Builds out the home experience on the curated moods work:

### For you
- Replaces the Get started section. Shows the locale country's selection — curated where one exists (GB), otherwise ten random stations from that country that have artwork — headed by the localized country name; falls back to featured stations under plain "For you" only when the registry has nothing for the country
- Cards follow the M3 filled-card spec (12dp, no border), single-line clipped titles, View all as an icon button

### Match your mood
- Six redrawn procedural scenes, all derived from the dynamic colour scheme: coast with sun glitter, snow-capped ranges with mist, sunrise with halo rings, perspective road, starlit skyline with lit windows and a beacon, and a running trainer with motion trails
- Artwork clips to bounds (fixes the Late night overflow in the mood view); mood cards use spec card defaults
- Mood detail rows show the localized country and circular logos, and gained preview play buttons

### Station artwork plates
- New shared `StationLogoCircle`: circular logos on a light palette-tinted plate that shows through transparent third-party artwork, with tonal fallbacks — applied to search rows, favourites rows and tiles, mood rows, For You cards, the mini player, the Now Playing artwork, and the track card/detail sheet
- Favourites tiles use the medium card radius so corners read consistently at every grid width

### Search
- Preview play buttons on all result rows (registry, A–Z browse, favourites) — play in place without closing the search sheet (closes #52's follow-on for favourites rows)

### Settings
- Favourites grid width option (2–5 columns) using an expressive connected button group

All strings localized across the 11 supported locales. Unit tests pass; verified throughout on a Pixel device.