### PR TITLE
fix(player): load media session artwork through Coil

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -109,6 +109,7 @@ dependencies {
     implementation 'io.coil-kt.coil3:coil-svg:3.5.0'
     implementation 'com.squareup.okhttp3:okhttp:5.4.0'
     implementation 'androidx.datastore:datastore-preferences:1.2.1'
+    implementation 'androidx.concurrent:concurrent-futures-ktx:1.2.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.json:json:20240303'

--- a/app/src/main/java/com/shapeshed/aerial/CoilBitmapLoader.kt
+++ b/app/src/main/java/com/shapeshed/aerial/CoilBitmapLoader.kt
@@ -1,0 +1,63 @@
+package com.shapeshed.aerial
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.net.Uri
+import androidx.concurrent.futures.SuspendToFutureAdapter
+import androidx.media3.common.util.BitmapLoader
+import androidx.media3.common.util.UnstableApi
+import coil3.BitmapImage
+import coil3.SingletonImageLoader
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.size.Size
+import com.google.common.util.concurrent.ListenableFuture
+import kotlinx.coroutines.Dispatchers
+
+// Media3's default BitmapLoader fetches artwork with its own bare HTTP stack and decodes it
+// with BitmapFactory: it can't render SVG logos at all, and it doesn't send the identified
+// User-Agent some hosts require (see AerialApp's Coil client) — so those stations show a
+// logo in the in-app mini player (which goes through Coil) but not in the media notification,
+// lock screen, quick settings player, or Android Auto. Routing artwork through the app's own
+// Coil image loader gives every system surface the same SVG decoding and networking as the UI.
+@UnstableApi
+class CoilBitmapLoader(private val context: Context) : BitmapLoader {
+
+    override fun supportsMimeType(mimeType: String): Boolean = true
+
+    override fun decodeBitmap(data: ByteArray): ListenableFuture<Bitmap> =
+        SuspendToFutureAdapter.launchFuture(Dispatchers.Default, false) {
+            BitmapFactory.decodeByteArray(data, 0, data.size)
+                ?: error("Could not decode artwork bytes")
+        }
+
+    override fun loadBitmap(uri: Uri): ListenableFuture<Bitmap> =
+        SuspendToFutureAdapter.launchFuture(Dispatchers.IO, false) {
+            val imageLoader = SingletonImageLoader.get(context)
+            val request = ImageRequest.Builder(context)
+                .data(uri)
+                .size(Size.ORIGINAL)
+                .build()
+            val result = imageLoader.execute(request) as? SuccessResult
+                ?: error("Could not load artwork from $uri")
+            when (val image = result.image) {
+                // The common case: a decoded raster logo. Coil may hand back a hardware
+                // bitmap for performance; system notifications need a software one, and
+                // Bitmap.copy() does that GPU-to-software readback correctly — unlike
+                // Canvas, which throws "Software rendering doesn't support hardware
+                // bitmaps" if you try to draw a hardware bitmap into a software canvas.
+                is BitmapImage -> if (image.bitmap.config == Bitmap.Config.HARDWARE) {
+                    image.bitmap.copy(Bitmap.Config.ARGB_8888, false)
+                } else {
+                    image.bitmap
+                }
+                // Any other Image implementation (e.g. a vector drawable) isn't backed by a
+                // hardware bitmap, so drawing it into a fresh software canvas is safe.
+                else -> Bitmap.createBitmap(image.width, image.height, Bitmap.Config.ARGB_8888).apply {
+                    image.draw(Canvas(this))
+                }
+            }
+        }
+}

--- a/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
+++ b/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
@@ -107,6 +107,7 @@ class PlayerService : MediaSessionService() {
             .setSessionActivity(pendingIntent())
             .setCallback(sessionCallback)
             .setMediaButtonPreferences(listOf(favoriteButton(null)))
+            .setBitmapLoader(CoilBitmapLoader(this))
             .build()
         log("onCreate")
         serviceScope.launch {


### PR DESCRIPTION
## Summary

Fixes stations (e.g. Smooth Radio) showing their logo correctly in the in-app mini player but not in the media notification, lock screen, quick settings player, or Android Auto.

**Root cause**: Media3's default `BitmapLoader` fetches artwork with its own bare HTTP stack and decodes it with `BitmapFactory`. It can't render SVG logos at all (794 registry stations use `.svg` logo URLs), and it doesn't send an identifying User-Agent, which some hosts require to avoid a 403. The in-app UI already handles both cases via the app's Coil image loader (`AerialApp` configures it with an SVG decoder and an identified OkHttp client) — the system media surfaces just weren't using it.

**Fix**: adds `CoilBitmapLoader`, wired via `MediaSession.Builder.setBitmapLoader()`, which routes the session's artwork loading through that same Coil loader.

Diagnosing this on device surfaced a second, real bug along the way: Coil can decode a hardware-backed bitmap, and drawing a hardware bitmap into a software `Canvas` throws `IllegalArgumentException: Software rendering doesn't support hardware bitmaps` (confirmed via logcat, `NotificationProvider`/`MediaSessionLegacyStub` were silently swallowing it and falling back to no artwork). `Bitmap.copy()` performs the GPU-to-software readback correctly, so the loader special-cases that conversion.

## Testing

- Unit tests pass
- Verified on device: played Smooth Radio (previously blank in the quick settings player), confirmed the logo now renders there identically to the mini player, and confirmed no more "Failed to load bitmap" warnings in logcat