### PR TITLE
Redesign mood cards, declutter home, fix Now Playing artwork flashes

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.combinedClickable
@@ -29,6 +28,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -43,7 +43,6 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.ArrowForward
-import androidx.compose.material.icons.automirrored.rounded.Article
 import androidx.compose.material.icons.automirrored.rounded.Sort
 import androidx.compose.material.icons.automirrored.rounded.ViewList
 import androidx.compose.material.icons.rounded.Add
@@ -64,16 +63,12 @@ import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.WifiOff
-import androidx.compose.material.icons.rounded.SportsSoccer
-import androidx.compose.material.icons.rounded.Star
-import androidx.compose.material.icons.rounded.ElectricBolt
-import androidx.compose.material.icons.rounded.Piano
-import androidx.compose.material.icons.rounded.LibraryMusic
-import androidx.compose.material.icons.rounded.Nightlife
-import androidx.compose.material.icons.rounded.Spa
+import androidx.compose.material.icons.rounded.WbSunny
+import androidx.compose.material.icons.rounded.BeachAccess
+import androidx.compose.material.icons.rounded.FitnessCenter
+import androidx.compose.material.icons.rounded.NightsStay
 import androidx.compose.material.icons.rounded.Landscape
-import androidx.compose.material.icons.rounded.MusicNote
-import androidx.compose.material.icons.rounded.GraphicEq
+import androidx.compose.material.icons.rounded.Psychology
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -151,17 +146,14 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.traversalIndex
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -199,37 +191,18 @@ private fun rememberTagLabels(): Map<String, String> = mapOf(
     "Electronic" to stringResource(R.string.tag_electronic),
 )
 
-// Fixed tag→icon map — hoisted to avoid allocating a new Map on every CategoryGrid recomposition.
-private val CATEGORY_ICONS = mapOf(
-    "News" to Icons.AutoMirrored.Rounded.Article,
-    "Sport" to Icons.Rounded.SportsSoccer,
-    "Pop" to Icons.Rounded.Star,
-    "Rock" to Icons.Rounded.ElectricBolt,
-    "Jazz" to Icons.Rounded.Piano,
-    "Classical" to Icons.Rounded.LibraryMusic,
-    "Dance" to Icons.Rounded.Nightlife,
-    "Soul" to Icons.Rounded.Spa,
-    "Country" to Icons.Rounded.Landscape,
-    "Electronic" to Icons.Rounded.GraphicEq,
-)
-
-private enum class MoodArtwork {
-    Coast,
-    Mountains,
-    Sunrise,
-    Road,
-    City,
-    Runner,
-}
-
+// One consistent tonal surface for every mood tile, per M3 guidance: primary/secondary/
+// tertiary are meant for small high-emphasis elements (buttons, FABs, selected states), not
+// large fills, and rotating colours across a grid of peer items — none more important than
+// another — is a decorative pattern, not a functional use of colour. The icon and label are
+// what tell the six moods apart, matching how every other card in this app (For You, search
+// rows, favourites tiles) uses one steady surface rather than per-item colour.
 private data class CuratedMood(
     val id: String,
     val titleRes: Int,
     val descriptionRes: Int,
     val detailDescriptionRes: Int = descriptionRes,
-    val tags: List<String>,
     val icon: ImageVector,
-    val artwork: MoodArtwork,
 )
 
 private val CURATED_MOODS = listOf(
@@ -238,49 +211,37 @@ private val CURATED_MOODS = listOf(
         titleRes = R.string.mood_relax,
         descriptionRes = R.string.mood_relax_desc,
         detailDescriptionRes = R.string.mood_relax_detail_desc,
-        tags = listOf("Jazz", "Soul", "Classical"),
-        icon = Icons.Rounded.Spa,
-        artwork = MoodArtwork.Coast,
+        icon = Icons.Rounded.BeachAccess,
     ),
     CuratedMood(
         id = "focus",
         titleRes = R.string.mood_focus,
         descriptionRes = R.string.mood_focus_desc,
-        tags = listOf("Classical", "Electronic", "Jazz"),
-        icon = Icons.Rounded.GraphicEq,
-        artwork = MoodArtwork.Mountains,
+        icon = Icons.Rounded.Psychology,
     ),
     CuratedMood(
         id = "morning",
         titleRes = R.string.mood_morning,
         descriptionRes = R.string.mood_morning_desc,
-        tags = listOf("Pop", "Soul", "News"),
-        icon = Icons.Rounded.Star,
-        artwork = MoodArtwork.Sunrise,
+        icon = Icons.Rounded.WbSunny,
     ),
     CuratedMood(
         id = "driving",
         titleRes = R.string.mood_driving,
         descriptionRes = R.string.mood_driving_desc,
-        tags = listOf("Rock", "Pop", "Country"),
         icon = Icons.Rounded.Landscape,
-        artwork = MoodArtwork.Road,
     ),
     CuratedMood(
         id = "late_night",
         titleRes = R.string.mood_late_night,
         descriptionRes = R.string.mood_late_night_desc,
-        tags = listOf("Jazz", "Electronic", "Soul"),
-        icon = Icons.Rounded.Nightlife,
-        artwork = MoodArtwork.City,
+        icon = Icons.Rounded.NightsStay,
     ),
     CuratedMood(
         id = "workout",
         titleRes = R.string.mood_workout,
         descriptionRes = R.string.mood_workout_desc,
-        tags = listOf("Dance", "Electronic", "Rock"),
-        icon = Icons.Rounded.ElectricBolt,
-        artwork = MoodArtwork.Runner,
+        icon = Icons.Rounded.FitnessCenter,
     ),
 )
 
@@ -577,12 +538,10 @@ fun MainScreen(
                     LaunchedEffect(forYouCountryCode) { viewModel.setForYouCountry(forYouCountryCode) }
                     val hasCountrySelection = forYouStations.isNotEmpty()
                     HomeTabContent(
-                        allTags = allTags,
                         forYouStations = forYouStations.ifEmpty { featuredStations },
                         forYouCountry = countryName(forYouCountryCode, appLocale).takeIf { hasCountrySelection },
                         listState = homeListState,
                         bottomPadding = stationContentBottomPadding,
-                        onCategoryTap = { viewModel.playRandomFromCategory(it) },
                         onMoodTap = { selectedMoodId = it.id },
                         onFeaturedStationTap = { viewModel.playFromRegistry(it) },
                         onForYouViewAll = {
@@ -601,9 +560,10 @@ fun MainScreen(
                         listState = favoritesListState,
                         bottomPadding = stationContentBottomPadding,
                         onPlay = { viewModel.play(it) },
+                        onTogglePlayback = { viewModel.togglePlayback() },
+                        onToggleFavorite = { viewModel.toggleFavorite(it) },
                         onHomeViewModeChange = { viewModel.setHomeViewMode(it) },
                         onSortSelected = { viewModel.setFavoritesSort(it) },
-                        onAddTapped = ::openRegistrySearch,
                         onStationLongPress = { contextStation = it },
                     )
                 }
@@ -1382,6 +1342,7 @@ private fun NoNetworkState() {
 private fun HomeEmptyState(
     text: String,
     supportingText: String,
+    icon: ImageVector = Icons.Rounded.Radio,
 ) {
     Box(
         modifier = Modifier
@@ -1400,7 +1361,7 @@ private fun HomeEmptyState(
             ) {
                 Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
                     Icon(
-                        imageVector = Icons.Rounded.Radio,
+                        imageVector = icon,
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.onSecondaryContainer,
                         modifier = Modifier.size(36.dp),
@@ -1427,13 +1388,11 @@ private fun HomeEmptyState(
 
 @Composable
 private fun HomeTabContent(
-    allTags: List<String>,
     forYouStations: List<com.shapeshed.aerial.data.RegistryStation>,
     // Null when the selection isn't country-specific; the header drops the country.
     forYouCountry: String?,
     listState: LazyListState,
     bottomPadding: androidx.compose.ui.unit.Dp,
-    onCategoryTap: (String) -> Unit,
     onMoodTap: (CuratedMood) -> Unit,
     onFeaturedStationTap: (com.shapeshed.aerial.data.RegistryStation) -> Unit,
     onForYouViewAll: () -> Unit,
@@ -1501,23 +1460,7 @@ private fun HomeTabContent(
             MoodGrid(
                 moods = CURATED_MOODS,
                 onMoodTap = onMoodTap,
-                modifier = Modifier.padding(horizontal = 16.dp),
-            )
-        }
-
-        item("just-listen-header") {
-            Text(
-                text = stringResource(R.string.just_listen),
-                style = MaterialTheme.typography.headlineSmall,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 20.dp, bottom = 12.dp),
-            )
-        }
-        item("just-listen-pills") {
-            CategoryGrid(
-                tags = allTags.take(10),
-                onCategoryTap = onCategoryTap,
-                modifier = Modifier.padding(horizontal = 16.dp),
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
             )
         }
     }
@@ -1557,63 +1500,52 @@ private fun MoodCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // Stock filled card (spec container colour and medium corner radius), matching the
-    // For You tiles; the artwork covers the container so only the shape shows.
+    // Same neutral tonal surface as the favourites station tiles, rather than an accent
+    // colour — text/icon pairing matches how every other neutral surface in the app reads
+    // (onSurface for primary text, onSurfaceVariant for supporting text and icon glyphs).
+    val background = MaterialTheme.colorScheme.surfaceContainerHigh
+    val titleColor = MaterialTheme.colorScheme.onSurface
+    val supportingColor = MaterialTheme.colorScheme.onSurfaceVariant
     Card(
         onClick = onClick,
+        colors = CardDefaults.cardColors(containerColor = background, contentColor = titleColor),
         modifier = modifier.height(132.dp),
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
-            MoodArtwork(
-                artwork = mood.artwork,
-                modifier = Modifier.fillMaxSize(),
-            )
-            Box(
+            // Top-right, clear of the title/description anchored bottom-left, so the icon
+            // never sits behind the text on these narrow tiles. Card clips its content to its
+            // own shape, so the oversized icon is simply cut off at the corner — no manual
+            // clipping needed to get the "bleeding off the edge" effect.
+            Icon(
+                imageVector = mood.icon,
+                contentDescription = null,
+                tint = supportingColor.copy(alpha = 0.4f),
                 modifier = Modifier
-                    .fillMaxSize()
-                    .background(
-                        Brush.verticalGradient(
-                            0f to MaterialTheme.colorScheme.surface.copy(alpha = 0.08f),
-                            1f to MaterialTheme.colorScheme.surface.copy(alpha = 0.44f),
-                        ),
-                    ),
+                    .size(108.dp)
+                    .align(Alignment.TopEnd)
+                    .offset(x = 24.dp, y = (-24).dp),
             )
             Column(
-                verticalArrangement = Arrangement.SpaceBetween,
+                verticalArrangement = Arrangement.Bottom,
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(14.dp),
             ) {
-                Surface(
-                    color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.9f),
-                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                    shape = CircleShape,
-                    modifier = Modifier.size(36.dp),
-                ) {
-                    Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-                        Icon(
-                            imageVector = mood.icon,
-                            contentDescription = null,
-                            modifier = Modifier.size(20.dp),
-                        )
-                    }
-                }
-                Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                    Text(
-                        text = stringResource(mood.titleRes),
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    Text(
-                        text = stringResource(mood.descriptionRes),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
+                Text(
+                    text = stringResource(mood.titleRes),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = titleColor,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = stringResource(mood.descriptionRes),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = supportingColor,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
         }
     }
@@ -1642,27 +1574,33 @@ private fun MoodDetailScreen(
         modifier = Modifier.fillMaxSize(),
     ) {
         item("mood-hero") {
+            // Same neutral tonal surface as the favourites station tiles and the grid tiles
+            // above, rather than an accent colour.
+            val background = MaterialTheme.colorScheme.surfaceContainerHigh
+            val titleColor = MaterialTheme.colorScheme.onSurface
+            val supportingColor = MaterialTheme.colorScheme.onSurfaceVariant
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(360.dp),
+                    .height(280.dp)
+                    // The oversized icon is deliberately offset past this box's own edge to
+                    // bleed off the corner; without clipping, that overflow paints straight
+                    // into the content below instead of stopping at the header.
+                    .clipToBounds()
+                    .background(background),
             ) {
-                MoodArtwork(
-                    artwork = mood.artwork,
-                    modifier = Modifier.fillMaxSize(),
-                )
-                Box(
+                Icon(
+                    imageVector = mood.icon,
+                    contentDescription = null,
+                    tint = supportingColor.copy(alpha = 0.4f),
                     modifier = Modifier
-                        .fillMaxSize()
-                        .background(
-                            Brush.verticalGradient(
-                                0f to MaterialTheme.colorScheme.surface.copy(alpha = 0.08f),
-                                1f to MaterialTheme.colorScheme.surface.copy(alpha = 0.42f),
-                            ),
-                        ),
+                        .size(220.dp)
+                        .align(Alignment.BottomEnd)
+                        .offset(x = 48.dp, y = 48.dp),
                 )
                 IconButton(
                     onClick = onBack,
+                    colors = IconButtonDefaults.iconButtonColors(contentColor = titleColor),
                     shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
                     modifier = Modifier
                         .windowInsetsPadding(WindowInsets.statusBars)
@@ -1679,12 +1617,12 @@ private fun MoodDetailScreen(
                     Text(
                         text = stringResource(mood.titleRes),
                         style = MaterialTheme.typography.displaySmall,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        color = titleColor,
                     )
                     Text(
                         text = stringResource(mood.detailDescriptionRes),
                         style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        color = supportingColor,
                         modifier = Modifier.fillMaxWidth(0.72f),
                     )
                 }
@@ -1833,522 +1771,6 @@ private fun MoodStationRow(
 }
 
 @Composable
-private fun MoodArtwork(
-    artwork: MoodArtwork,
-    modifier: Modifier = Modifier,
-) {
-    val scheme = MaterialTheme.colorScheme
-    // clipToBounds: the scenes draw glows and rotated shapes that may exceed the canvas,
-    // and not every host (e.g. the mood detail header) clips with a shape.
-    Canvas(modifier = modifier.clipToBounds()) {
-        when (artwork) {
-            MoodArtwork.Coast -> drawCoastMood(scheme)
-            MoodArtwork.Mountains -> drawMountainMood(scheme)
-            MoodArtwork.Sunrise -> drawSunriseMood(scheme)
-            MoodArtwork.Road -> drawRoadMood(scheme)
-            MoodArtwork.City -> drawCityMood(scheme)
-            MoodArtwork.Runner -> drawRunnerMood(scheme)
-        }
-    }
-}
-
-// The scenes below are drawn entirely from the Material colour scheme so they re-tint with
-// the wallpaper palette. Each mood owns its sky, light source, and landscape rather than
-// sharing generic layers, and every position is a fixed fraction of the canvas so the art
-// is deterministic across sizes.
-
-private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawSky(
-    top: Color,
-    mid: Color,
-    bottom: Color,
-) {
-    drawRect(brush = Brush.verticalGradient(0f to top, 0.55f to mid, 1f to bottom))
-}
-
-// A light source with a soft radial halo fading to nothing around a solid core.
-private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawGlow(
-    color: Color,
-    center: Offset,
-    coreRadius: Float,
-    glowRadius: Float,
-    coreAlpha: Float = 0.8f,
-    glowAlpha: Float = 0.4f,
-) {
-    drawCircle(
-        brush = Brush.radialGradient(
-            colors = listOf(color.copy(alpha = glowAlpha), color.copy(alpha = 0f)),
-            center = center,
-            radius = glowRadius,
-        ),
-        radius = glowRadius,
-        center = center,
-    )
-    drawCircle(color.copy(alpha = coreAlpha), coreRadius, center)
-}
-
-private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawBird(
-    color: Color,
-    center: Offset,
-    span: Float,
-    strokeWidth: Float,
-) {
-    val wing = Path().apply {
-        moveTo(center.x - span, center.y)
-        quadraticTo(center.x - span * 0.5f, center.y - span * 0.7f, center.x, center.y)
-        quadraticTo(center.x + span * 0.5f, center.y - span * 0.7f, center.x + span, center.y)
-    }
-    drawPath(wing, color, style = androidx.compose.ui.graphics.drawscope.Stroke(width = strokeWidth, cap = StrokeCap.Round))
-}
-
-// Calm sea at golden hour: low sun, glitter path on the water, headlands, gulls.
-private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawCoastMood(
-    scheme: androidx.compose.material3.ColorScheme,
-) {
-    val horizon = size.height * 0.55f
-    drawSky(
-        top = lerp(scheme.tertiaryContainer, scheme.primaryContainer, 0.3f),
-        mid = lerp(scheme.tertiaryContainer, scheme.tertiary, 0.15f),
-        bottom = lerp(scheme.surface, scheme.tertiaryContainer, 0.5f),
-    )
-    drawGlow(
-        color = scheme.tertiary,
-        center = Offset(size.width * 0.70f, horizon - size.height * 0.13f),
-        coreRadius = size.minDimension * 0.085f,
-        glowRadius = size.minDimension * 0.34f,
-    )
-    // Sea with depth, brightest at the horizon.
-    drawRect(
-        brush = Brush.verticalGradient(
-            horizon / size.height to lerp(scheme.primaryContainer, scheme.tertiary, 0.25f).copy(alpha = 0.55f),
-            1f to scheme.primary.copy(alpha = 0.35f),
-        ),
-        topLeft = Offset(0f, horizon),
-        size = androidx.compose.ui.geometry.Size(size.width, size.height - horizon),
-    )
-    drawLine(
-        color = scheme.tertiaryContainer.copy(alpha = 0.6f),
-        start = Offset(0f, horizon),
-        end = Offset(size.width, horizon),
-        strokeWidth = 1.5.dp.toPx(),
-    )
-    // Sun glitter: tapering dashes down the water.
-    val glitterX = size.width * 0.70f
-    repeat(5) { index ->
-        val t = index / 4f
-        val y = horizon + size.height * (0.05f + 0.075f * index)
-        val half = size.width * (0.055f - 0.008f * index)
-        drawLine(
-            color = scheme.tertiary.copy(alpha = 0.5f - 0.08f * index),
-            start = Offset(glitterX - half + size.width * 0.01f * t, y),
-            end = Offset(glitterX + half, y),
-            strokeWidth = (2.5f - 0.3f * index).dp.toPx(),
-            cap = StrokeCap.Round,
-        )
-    }
-    // Headland sliding in from the left.
-    val headland = Path().apply {
-        moveTo(0f, horizon)
-        cubicTo(size.width * 0.10f, horizon - size.height * 0.10f, size.width * 0.22f, horizon - size.height * 0.02f, size.width * 0.34f, horizon)
-        lineTo(0f, horizon)
-        close()
-    }
-    drawPath(headland, scheme.primary.copy(alpha = 0.45f))
-    drawBird(scheme.onSurface.copy(alpha = 0.4f), Offset(size.width * 0.30f, size.height * 0.24f), size.minDimension * 0.035f, 1.8.dp.toPx())
-    drawBird(scheme.onSurface.copy(alpha = 0.3f), Offset(size.width * 0.40f, size.height * 0.18f), size.minDimension * 0.025f, 1.5.dp.toPx())
-}
-
-// Still, hazy ranges receding into mist, with snow on the far peaks.
-private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawMountainMood(
-    scheme: androidx.compose.material3.ColorScheme,
-) {
-    val skyTop = lerp(scheme.secondaryContainer, scheme.surfaceVariant, 0.35f)
-    drawSky(
-        top = skyTop,
-        mid = lerp(skyTop, scheme.surface, 0.45f),
-        bottom = lerp(scheme.surface, scheme.secondaryContainer, 0.35f),
-    )
-    drawGlow(
-        color = scheme.secondary,
-        center = Offset(size.width * 0.26f, size.height * 0.20f),
-        coreRadius = size.minDimension * 0.05f,
-        glowRadius = size.minDimension * 0.2f,
-        coreAlpha = 0.35f,
-        glowAlpha = 0.2f,
-    )
-    // Back range, faded into the sky, with snow caps.
-    val backTop = size.height * 0.34f
-    val back = Path().apply {
-        moveTo(0f, size.height * 0.62f)
-        lineTo(size.width * 0.24f, backTop)
-        lineTo(size.width * 0.42f, size.height * 0.56f)
-        lineTo(size.width * 0.62f, size.height * 0.40f)
-        lineTo(size.width * 0.80f, size.height * 0.58f)
-        lineTo(size.width, size.height * 0.48f)
-        lineTo(size.width, size.height)
-        lineTo(0f, size.height)
-        close()
-    }
-    drawPath(back, lerp(skyTop, scheme.secondary, 0.35f).copy(alpha = 0.7f))
-    // Snow caps on the two tallest back peaks.
-    listOf(
-        Offset(size.width * 0.24f, backTop) to size.width * 0.05f,
-        Offset(size.width * 0.62f, size.height * 0.40f) to size.width * 0.04f,
-    ).forEach { (peak, halfWidth) ->
-        val cap = Path().apply {
-            moveTo(peak.x - halfWidth, peak.y + halfWidth * 0.9f)
-            lineTo(peak.x, peak.y)
-            lineTo(peak.x + halfWidth, peak.y + halfWidth * 0.9f)
-            close()
-        }
-        drawPath(cap, lerp(scheme.surface, scheme.onSurface, 0.08f).copy(alpha = 0.75f))
-    }
-    // Mist band between the ranges.
-    drawRect(
-        brush = Brush.verticalGradient(
-            0.58f to scheme.surface.copy(alpha = 0f),
-            0.68f to scheme.surface.copy(alpha = 0.35f),
-            0.78f to scheme.surface.copy(alpha = 0f),
-        ),
-    )
-    // Front ridge, strongest.
-    val front = Path().apply {
-        moveTo(0f, size.height * 0.86f)
-        lineTo(size.width * 0.20f, size.height * 0.64f)
-        lineTo(size.width * 0.40f, size.height * 0.80f)
-        lineTo(size.width * 0.58f, size.height * 0.62f)
-        lineTo(size.width * 0.78f, size.height * 0.82f)
-        lineTo(size.width, size.height * 0.70f)
-        lineTo(size.width, size.height)
-        lineTo(0f, size.height)
-        close()
-    }
-    drawPath(front, scheme.secondary.copy(alpha = 0.55f))
-}
-
-// Big sun lifting out of rolling hills, halo rings widening into the morning sky.
-private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawSunriseMood(
-    scheme: androidx.compose.material3.ColorScheme,
-) {
-    drawSky(
-        top = lerp(scheme.primaryContainer, scheme.surface, 0.25f),
-        mid = lerp(scheme.tertiaryContainer, scheme.tertiary, 0.2f),
-        bottom = lerp(scheme.tertiary, scheme.tertiaryContainer, 0.35f),
-    )
-    val sunCenter = Offset(size.width * 0.5f, size.height * 0.60f)
-    // Halo rings around the rising sun.
-    listOf(0.30f to 0.10f, 0.42f to 0.06f).forEach { (radiusFraction, alpha) ->
-        drawCircle(
-            color = scheme.tertiary.copy(alpha = alpha),
-            radius = size.minDimension * radiusFraction,
-            center = sunCenter,
-            style = androidx.compose.ui.graphics.drawscope.Stroke(width = 2.dp.toPx()),
-        )
-    }
-    drawGlow(
-        color = scheme.tertiary,
-        center = sunCenter,
-        coreRadius = size.minDimension * 0.17f,
-        glowRadius = size.minDimension * 0.48f,
-        coreAlpha = 0.85f,
-        glowAlpha = 0.5f,
-    )
-    drawBird(scheme.onSurface.copy(alpha = 0.35f), Offset(size.width * 0.76f, size.height * 0.26f), size.minDimension * 0.03f, 1.8.dp.toPx())
-    // Hills drawn after the sun so it rises from behind them.
-    val backHill = Path().apply {
-        moveTo(0f, size.height * 0.72f)
-        cubicTo(size.width * 0.25f, size.height * 0.60f, size.width * 0.45f, size.height * 0.74f, size.width * 0.68f, size.height * 0.66f)
-        cubicTo(size.width * 0.85f, size.height * 0.60f, size.width * 0.94f, size.height * 0.68f, size.width, size.height * 0.64f)
-        lineTo(size.width, size.height)
-        lineTo(0f, size.height)
-        close()
-    }
-    drawPath(backHill, lerp(scheme.tertiary, scheme.primary, 0.55f).copy(alpha = 0.5f))
-    val frontHill = Path().apply {
-        moveTo(0f, size.height * 0.88f)
-        cubicTo(size.width * 0.22f, size.height * 0.76f, size.width * 0.48f, size.height * 0.92f, size.width * 0.72f, size.height * 0.80f)
-        cubicTo(size.width * 0.88f, size.height * 0.73f, size.width * 0.96f, size.height * 0.80f, size.width, size.height * 0.78f)
-        lineTo(size.width, size.height)
-        lineTo(0f, size.height)
-        close()
-    }
-    drawPath(frontHill, scheme.primary.copy(alpha = 0.5f))
-}
-
-// Open road to a vanishing point on the horizon, driving into the light.
-private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawRoadMood(
-    scheme: androidx.compose.material3.ColorScheme,
-) {
-    val horizon = size.height * 0.52f
-    val vanish = Offset(size.width * 0.60f, horizon)
-    drawSky(
-        top = lerp(scheme.primaryContainer, scheme.secondaryContainer, 0.4f),
-        mid = lerp(scheme.primaryContainer, scheme.tertiaryContainer, 0.45f),
-        bottom = lerp(scheme.surface, scheme.tertiaryContainer, 0.55f),
-    )
-    drawGlow(
-        color = scheme.tertiary,
-        center = vanish.copy(y = horizon - size.height * 0.04f),
-        coreRadius = size.minDimension * 0.06f,
-        glowRadius = size.minDimension * 0.3f,
-        coreAlpha = 0.6f,
-    )
-    // Distant ridge on the skyline.
-    val ridge = Path().apply {
-        moveTo(0f, horizon)
-        lineTo(size.width * 0.18f, horizon - size.height * 0.07f)
-        lineTo(size.width * 0.38f, horizon - size.height * 0.015f)
-        lineTo(size.width * 0.86f, horizon - size.height * 0.09f)
-        lineTo(size.width, horizon - size.height * 0.03f)
-        lineTo(size.width, horizon)
-        close()
-    }
-    drawPath(ridge, scheme.secondary.copy(alpha = 0.35f))
-    // Ground plane.
-    drawRect(
-        brush = Brush.verticalGradient(
-            horizon / size.height to scheme.secondaryContainer.copy(alpha = 0.5f),
-            1f to scheme.secondary.copy(alpha = 0.45f),
-        ),
-        topLeft = Offset(0f, horizon),
-        size = androidx.compose.ui.geometry.Size(size.width, size.height - horizon),
-    )
-    // Road converging on the vanishing point.
-    val road = Path().apply {
-        moveTo(size.width * 0.24f, size.height)
-        lineTo(vanish.x - size.width * 0.012f, vanish.y)
-        lineTo(vanish.x + size.width * 0.012f, vanish.y)
-        lineTo(size.width * 0.88f, size.height)
-        close()
-    }
-    drawPath(
-        road,
-        brush = Brush.verticalGradient(
-            horizon / size.height to scheme.onSurface.copy(alpha = 0.18f),
-            1f to scheme.onSurface.copy(alpha = 0.34f),
-        ),
-    )
-    // Centre line dashes shrinking with distance.
-    val dashes = listOf(0.97f to 0.885f, 0.83f to 0.755f, 0.71f to 0.665f, 0.62f to 0.585f)
-    dashes.forEachIndexed { index, (startT, endT) ->
-        fun along(t: Float): Offset {
-            val bottomCentre = Offset(size.width * 0.56f, size.height)
-            return Offset(
-                bottomCentre.x + (vanish.x - bottomCentre.x) * (1f - t),
-                size.height + (vanish.y - size.height) * (1f - t),
-            )
-        }
-        drawLine(
-            color = lerp(scheme.surface, scheme.tertiaryContainer, 0.4f).copy(alpha = 0.85f - 0.12f * index),
-            start = along(startT),
-            end = along(endT),
-            strokeWidth = (3.5f - 0.7f * index).dp.toPx(),
-            cap = StrokeCap.Round,
-        )
-    }
-}
-
-// Night skyline: stars, a haloed moon, two building rows, and lit windows.
-private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawCityMood(
-    scheme: androidx.compose.material3.ColorScheme,
-) {
-    drawSky(
-        top = lerp(scheme.surface, scheme.primary, 0.10f),
-        mid = lerp(scheme.surface, scheme.primary, 0.22f),
-        bottom = lerp(scheme.surface, scheme.primaryContainer, 0.5f),
-    )
-    // Stars: fixed constellation, brighter high up.
-    listOf(
-        Offset(0.10f, 0.14f), Offset(0.22f, 0.08f), Offset(0.33f, 0.20f), Offset(0.45f, 0.10f),
-        Offset(0.55f, 0.24f), Offset(0.63f, 0.07f), Offset(0.87f, 0.12f), Offset(0.94f, 0.26f),
-        Offset(0.16f, 0.30f), Offset(0.50f, 0.33f),
-    ).forEachIndexed { index, fraction ->
-        drawCircle(
-            color = lerp(scheme.surface, scheme.onSurface, 0.85f).copy(alpha = if (index % 3 == 0) 0.6f else 0.35f),
-            radius = (if (index % 4 == 0) 1.6f else 1.1f).dp.toPx(),
-            center = Offset(size.width * fraction.x, size.height * fraction.y),
-        )
-    }
-    drawGlow(
-        color = lerp(scheme.tertiaryContainer, scheme.tertiary, 0.3f),
-        center = Offset(size.width * 0.76f, size.height * 0.20f),
-        coreRadius = size.minDimension * 0.07f,
-        glowRadius = size.minDimension * 0.22f,
-        coreAlpha = 0.9f,
-        glowAlpha = 0.3f,
-    )
-    // Back row of towers, faded into the night haze.
-    val backTowers = listOf(0.00f to 0.48f, 0.14f to 0.38f, 0.30f to 0.52f, 0.47f to 0.42f, 0.66f to 0.55f, 0.84f to 0.44f)
-    backTowers.forEach { (leftFraction, topFraction) ->
-        drawRect(
-            color = lerp(scheme.surface, scheme.primary, 0.28f).copy(alpha = 0.55f),
-            topLeft = Offset(size.width * leftFraction, size.height * topFraction),
-            size = androidx.compose.ui.geometry.Size(size.width * 0.12f, size.height * (1f - topFraction)),
-        )
-    }
-    // Front skyline with an antenna beacon, plus gridded lit windows.
-    val frontBuildings = listOf(
-        Triple(0.04f, 0.14f, 0.58f),
-        Triple(0.21f, 0.17f, 0.48f),
-        Triple(0.41f, 0.12f, 0.64f),
-        Triple(0.56f, 0.18f, 0.52f),
-        Triple(0.77f, 0.16f, 0.60f),
-    )
-    val buildingColor = lerp(scheme.surface, scheme.primary, 0.14f)
-    frontBuildings.forEachIndexed { buildingIndex, (leftFraction, widthFraction, topFraction) ->
-        val left = size.width * leftFraction
-        val towerWidth = size.width * widthFraction
-        val top = size.height * topFraction
-        drawRect(
-            color = buildingColor,
-            topLeft = Offset(left, top),
-            size = androidx.compose.ui.geometry.Size(towerWidth, size.height - top),
-        )
-        if (buildingIndex == 1) {
-            val mastX = left + towerWidth * 0.5f
-            val mastTop = top - size.height * 0.09f
-            drawLine(
-                color = buildingColor,
-                start = Offset(mastX, top),
-                end = Offset(mastX, mastTop),
-                strokeWidth = 2.dp.toPx(),
-            )
-            drawCircle(
-                color = scheme.tertiary.copy(alpha = 0.9f),
-                radius = 1.8.dp.toPx(),
-                center = Offset(mastX, mastTop),
-            )
-        }
-        // Windows: a regular grid of small panes in the tower's upper half — mostly lit,
-        // a deterministic few dark — leaving the base calm behind the card text.
-        val columns = if (widthFraction > 0.15f) 3 else 2
-        val rows = 4
-        val paneWidth = towerWidth * 0.14f
-        val paneHeight = size.height * 0.022f
-        repeat(columns * rows) { windowIndex ->
-            if ((windowIndex * 7 + buildingIndex * 5) % 5 == 0) return@repeat
-            val column = windowIndex % columns
-            val row = windowIndex / columns
-            drawRect(
-                color = scheme.tertiary.copy(alpha = 0.6f),
-                topLeft = Offset(
-                    left + towerWidth * (0.16f + column * (0.68f / columns)),
-                    top + size.height * (0.035f + row * 0.055f),
-                ),
-                size = androidx.compose.ui.geometry.Size(paneWidth, paneHeight),
-            )
-        }
-    }
-    // Grounding band so the skyline settles into a dark street level.
-    drawRect(
-        brush = Brush.verticalGradient(
-            0.82f to scheme.surface.copy(alpha = 0f),
-            1f to scheme.surface.copy(alpha = 0.85f),
-        ),
-    )
-}
-
-// Runner at first light: leaning silhouette mid-stride with motion trails.
-private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawRunnerMood(
-    scheme: androidx.compose.material3.ColorScheme,
-) {
-    drawSky(
-        top = lerp(scheme.secondaryContainer, scheme.tertiaryContainer, 0.3f),
-        mid = lerp(scheme.tertiaryContainer, scheme.tertiary, 0.12f),
-        bottom = lerp(scheme.surface, scheme.tertiaryContainer, 0.5f),
-    )
-    drawGlow(
-        color = scheme.tertiary,
-        center = Offset(size.width * 0.22f, size.height * 0.38f),
-        coreRadius = size.minDimension * 0.10f,
-        glowRadius = size.minDimension * 0.32f,
-        coreAlpha = 0.7f,
-    )
-    // Rolling ground.
-    val ground = Path().apply {
-        moveTo(0f, size.height * 0.80f)
-        cubicTo(size.width * 0.3f, size.height * 0.72f, size.width * 0.6f, size.height * 0.82f, size.width, size.height * 0.74f)
-        lineTo(size.width, size.height)
-        lineTo(0f, size.height)
-        close()
-    }
-    drawPath(ground, scheme.secondary.copy(alpha = 0.4f))
-    // A running shoe mid-flight, toe kicked up, with motion trails behind the heel.
-    val body = lerp(scheme.onSurface, scheme.primary, 0.25f).copy(alpha = 0.8f)
-    val midsoleColor = lerp(scheme.surface, scheme.onSurface, 0.12f).copy(alpha = 0.9f)
-    val m = size.minDimension
-    val c = Offset(size.width * 0.63f, size.height * 0.50f)
-    rotate(degrees = -12f, pivot = c) {
-        val heelX = c.x - m * 0.175f
-        val toeX = c.x + m * 0.185f
-        val soleTop = c.y + m * 0.035f
-        // Midsole then outsole beneath it.
-        drawRoundRect(
-            color = midsoleColor,
-            topLeft = Offset(heelX, soleTop),
-            size = androidx.compose.ui.geometry.Size(toeX - heelX, m * 0.035f),
-            cornerRadius = androidx.compose.ui.geometry.CornerRadius(m * 0.018f),
-        )
-        drawRoundRect(
-            color = body,
-            topLeft = Offset(heelX, soleTop + m * 0.030f),
-            size = androidx.compose.ui.geometry.Size(toeX - heelX, m * 0.022f),
-            cornerRadius = androidx.compose.ui.geometry.CornerRadius(m * 0.011f),
-        )
-        // Upper: tall heel collar sweeping down to a low toe box.
-        val upper = Path().apply {
-            moveTo(heelX, soleTop)
-            lineTo(heelX, c.y - m * 0.075f)
-            quadraticTo(heelX + m * 0.015f, c.y - m * 0.105f, heelX + m * 0.06f, c.y - m * 0.10f)
-            quadraticTo(heelX + m * 0.13f, c.y - m * 0.09f, c.x + m * 0.04f, c.y - m * 0.035f)
-            quadraticTo(c.x + m * 0.115f, c.y + m * 0.005f, toeX, soleTop - m * 0.002f)
-            lineTo(heelX, soleTop)
-            close()
-        }
-        drawPath(upper, body)
-        // Collar opening.
-        drawLine(
-            color = midsoleColor.copy(alpha = 0.7f),
-            start = Offset(heelX + m * 0.055f, c.y - m * 0.092f),
-            end = Offset(heelX + m * 0.105f, c.y - m * 0.062f),
-            strokeWidth = 2.dp.toPx(),
-            cap = StrokeCap.Round,
-        )
-        // Laces across the instep.
-        repeat(3) { index ->
-            val t = index * m * 0.038f
-            drawLine(
-                color = midsoleColor,
-                start = Offset(c.x - m * 0.035f + t, c.y - m * 0.070f + t * 0.55f),
-                end = Offset(c.x + m * 0.005f + t, c.y - m * 0.098f + t * 0.55f),
-                strokeWidth = 2.2.dp.toPx(),
-                cap = StrokeCap.Round,
-            )
-        }
-        // Side accent stripe.
-        val accent = Path().apply {
-            moveTo(heelX + m * 0.03f, c.y - m * 0.005f)
-            quadraticTo(c.x - m * 0.02f, c.y + m * 0.028f, c.x + m * 0.09f, c.y - m * 0.012f)
-        }
-        drawPath(
-            accent,
-            scheme.tertiary.copy(alpha = 0.85f),
-            style = androidx.compose.ui.graphics.drawscope.Stroke(width = 2.5.dp.toPx(), cap = StrokeCap.Round),
-        )
-    }
-    // Motion trails behind the heel.
-    repeat(3) { index ->
-        val y = c.y - m * (0.055f - 0.05f * index)
-        drawLine(
-            color = body.copy(alpha = 0.35f - 0.08f * index),
-            start = Offset(c.x - m * (0.34f + 0.045f * index), y),
-            end = Offset(c.x - m * (0.21f + 0.02f * index), y),
-            strokeWidth = (3.2f - 0.5f * index).dp.toPx(),
-            cap = StrokeCap.Round,
-        )
-    }
-}
-
-@Composable
 private fun favoritesSortLabel(sort: FavoritesSort): String = stringResource(
     when (sort) {
         FavoritesSort.AZ -> R.string.sort_az
@@ -2370,16 +1792,29 @@ private fun FavoritesTabContent(
     listState: LazyListState,
     bottomPadding: androidx.compose.ui.unit.Dp,
     onPlay: (Station) -> Unit,
+    onTogglePlayback: () -> Unit,
+    onToggleFavorite: (Station) -> Unit,
     onHomeViewModeChange: (HomeViewMode) -> Unit,
     onSortSelected: (FavoritesSort) -> Unit,
-    onAddTapped: () -> Unit,
     onStationLongPress: (Station) -> Unit,
 ) {
+    // Matches Drive's "No starred files": just the illustration and caption, no sort/view
+    // controls (meaningless with nothing to sort) and no button — the search bar above is
+    // always the way in.
+    if (stations.isEmpty()) {
+        HomeEmptyState(
+            text = stringResource(R.string.no_favorites),
+            supportingText = stringResource(R.string.no_favorites_desc),
+            icon = Icons.Rounded.FavoriteBorder,
+        )
+        return
+    }
+
     val tileColor = MaterialTheme.colorScheme.surfaceContainerHigh
     val activeTileColor = MaterialTheme.colorScheme.primaryContainer
     val tileContentColor = MaterialTheme.colorScheme.onPrimaryContainer
     val favoriteRows = remember(stations, gridColumns) {
-        (0 until stations.size + 1).toList().chunked(gridColumns)
+        stations.indices.toList().chunked(gridColumns)
     }
     val showFavoriteActivityIndicators by remember {
         derivedStateOf { !listState.isScrollInProgress }
@@ -2452,7 +1887,6 @@ private fun FavoritesTabContent(
                     activeTileColor = activeTileColor,
                     tileContentColor = tileContentColor,
                     onPlay = onPlay,
-                    onAddTapped = onAddTapped,
                     onStationLongPress = onStationLongPress,
                 )
             }
@@ -2470,13 +1904,10 @@ private fun FavoritesTabContent(
                     isBuffering = isBuffering && isActive,
                     // Stable false for inactive rows — see the card-mode note above.
                     showActivityIndicator = showFavoriteActivityIndicators && isActive,
-                    onClick = { onPlay(station) },
+                    onPlay = { onPlay(station) },
+                    onTogglePlayback = onTogglePlayback,
+                    onToggleFavorite = { onToggleFavorite(station) },
                     onLongClick = { onStationLongPress(station) },
-                )
-            }
-            item("favorite-list-add", contentType = "favorite-list-add") {
-                AddStationListRow(
-                    onClick = onAddTapped,
                 )
             }
         }
@@ -2593,7 +2024,6 @@ private fun FavoriteStationCardRow(
     activeTileColor: androidx.compose.ui.graphics.Color,
     tileContentColor: androidx.compose.ui.graphics.Color,
     onPlay: (Station) -> Unit,
-    onAddTapped: () -> Unit,
     onStationLongPress: (Station) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -2606,59 +2036,26 @@ private fun FavoriteStationCardRow(
         ),
     ) {
         rowIndices.forEach { idx ->
-            if (idx < stations.size) {
-                val station = stations[idx]
-                val isActive = currentStation?.id == station.id
-                StationTile(
-                    station = station,
-                    tileColor = if (isActive) activeTileColor else tileColor,
-                    contentColor = tileContentColor,
-                    isActive = isActive,
-                    isPlaying = isPlaying && isActive,
-                    isBuffering = isBuffering && isActive,
-                    // Only the active tile can show an indicator, so inactive tiles get a
-                    // stable false and skip the recomposition when scrolling starts/stops.
-                    showActivityIndicator = showActivityIndicator && isActive,
-                    onClick = { onPlay(station) },
-                    onLongClick = { onStationLongPress(station) },
-                    modifier = Modifier.weight(1f),
-                )
-            } else {
-                AddTile(onClick = onAddTapped, modifier = Modifier.weight(1f))
-            }
+            val station = stations[idx]
+            val isActive = currentStation?.id == station.id
+            StationTile(
+                station = station,
+                tileColor = if (isActive) activeTileColor else tileColor,
+                contentColor = tileContentColor,
+                isActive = isActive,
+                isPlaying = isPlaying && isActive,
+                isBuffering = isBuffering && isActive,
+                // Only the active tile can show an indicator, so inactive tiles get a
+                // stable false and skip the recomposition when scrolling starts/stops.
+                showActivityIndicator = showActivityIndicator && isActive,
+                onClick = { onPlay(station) },
+                onLongClick = { onStationLongPress(station) },
+                modifier = Modifier.weight(1f),
+            )
         }
         repeat(columns - rowIndices.size) {
             Spacer(modifier = Modifier.weight(1f))
         }
-    }
-}
-
-@Composable
-private fun AddStationListRow(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    ListItem(
-        modifier = modifier.fillMaxWidth().clickable(onClick = onClick),
-        leadingContent = {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .size(50.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surfaceContainerHigh),
-            ) {
-                Icon(
-                    imageVector = Icons.Rounded.Add,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(24.dp),
-                )
-            }
-        },
-        supportingContent = { Text(stringResource(R.string.find_one_to_listen)) },
-    ) {
-        Text(stringResource(R.string.find_a_station))
     }
 }
 
@@ -2669,10 +2066,13 @@ private fun StationListRow(
     isPlaying: Boolean,
     isBuffering: Boolean,
     showActivityIndicator: Boolean,
-    onClick: () -> Unit,
+    onPlay: () -> Unit,
+    onTogglePlayback: () -> Unit,
+    onToggleFavorite: () -> Unit,
     onLongClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val pauseLabel = stringResource(R.string.pause)
     val haptic = LocalHapticFeedback.current
     val appLocale = LocalConfiguration.current.locales[0]
     val countryLabel = station.countryCode.takeIf { it.isNotBlank() }
@@ -2682,7 +2082,7 @@ private fun StationListRow(
         modifier = modifier
             .fillMaxWidth()
             .combinedClickable(
-                onClick = onClick,
+                onClick = onPlay,
                 onLongClick = {
                     haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                     onLongClick()
@@ -2701,18 +2101,43 @@ private fun StationListRow(
             }
         },
         trailingContent = {
-            when {
-                !showActivityIndicator -> Unit
-                isBuffering -> CircularWavyProgressIndicator(
-                    modifier = Modifier.size(26.dp),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    trackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
-                )
-                isActive && isPlaying -> EqualizerBars(
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(width = 30.dp, height = 24.dp),
-                    barCount = 3,
-                )
+            // Same preview-play + favourite pattern as the mood and search rows: a dedicated
+            // button toggles playback in place (rather than only via the row tap), and the
+            // heart removes the row directly. The glyph — not the button itself — is gated by
+            // showActivityIndicator, so the animated equalizer bars still skip recomposition
+            // during scroll (see the card-grid note elsewhere) without hiding a functional
+            // control; a still-correct tap lands even on the rare frame where the icon lags.
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                IconButton(
+                    onClick = if (isActive && isPlaying) onTogglePlayback else onPlay,
+                    shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
+                ) {
+                    when {
+                        showActivityIndicator && isBuffering -> CircularWavyProgressIndicator(
+                            modifier = Modifier.size(24.dp),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            trackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+                        )
+                        showActivityIndicator && isActive && isPlaying -> EqualizerBars(
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier
+                                .size(width = 28.dp, height = 22.dp)
+                                .semantics { contentDescription = pauseLabel },
+                            barCount = 3,
+                        )
+                        else -> Icon(Icons.Rounded.PlayArrow, contentDescription = stringResource(R.string.play))
+                    }
+                }
+                IconButton(
+                    onClick = onToggleFavorite,
+                    shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
+                ) {
+                    Icon(
+                        imageVector = if (station.isFavorite) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
+                        contentDescription = stringResource(if (station.isFavorite) R.string.remove_from_favorites else R.string.save_to_favorites),
+                        tint = if (station.isFavorite) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
         },
     ) {
@@ -2820,86 +2245,6 @@ private fun StationTile(
             textAlign = TextAlign.Center,
             modifier = Modifier.padding(top = 6.dp, start = 2.dp, end = 2.dp),
         )
-    }
-}
-
-@Composable
-private fun AddTile(onClick: () -> Unit, modifier: Modifier = Modifier) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier,
-    ) {
-        Surface(
-            onClick = onClick,
-            color = MaterialTheme.colorScheme.surfaceContainerHigh,
-            shape = MaterialTheme.shapes.medium,
-            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
-            modifier = Modifier.fillMaxWidth().aspectRatio(1f),
-        ) {
-            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-                Icon(
-                    imageVector = Icons.Rounded.Add,
-                    contentDescription = stringResource(R.string.find_a_station),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(32.dp),
-                )
-            }
-        }
-        Text(
-            text = stringResource(R.string.find_one_to_listen),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.padding(top = 4.dp, start = 2.dp, end = 2.dp),
-        )
-    }
-}
-
-@Composable
-private fun CategoryGrid(
-    tags: List<String>,
-    onCategoryTap: (String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    if (tags.isEmpty()) return
-    val tagLabels = rememberTagLabels()
-    Column(
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = modifier,
-    ) {
-        tags.chunked(2).forEach { pair ->
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                pair.forEach { tag ->
-                    Card(
-                        onClick = { onCategoryTap(tag) },
-                        colors = CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                        ),
-                        shape = MaterialTheme.shapes.large,
-                        modifier = Modifier.weight(1f).height(72.dp),
-                    ) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                            modifier = Modifier.padding(horizontal = 16.dp).fillMaxSize(),
-                        ) {
-                            Icon(
-                                imageVector = CATEGORY_ICONS[tag] ?: Icons.Rounded.MusicNote,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary,
-                            )
-                            Text(tagLabels[tag] ?: tag, style = MaterialTheme.typography.titleMedium)
-                        }
-                    }
-                }
-                if (pair.size == 1) Spacer(Modifier.weight(1f))
-            }
-        }
     }
 }
 

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -423,15 +423,6 @@ class MainViewModel(
         runSearch(_lastSearchQuery)
     }
 
-    fun playRandomFromCategory(tag: String) {
-        viewModelScope.launch {
-            val station = withContext(Dispatchers.IO) {
-                registryRepository.randomByCategory(tag.lowercase())
-            } ?: return@launch
-            playFromRegistry(station)
-        }
-    }
-
     fun playRandomFromMood(tags: List<String>) {
         viewModelScope.launch {
             val station = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -735,7 +735,19 @@ class MainViewModel(
             conn.connectTimeout = 10_000
             conn.readTimeout = 10_000
             try {
-                val dest = logoFileForUrl(url, dir, conn.contentType)
+                // A dead/moved logo URL can respond with a redirect or an HTML error page
+                // instead of an image (e.g. a 301 whose body is just an nginx redirect
+                // notice) — without this check that body gets saved to disk as if it were
+                // the logo. On rejection the caller falls back to the raw URL, which Coil's
+                // own HTTP client can still resolve correctly at render time (it isn't
+                // restricted to same-protocol redirects the way HttpURLConnection is).
+                val contentType = conn.contentType?.substringBefore(';')?.trim()
+                if (conn.responseCode != HttpURLConnection.HTTP_OK ||
+                    (contentType != null && !contentType.startsWith("image/"))
+                ) {
+                    return null
+                }
+                val dest = logoFileForUrl(url, dir, contentType)
                 conn.inputStream.use { input ->
                     dest.outputStream().use { output -> input.copyTo(output) }
                 }

--- a/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -64,6 +65,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -80,12 +82,16 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import androidx.compose.ui.res.stringResource
 import com.shapeshed.aerial.R
 import com.shapeshed.aerial.data.NowPlayingInfo
 import com.shapeshed.aerial.data.SleepTimerState
 import com.shapeshed.aerial.data.Station
+import java.io.File
 import kotlin.math.abs
 
 private fun Station.matchesStation(other: Station): Boolean =
@@ -97,6 +103,17 @@ private fun Station.matchesStation(other: Station): Boolean =
             providerId == other.providerId)
 
 private fun circularPageIndex(page: Int, size: Int): Int = ((page % size) + size) % size
+
+// A station's own saved logo, resolved the same way StationAvatar does. Used as full-bleed
+// artwork for swipe-pager pages that aren't the actively playing station: those have no live
+// "now playing" metadata (that pipeline only feeds the active MediaController), but the
+// station's own logo is still real artwork — showing it full-bleed keeps every page visually
+// consistent, instead of falling back to the small circular avatar meant for list rows.
+private fun Station.ownLogoModel(): Any? = when {
+    logoPath.startsWith("http") -> logoPath
+    logoPath.isNotEmpty() -> File(logoPath)
+    else -> null
+}
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -124,6 +141,7 @@ fun NowPlayingScreen(
     val shareStationLabel = stringResource(R.string.share_station)
     val dismissThresholdPx = with(LocalDensity.current) { 96.dp.toPx() }
     var dragOffsetY by remember { mutableFloatStateOf(0f) }
+    val dismissScope = rememberCoroutineScope()
     // Horizontal paging steps through swipeStations (the favourites in their selected sort
     // order). A non-favourite station isn't in the list, so the artwork stays static for it.
     val swipeIndex = remember(swipeStations, station) {
@@ -165,6 +183,17 @@ fun NowPlayingScreen(
     // when the enricher supplied its own artwork. Otherwise the main image already is the
     // station logo, so the small logo badge would just duplicate it.
     val mainArtworkIsDistinct = nowPlayingInfo?.artworkData != null || !nowPlayingInfo?.artworkUrl.isNullOrBlank()
+    // When there's no distinct enrichment artwork, mainArtworkModel is just whatever play()
+    // wrote into the MediaItem for system media surfaces: the station's own logo if it has
+    // one, or the app icon as a last resort if it doesn't. That value also arrives
+    // asynchronously (play() clears it, and it only repopulates once the media session's
+    // metadata callback fires again), so using it here would both flash through the small
+    // circular avatar for a frame after every swipe and, for a logo-less station, "upgrade"
+    // to showing the app's launcher icon as if it were the station's own artwork. Resolving
+    // the station's own logo directly — synchronously, no gap — avoids both: it's the exact
+    // image the pager already showed for this page before it became active, and it's simply
+    // absent (falling back to the avatar, not the app icon) for a station with no logo.
+    val activeArtworkModel = if (mainArtworkIsDistinct) mainArtworkModel else station.ownLogoModel()
     val trackArtworkModel = when {
         track?.artworkData != null -> track.artworkData
         track?.artworkUrl?.isNotBlank() == true -> track.artworkUrl
@@ -172,7 +201,7 @@ fun NowPlayingScreen(
         !currentTrackArtworkUrl.isNullOrBlank() -> currentTrackArtworkUrl
         else -> null
     }
-    var mainArtworkFailed by remember(mainArtworkModel) { mutableStateOf(false) }
+    var mainArtworkFailed by remember(activeArtworkModel) { mutableStateOf(false) }
     var trackArtworkFailed by remember(trackArtworkModel) { mutableStateOf(false) }
     // The track flows reset asynchronously when the station changes, so for a frame or two
     // the previous station's song can pair with the new station. Hide the track card from
@@ -214,6 +243,18 @@ fun NowPlayingScreen(
                     onDragEnd = {
                         if (dragOffsetY >= dismissThresholdPx) {
                             onDismiss()
+                            // Deferred, not immediate: resetting dragOffsetY synchronously here
+                            // would zero out this graphicsLayer's translationY on the same frame
+                            // the outer AnimatedVisibility's own exit slide starts from *its*
+                            // zero baseline, so the pane visibly snapped up before sliding back
+                            // down. Waiting until well after the exit animation has finished
+                            // avoids that flicker, while still guaranteeing the offset is clean
+                            // before a fast reopen — the scenario this reset exists for — could
+                            // plausibly reuse this composable's state mid-exit.
+                            dismissScope.launch {
+                                delay(500)
+                                dragOffsetY = 0f
+                            }
                         } else {
                             dragOffsetY = 0f
                         }
@@ -284,18 +325,32 @@ fun NowPlayingScreen(
                         pageSpacing = 24.dp,
                     ) { page ->
                         val pageStation = swipeStations[circularPageIndex(page, swipeStations.size)]
-                        StationArtworkSurface(
-                            station = pageStation,
-                            shape = artworkShape,
-                            artworkModel = mainArtworkModel.takeIf { pageStation.matchesStation(station) && !mainArtworkFailed },
-                            onArtworkError = { mainArtworkFailed = true },
-                        )
+                        if (pageStation.matchesStation(station)) {
+                            StationArtworkSurface(
+                                station = pageStation,
+                                shape = artworkShape,
+                                artworkModel = activeArtworkModel.takeIf { !mainArtworkFailed },
+                                onArtworkError = { mainArtworkFailed = true },
+                            )
+                        } else {
+                            // Own logo, full-bleed — not the small circular avatar, and not
+                            // sharing mainArtworkFailed with the active page (a neighbour's
+                            // logo failing to load must not blank out the real artwork above).
+                            val ownLogoModel = pageStation.ownLogoModel()
+                            var ownLogoFailed by remember(ownLogoModel) { mutableStateOf(false) }
+                            StationArtworkSurface(
+                                station = pageStation,
+                                shape = artworkShape,
+                                artworkModel = ownLogoModel.takeIf { !ownLogoFailed },
+                                onArtworkError = { ownLogoFailed = true },
+                            )
+                        }
                     }
                 } else {
                     StationArtworkSurface(
                         station = station,
                         shape = artworkShape,
-                        artworkModel = mainArtworkModel.takeIf { !mainArtworkFailed },
+                        artworkModel = activeArtworkModel.takeIf { !mainArtworkFailed },
                         onArtworkError = { mainArtworkFailed = true },
                     )
                 }
@@ -713,10 +768,20 @@ private fun StationArtworkSurface(
             .fillMaxWidth()
             .aspectRatio(1f),
     ) {
-        Box(modifier = Modifier.fillMaxSize()) {
+        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
             if (artworkModel != null) {
+                val context = LocalContext.current
+                // Crossfade rather than pop: activeArtworkModel legitimately changes after a
+                // swipe settles (station logo shown first, upgraded to real enrichment artwork
+                // once the metadata pipeline catches up), and a hard cut reads as a flash.
+                val request = remember(context, artworkModel) {
+                    ImageRequest.Builder(context)
+                        .data(artworkModel)
+                        .crossfade(300)
+                        .build()
+                }
                 AsyncImage(
-                    model = artworkModel,
+                    model = request,
                     contentDescription = null,
                     // Fit (not Crop) so non-square artwork isn't cropped; the
                     // surface colour fills the letterbox space.
@@ -725,10 +790,15 @@ private fun StationArtworkSurface(
                     modifier = Modifier.fillMaxSize(),
                 )
             } else {
+                // Sized relative to the surface rather than a fixed dp value: every station
+                // in the swipe pager besides the one actually playing falls back to this
+                // avatar (only the active station has live "now playing" artwork), so a
+                // fixed size reads as jarringly smaller than the full-bleed artwork on the
+                // active page.
                 StationAvatar(
                     station = station,
                     isActive = true,
-                    size = 200.dp,
+                    size = maxWidth * 0.56f,
                     modifier = Modifier.align(Alignment.Center),
                 )
             }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -35,9 +35,6 @@
     <string name="home_view_list">Liste</string>
     <string name="search_stations_header">Stationen</string>
     <string name="view_all">Alle anzeigen</string>
-    <string name="just_listen">Einfach zuhören</string>
-    <string name="find_a_station">Sender finden</string>
-    <string name="find_one_to_listen">Finde einen zum Anhören</string>
     <string name="no_matches">Keine Treffer</string>
     <string name="no_matches_desc">Versuche eine andere Suche.</string>
     <string name="listen_by_mood">Passend zu deiner Stimmung</string>
@@ -111,4 +108,6 @@
     <string name="for_you">Für dich</string>
     <string name="favorites_grid_columns">Rasterbreite der Favoriten</string>
     <string name="favorites_grid_columns_desc">Spalten in der Kartenansicht</string>
+    <string name="no_favorites">Noch keine Favoriten</string>
+    <string name="no_favorites_desc">Füge Sender hinzu, die du liebst, um sie hier leicht wiederzufinden</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -35,9 +35,6 @@
     <string name="home_view_list">Lista</string>
     <string name="search_stations_header">Emisoras</string>
     <string name="view_all">Ver todo</string>
-    <string name="just_listen">Solo escucha</string>
-    <string name="find_a_station">Buscar una emisora</string>
-    <string name="find_one_to_listen">Encuentra una para escuchar</string>
     <string name="no_matches">Sin resultados</string>
     <string name="no_matches_desc">Prueba otra búsqueda.</string>
     <string name="listen_by_mood">Según tu estado de ánimo</string>
@@ -111,4 +108,6 @@
     <string name="for_you">Para ti</string>
     <string name="favorites_grid_columns">Ancho de la cuadrícula de favoritos</string>
     <string name="favorites_grid_columns_desc">Columnas en la vista de tarjetas</string>
+    <string name="no_favorites">Aún no tienes favoritos</string>
+    <string name="no_favorites_desc">Añade las emisoras que te gustan para encontrarlas fácilmente aquí</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -35,9 +35,6 @@
     <string name="home_view_list">Liste</string>
     <string name="search_stations_header">Stations</string>
     <string name="view_all">Tout voir</string>
-    <string name="just_listen">Écoutez, tout simplement</string>
-    <string name="find_a_station">Trouver une station</string>
-    <string name="find_one_to_listen">Trouvez-en une à écouter</string>
     <string name="no_matches">Aucun résultat</string>
     <string name="no_matches_desc">Essayez une autre recherche.</string>
     <string name="listen_by_mood">Selon votre humeur</string>
@@ -111,4 +108,6 @@
     <string name="for_you">Pour vous</string>
     <string name="favorites_grid_columns">Largeur de la grille des favoris</string>
     <string name="favorites_grid_columns_desc">Colonnes dans la vue en cartes</string>
+    <string name="no_favorites">Aucun favori pour l\'instant</string>
+    <string name="no_favorites_desc">Ajoutez vos stations préférées pour les retrouver facilement ici</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -35,9 +35,6 @@
     <string name="home_view_list">Elenco</string>
     <string name="search_stations_header">Stazioni</string>
     <string name="view_all">Vedi tutto</string>
-    <string name="just_listen">Ascolta e basta</string>
-    <string name="find_a_station">Trova una stazione</string>
-    <string name="find_one_to_listen">Trovane una da ascoltare</string>
     <string name="no_matches">Nessun risultato</string>
     <string name="no_matches_desc">Prova un\'altra ricerca.</string>
     <string name="listen_by_mood">In base al tuo umore</string>
@@ -111,4 +108,6 @@
     <string name="for_you">Per te</string>
     <string name="favorites_grid_columns">Larghezza della griglia dei preferiti</string>
     <string name="favorites_grid_columns_desc">Colonne nella vista a schede</string>
+    <string name="no_favorites">Nessun preferito</string>
+    <string name="no_favorites_desc">Aggiungi le stazioni che ami per ritrovarle facilmente qui</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -35,9 +35,6 @@
     <string name="home_view_list">リスト</string>
     <string name="search_stations_header">放送局</string>
     <string name="view_all">すべて表示</string>
-    <string name="just_listen">ただ聴くだけ</string>
-    <string name="find_a_station">放送局を探す</string>
-    <string name="find_one_to_listen">聴きたい放送局を見つけよう</string>
     <string name="no_matches">一致するものがありません</string>
     <string name="no_matches_desc">別のキーワードで検索してください。</string>
     <string name="listen_by_mood">気分に合わせて</string>
@@ -111,4 +108,6 @@
     <string name="for_you">あなたへのおすすめ</string>
     <string name="favorites_grid_columns">お気に入りのグリッド幅</string>
     <string name="favorites_grid_columns_desc">カード表示の列数</string>
+    <string name="no_favorites">お気に入りはまだありません</string>
+    <string name="no_favorites_desc">お気に入りの放送局を追加すると、ここからすぐに見つけられます</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -35,9 +35,6 @@
     <string name="home_view_list">목록</string>
     <string name="search_stations_header">방송국</string>
     <string name="view_all">모두 보기</string>
-    <string name="just_listen">그냥 들어보세요</string>
-    <string name="find_a_station">방송국 찾기</string>
-    <string name="find_one_to_listen">들을 방송국을 찾아보세요</string>
     <string name="no_matches">일치하는 항목 없음</string>
     <string name="no_matches_desc">다른 검색어를 시도하세요.</string>
     <string name="listen_by_mood">기분에 맞게</string>
@@ -111,4 +108,6 @@
     <string name="for_you">맞춤 추천</string>
     <string name="favorites_grid_columns">즐겨찾기 그리드 너비</string>
     <string name="favorites_grid_columns_desc">카드 보기의 열 수</string>
+    <string name="no_favorites">즐겨찾기가 없습니다</string>
+    <string name="no_favorites_desc">좋아하는 방송국을 추가하면 여기서 쉽게 찾을 수 있어요</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -35,9 +35,6 @@
     <string name="home_view_list">Lijst</string>
     <string name="search_stations_header">Stations</string>
     <string name="view_all">Alles bekijken</string>
-    <string name="just_listen">Gewoon luisteren</string>
-    <string name="find_a_station">Zoek een zender</string>
-    <string name="find_one_to_listen">Zoek er een om naar te luisteren</string>
     <string name="no_matches">Geen resultaten</string>
     <string name="no_matches_desc">Probeer een andere zoekopdracht.</string>
     <string name="listen_by_mood">Passend bij je stemming</string>
@@ -111,4 +108,6 @@
     <string name="for_you">Voor jou</string>
     <string name="favorites_grid_columns">Rasterbreedte van favorieten</string>
     <string name="favorites_grid_columns_desc">Kolommen in de kaartweergave</string>
+    <string name="no_favorites">Nog geen favorieten</string>
+    <string name="no_favorites_desc">Voeg zenders toe die je leuk vindt om ze hier snel terug te vinden</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -35,9 +35,6 @@
     <string name="home_view_list">Lista</string>
     <string name="search_stations_header">Estações</string>
     <string name="view_all">Ver tudo</string>
-    <string name="just_listen">É só ouvir</string>
-    <string name="find_a_station">Encontrar uma estação</string>
-    <string name="find_one_to_listen">Encontre uma para ouvir</string>
     <string name="no_matches">Nenhum resultado</string>
     <string name="no_matches_desc">Tente outra busca.</string>
     <string name="listen_by_mood">Combine com seu humor</string>
@@ -111,4 +108,6 @@
     <string name="for_you">Para você</string>
     <string name="favorites_grid_columns">Largura da grade de favoritos</string>
     <string name="favorites_grid_columns_desc">Colunas na visualização de cartões</string>
+    <string name="no_favorites">Ainda sem favoritos</string>
+    <string name="no_favorites_desc">Adicione as estações que você gosta para encontrá-las facilmente aqui</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -35,9 +35,6 @@
     <string name="home_view_list">列表</string>
     <string name="search_stations_header">电台</string>
     <string name="view_all">查看全部</string>
-    <string name="just_listen">尽情聆听</string>
-    <string name="find_a_station">查找电台</string>
-    <string name="find_one_to_listen">找一个来收听</string>
     <string name="no_matches">无匹配结果</string>
     <string name="no_matches_desc">请尝试其他搜索。</string>
     <string name="listen_by_mood">匹配你的心情</string>
@@ -111,4 +108,6 @@
     <string name="for_you">为你推荐</string>
     <string name="favorites_grid_columns">收藏网格宽度</string>
     <string name="favorites_grid_columns_desc">卡片视图的列数</string>
+    <string name="no_favorites">暂无收藏</string>
+    <string name="no_favorites_desc">添加喜欢的电台，方便在此快速找到</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,9 +35,6 @@
     <string name="home_view_list">List</string>
     <string name="search_stations_header">Stations</string>
     <string name="view_all">View all</string>
-    <string name="just_listen">Just listen</string>
-    <string name="find_a_station">Find a station</string>
-    <string name="find_one_to_listen">Find one to listen to</string>
     <string name="no_matches">No matches</string>
     <string name="no_matches_desc">Try a different search.</string>
     <string name="listen_by_mood">Match your mood</string>
@@ -113,4 +110,6 @@
     <string name="for_you">For you</string>
     <string name="favorites_grid_columns">Favorites grid width</string>
     <string name="favorites_grid_columns_desc">Columns shown in the cards view</string>
+    <string name="no_favorites">No favourites yet</string>
+    <string name="no_favorites_desc">Add stations you love to easily find them here</string>
 </resources>


### PR DESCRIPTION
## Summary
- Redesign "Listen by mood" cards onto a single neutral M3 container colour (matching station tiles) instead of per-mood painted scenes; drop the unused `tags` field from `CuratedMood`.
- Remove the "Just Listen" genre-pill section from Home.
- Favourites: list rows gain preview-play and favourite/remove controls matching mood/search rows; remove the "Find a station" add-tile/add-row; add a dedicated empty state for zero favourites.
- Fix several Now Playing swipe-pager artwork issues: inconsistent icon sizing between pages, inactive pages showing a small avatar instead of the station's own full-bleed logo, and flashes when swiping (through the small avatar, or briefly to the app's own launcher icon for logo-less stations). Artwork transitions now crossfade.
- Fix a drag-to-dismiss flicker caused by two independent offset/animation mechanisms disagreeing for a frame.
- Reject corrupt logo downloads: a logo URL that now redirects to an unrelated page was previously saved to disk as if the redirect's HTML body were the image, causing a permanent decode failure (and visible flash) for that station.

## Test plan
- [x] `./gradlew assembleDebug testDebugUnitTest`
- [x] Manually tested on device: mood cards, favourites list actions/empty state, Now Playing swipe pager (including a logo-less station), drag-to-dismiss gesture