### PR TITLE
Curate all mood playlists (relax, focus, morning, on the road, late night, workout)

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
@@ -37,85 +37,154 @@ private val CURATED_TAG_ORDER = listOf(
 // upstream on a future registry refresh (name alone would silently stop resolving). Curated
 // entries have no stable id (providerId is always "" in that bucket), so those refs still
 // fall back to matching by name.
-private data class MoodStationRef(val name: String, val provider: String? = null, val providerId: String? = null)
+//
+// displayName overrides the station's name for this mood list only (e.g. dropping a
+// disambiguator like "(International)" that's useful in search but redundant in a themed
+// list) — it does not touch the registry, so search results still show the real name.
+private data class MoodStationRef(
+    val name: String,
+    val provider: String? = null,
+    val providerId: String? = null,
+    val displayName: String? = null,
+)
 
 private val CURATED_MOOD_STATIONS = mapOf(
+    // Ordered so logo colours flow rather than clash: navy/blue -> white/orange -> red/gold ->
+    // dark/pink -> monochrome, with Café del Mar fixed first as requested.
     "relax" to listOf(
-        MoodStationRef("Café del Mar"),
-        MoodStationRef("Radio Paradise Mellow Mix", "curated"),
-        MoodStationRef("Soma FM Groove Salad", "curated"),
-        MoodStationRef("FIP", "curated"),
+        MoodStationRef("Café del Mar", "radio-browser", "3fd18c3f-8157-11e9-aa30-52543be04c81"),
+        // Registry name is "ABC-Loungr" (an upstream typo) — this is now curated (see
+        // stations.toml) so the corrected name and a real logo stick.
+        MoodStationRef("ABC Lounge", "curated"),
+        // Registry name is all-lowercase ("nordic lodge copenhagen"); displayName just fixes
+        // capitalisation for this list.
+        MoodStationRef(
+            "nordic lodge copenhagen",
+            "radio-browser",
+            "2ee81587-dba9-4d68-82b3-a7b32aafc525",
+            displayName = "Nordic Lodge Copenhagen",
+        ),
         MoodStationRef("Bossa Jazz Brasil", "curated"),
-        MoodStationRef("Radio Schizoid - Chillout / Ambient"),
-        MoodStationRef("Jazz Sakura (asia dream radio)"),
-        MoodStationRef("KLCBS Tropical"),
-        MoodStationRef("Radio Samui Online"),
-        MoodStationRef("Cape Town Classic"),
+        MoodStationRef("Radio Paradise Mellow Mix", "curated"),
+        MoodStationRef("Skylab Radio", "radio-browser", "24273571-703e-4373-b715-d7e7680d7599"),
+        MoodStationRef("OneLuvFM", "curated"),
+        MoodStationRef("FIP", "curated"),
+        MoodStationRef("Jazz Sakura (asia dream radio)", "radio-browser", "9766d47a-68a3-4a30-8aec-c026f1ec6020"),
+        MoodStationRef("Radio Samui Online", "radio-browser", "86468748-3045-4b88-97ef-e6d266c901f5"),
     ),
+    // Ordered so logo colours flow rather than clash: navy/black/grey -> teal/cream ->
+    // green -> yellow -> orange, with freeCodeCamp Code Radio fixed first as requested.
     "focus" to listOf(
         MoodStationRef("freeCodeCamp Code Radio", "radio-browser", "60ede1ca-d7fa-4a36-a047-aec873b9be41"),
-        MoodStationRef("Box Lofi Radio", "radio-browser", "a5213a32-d614-47bc-8d52-70a2b6eed8e1"),
-        MoodStationRef("FluxFM Chillhop – Chill Beats and LoFi HipHop", "radio-browser", "58d3cce6-62b5-43f1-8f41-8d024998aabc"),
-        MoodStationRef("SomaFM Groove Salad", "radio-browser", "960cf833-0601-11e8-ae97-52543be04c81"),
+        MoodStationRef("Slow Focus | NTS", "radio-browser", "d5468df4-e6d0-11e9-a96c-52543be04c81"),
+        MoodStationRef("Sheet Music | NTS", "radio-browser", "1e0ad463-0dbc-4913-b12d-7d0b7300882b"),
+        MoodStationRef("Systrum Sistum - SSR1", "radio-browser", "37e6772a-5ab7-429d-84bc-fedc606cc8c4"),
         MoodStationRef("SomaFM Beat Blender", "radio-browser", "960eb232-0601-11e8-ae97-52543be04c81"),
         // No stable id in the "curated" bucket (providerId is always ""), so this one still
         // resolves by name.
         MoodStationRef("A Strangely Isolated Place", "curated"),
-        MoodStationRef("Systrum Sistum - SSR1", "radio-browser", "37e6772a-5ab7-429d-84bc-fedc606cc8c4"),
-        MoodStationRef("Slow Focus | NTS", "radio-browser", "d5468df4-e6d0-11e9-a96c-52543be04c81"),
-        MoodStationRef("Sheet Music | NTS", "radio-browser", "1e0ad463-0dbc-4913-b12d-7d0b7300882b"),
+        MoodStationRef("Box Lofi Radio", "radio-browser", "a5213a32-d614-47bc-8d52-70a2b6eed8e1"),
+        MoodStationRef("SomaFM Groove Salad", "radio-browser", "960cf833-0601-11e8-ae97-52543be04c81"),
+        MoodStationRef("FluxFM Chillhop – Chill Beats and LoFi HipHop", "radio-browser", "58d3cce6-62b5-43f1-8f41-8d024998aabc"),
         MoodStationRef("Radio Swiss Jazz", "curated"),
     ),
+    // Ordered so logo colours flow: dark blue/purple -> dark/orange -> teal/red -> lime green
+    // -> white/blue -> white/black monochrome, with Dogglounge fixed first as requested.
     "morning" to listOf(
-        MoodStationRef("BBC Radio 6 Music", "bbc"),
-        MoodStationRef("KEXP 90.3 Seattle", "curated"),
-        MoodStationRef("FIP", "curated"),
-        MoodStationRef("Radio Nova", "curated"),
-        MoodStationRef("Antena 1 FM 94.7 São Paulo", "curated"),
-        MoodStationRef("Shonan Beach FM 78.9", "curated"),
-        MoodStationRef("Cool Fahrenheit", "curated"),
-        MoodStationRef("ABC Jazz", "abc"),
-        MoodStationRef("Worldwide FM"),
-        MoodStationRef("1LIVE", "ard"),
+        MoodStationRef("Dogglounge", "radio-browser", "1c41c07b-b995-11e8-aaf2-52543be04c81"),
+        MoodStationRef("D3EP Radio", "radio-browser", "d210ac34-0fee-4586-b9d6-24b84e2c0c4e"),
+        MoodStationRef("Oroko Radio", "radio-browser", "7babd377-ed7c-4a63-9778-47b0fd94983b"),
+        MoodStationRef("SomaFM Heavyweight Reggae", "radio-browser", "c5955cee-2cdf-40b2-8b5f-aa55bafddbef"),
+        // Moved from workout — talky but upbeat, a better fit for a morning mix.
+        MoodStationRef("Pure Ibiza Radio", "radio-browser", "26edc6b6-d221-4814-a6a9-0dd5d5d365d2"),
+        // Not in the bundled registry snapshot yet — added as a new curated entry (see
+        // stations.toml).
+        MoodStationRef("Veneno", "curated"),
+        MoodStationRef("Cafe Mambo Ibiza Radio", "radio-browser", "450a5177-1752-11ea-a620-52543be04c81"),
+        MoodStationRef("Radio Raheem", "radio-browser", "a1c99f81-f8d1-4f6d-b9e3-714763a72b7d"),
+        MoodStationRef("Soho Radio", "radio-browser", "b830f77b-cb54-431d-9bdb-0af9bc6af301"),
+        MoodStationRef("The Lot Radio", "radio-browser", "434e9a4b-018a-4557-8ca1-8c328bb1e09d"),
     ),
+    // "On The Road" — a broad, genre-mixed set rather than one style. Ordered so logo colours
+    // flow: black/white -> white/blue -> white/orange -> gold -> red, with Radio alHara fixed
+    // first as requested.
     "driving" to listOf(
-        MoodStationRef("Radio Paradise Main Mix", "curated"),
-        MoodStationRef("BBC Radio 6 Music", "bbc"),
-        MoodStationRef("KEXP 90.3 Seattle", "curated"),
-        MoodStationRef("NTS Radio 1", "curated"),
-        MoodStationRef("Radio Nova", "curated"),
-        MoodStationRef("Triple J", "abc"),
+        // Independent community station broadcasting from Bethlehem, Palestine.
+        MoodStationRef("Radio alHara", "radio-browser", "d62fa52b-7c1c-492c-9861-cd2c0ec02f00"),
         MoodStationRef("Rinse FM", "rinse"),
-        MoodStationRef("KISS", "bauer"),
-        MoodStationRef("1LIVE", "ard"),
-        MoodStationRef("FIP", "curated"),
+        // Berlin-based but explicitly globally curated (guest DJs and shows from around the
+        // world), for broader geographic range.
+        MoodStationRef("Refuge Worldwide", "radio-browser", "edb81cbf-0645-4944-a376-554b8299ff27"),
+        MoodStationRef("Worldwide FM", "radio-browser", "1651c32f-55d8-4429-995d-872ea0dcf520"),
+        MoodStationRef("ZonaSalsa Radio", "radio-browser", "0957a107-50fc-435e-a402-ddfa5cdda777"),
+        MoodStationRef("Dandelion Radio", "radio-browser", "961fe58c-0601-11e8-ae97-52543be04c81"),
+        MoodStationRef("Radio Paradise Main Mix", "curated"),
+        MoodStationRef("KEXP 90.3 Seattle", "curated"),
+        MoodStationRef("Cashmere Radio", "radio-browser", "356a337d-4552-4b2d-bfdb-d381a6d85a9d"),
+        MoodStationRef("Triple J", "abc", "TRIPLEJ"),
     ),
+    // Ordered so logo colours flow: pale blue -> deep blue -> purple -> dark/orange ->
+    // white/grey -> pink -> brown, with SomaFM Drone Zone fixed first as requested.
     "late_night" to listOf(
-        MoodStationRef("NTS Radio 2", "curated"),
-        MoodStationRef("SomaFM Drone Zone"),
-        MoodStationRef("Nightwave Plaza", "curated"),
-        MoodStationRef("Colombia Lounge"),
-        MoodStationRef("Radio Schizoid - Chillout / Ambient"),
-        MoodStationRef("Ambient Sleeping Pill"),
-        MoodStationRef("FIP Jazz"),
-        MoodStationRef("KLCBS New Age"),
-        MoodStationRef("BBC Radio 3 Unwind", "bbc"),
-        MoodStationRef("Radio Samui Online"),
+        MoodStationRef("SomaFM Drone Zone", "radio-browser", "960eb2e9-0601-11e8-ae97-52543be04c81"),
+        MoodStationRef("Dinamo.fm Sleep", "curated"),
+        // Registry name is "SomaFM - Deep Space One (128 kb/s AAC)"; displayName drops the
+        // bitrate suffix.
+        MoodStationRef(
+            "SomaFM - Deep Space One (128 kb/s AAC)",
+            "radio-browser",
+            "0042e94c-55d6-4ff4-a3a7-46136e703424",
+            displayName = "SomaFM Deep Space One",
+        ),
+        MoodStationRef("Cryosleep", "curated"),
+        MoodStationRef("MyNoise Ocean Waves", "radio-browser", "b69fe610-1522-47b1-a784-e7025d11f884"),
+        MoodStationRef("Nature Radio Rain", "radio-browser", "95277bca-2c9a-4c08-b2e7-0854e5793f8e"),
+        // Registry name includes a bitrate suffix; displayName drops it for this list.
+        MoodStationRef(
+            "Ambient Sleeping Pill | 128 kbps",
+            "radio-browser",
+            "4b4d1308-9fdb-42a7-b92d-6370bc3284fe",
+            displayName = "Ambient Sleeping Pill",
+        ),
+        // No stable id in the "curated" bucket (providerId is always ""), so these three
+        // resolve by name. Given solid-colour placeholder logos (see stations.toml) for
+        // visual consistency as a set.
+        // Registry's radio-browser "White Noise Radio" points at a mount that now actually
+        // serves Brown Noise Radio's audio — curated here with the correct stream instead.
+        MoodStationRef("White Noise Radio", "curated"),
+        MoodStationRef("Pink Noise Radio", "curated"),
+        MoodStationRef("Brown Noise Radio", "curated"),
     ),
+    // Ordered so logo colours flow: black -> dark navy/red -> pink -> magenta/purple ->
+    // white/red -> grey, with BBC Radio 1 Dance fixed first as requested.
     "workout" to listOf(
-        // International variant, not the UK-only feed.
-        MoodStationRef("BBC Radio 1 Dance (International)", "bbc", "bbc_radio_one_dance_int"),
-        MoodStationRef("Radio FG 98.2", "radio-browser", "4a1bbe28-0675-43bb-98dc-fae037b0b026"),
-        MoodStationRef("54house.fm Clubstream", "radio-browser", "a20e7f55-661e-4f4c-b87f-a087c64633f8"),
+        // Uses the international stream (bbc_radio_one_dance_int), not the UK-only feed.
+        // displayName drops "(International)" here only — search still shows the real name.
+        MoodStationRef(
+            "BBC Radio 1 Dance (International)",
+            "bbc",
+            "bbc_radio_one_dance_int",
+            displayName = "BBC Radio 1 Dance",
+        ),
+        // Replaced Pure Ibiza Radio, which was talky and a better fit for morning — moved
+        // there instead.
+        MoodStationRef("Liquid DnB", "radio-browser", "b8148b29-09d0-4aa1-8bfe-43d236260170"),
+        MoodStationRef("Bassdrive", "radio-browser", "960cc332-0601-11e8-ae97-52543be04c81"),
         MoodStationRef("Technolovers - TECHNO", "radio-browser", "2100610c-13c2-4536-879f-6a88ccb07dc8"),
+        MoodStationRef("Kool FM", "rinse", "kool"),
+        MoodStationRef("54house.fm", "radio-browser", "a20e7f55-661e-4f4c-b87f-a087c64633f8"),
+        // Independent LA station. Replaced LiSTNR - Festival Bangers (an SCA network
+        // aggregator channel, not an independent station) and, before that, PulseEDM Dance
+        // Music Radio, whose bundled logo was dead (404).
+        MoodStationRef("ShoutDRIVE", "radio-browser", "b294bf46-7c1d-45ba-b852-71c5b26298ac"),
         // No stable id in the "curated" bucket (providerId is always ""), so this one still
         // resolves by name.
         MoodStationRef("Techno.FM", "curated"),
-        MoodStationRef("Bassdrive", "radio-browser", "960cc332-0601-11e8-ae97-52543be04c81"),
-        MoodStationRef("Kool FM", "rinse", "kool"),
-        MoodStationRef("Pure Ibiza Radio", "radio-browser", "26edc6b6-d221-4814-a6a9-0dd5d5d365d2"),
-        MoodStationRef("FIP Electro", "radio-browser", "ceba99fe-a1e5-4f2b-b9af-105d8eb7697d"),
-        MoodStationRef("Point Blank FM", "radio-browser", "9957dc39-7c25-499c-8a9c-5ce871924316"),
+        MoodStationRef("Radio FG 98.2", "radio-browser", "4a1bbe28-0675-43bb-98dc-fae037b0b026"),
+        // Replaced FIP Electro and Point Blank FM — both ran noticeably lower BPM than the
+        // rest of this mix. Q-Dance (hardstyle) was tried here too but dropped for being too
+        // cheesy for a workout mix; hard techno keeps the energy without the vibe.
+        MoodStationRef("Hard Techno Radio", "radio-browser", "6eef88eb-396c-4393-86aa-1ba04ff91918"),
     ),
 )
 
@@ -224,13 +293,15 @@ class RegistryRepository(private val dao: RegistryDao) {
         target: MoodStationRef,
         candidates: List<RegistryStation>,
     ): RegistryStation? {
-        if (!target.providerId.isNullOrBlank()) {
-            return candidates.firstOrNull { it.provider == target.provider && it.providerId == target.providerId }
+        val match = if (!target.providerId.isNullOrBlank()) {
+            candidates.firstOrNull { it.provider == target.provider && it.providerId == target.providerId }
+        } else {
+            target.provider
+                ?.let { provider -> candidates.firstOrNull { it.name == target.name && it.provider == provider } }
+                ?: candidates.firstOrNull { it.name == target.name && it.provider == "curated" }
+                ?: candidates.firstOrNull { it.name == target.name }
         }
-        return target.provider
-            ?.let { provider -> candidates.firstOrNull { it.name == target.name && it.provider == provider } }
-            ?: candidates.firstOrNull { it.name == target.name && it.provider == "curated" }
-            ?: candidates.firstOrNull { it.name == target.name }
+        return match?.let { station -> target.displayName?.let { station.copy(name = it) } ?: station }
     }
 
     // A-Z subsection shown as browse suggestions before the user has typed anything.

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
@@ -33,7 +33,11 @@ private val CURATED_TAG_ORDER = listOf(
     "News", "Sport", "Pop", "Rock", "Jazz", "Classical", "Dance", "Soul", "Country", "Electronic"
 )
 
-private data class MoodStationRef(val name: String, val provider: String? = null)
+// providerId pins a ref to one exact registry row so it survives a station being renamed
+// upstream on a future registry refresh (name alone would silently stop resolving). Curated
+// entries have no stable id (providerId is always "" in that bucket), so those refs still
+// fall back to matching by name.
+private data class MoodStationRef(val name: String, val provider: String? = null, val providerId: String? = null)
 
 private val CURATED_MOOD_STATIONS = mapOf(
     "relax" to listOf(
@@ -49,16 +53,18 @@ private val CURATED_MOOD_STATIONS = mapOf(
         MoodStationRef("Cape Town Classic"),
     ),
     "focus" to listOf(
-        MoodStationRef("BBC Radio 3 Unwind", "bbc"),
-        MoodStationRef("Classic FM Calm", "global"),
-        MoodStationRef("Radio Schizoid - Chillout / Ambient"),
-        MoodStationRef("Ottava", "curated"),
-        MoodStationRef("KBS Classic FM"),
-        MoodStationRef("Radio Swiss Classic", "curated"),
-        MoodStationRef("MDR KLASSIK Livestream", "ard"),
-        MoodStationRef("Ambient Sleeping Pill"),
-        MoodStationRef("SomaFM Drone Zone"),
-        MoodStationRef("WDR 3 Klassik", "ard"),
+        MoodStationRef("freeCodeCamp Code Radio", "radio-browser", "60ede1ca-d7fa-4a36-a047-aec873b9be41"),
+        MoodStationRef("Box Lofi Radio", "radio-browser", "a5213a32-d614-47bc-8d52-70a2b6eed8e1"),
+        MoodStationRef("FluxFM Chillhop – Chill Beats and LoFi HipHop", "radio-browser", "58d3cce6-62b5-43f1-8f41-8d024998aabc"),
+        MoodStationRef("SomaFM Groove Salad", "radio-browser", "960cf833-0601-11e8-ae97-52543be04c81"),
+        MoodStationRef("SomaFM Beat Blender", "radio-browser", "960eb232-0601-11e8-ae97-52543be04c81"),
+        // No stable id in the "curated" bucket (providerId is always ""), so this one still
+        // resolves by name.
+        MoodStationRef("A Strangely Isolated Place", "curated"),
+        MoodStationRef("Systrum Sistum - SSR1", "radio-browser", "37e6772a-5ab7-429d-84bc-fedc606cc8c4"),
+        MoodStationRef("Slow Focus | NTS", "radio-browser", "d5468df4-e6d0-11e9-a96c-52543be04c81"),
+        MoodStationRef("Sheet Music | NTS", "radio-browser", "1e0ad463-0dbc-4913-b12d-7d0b7300882b"),
+        MoodStationRef("Radio Swiss Jazz", "curated"),
     ),
     "morning" to listOf(
         MoodStationRef("BBC Radio 6 Music", "bbc"),
@@ -97,16 +103,19 @@ private val CURATED_MOOD_STATIONS = mapOf(
         MoodStationRef("Radio Samui Online"),
     ),
     "workout" to listOf(
-        MoodStationRef("BBC Radio 1 Dance", "bbc"),
-        MoodStationRef("Capital Dance", "global"),
-        MoodStationRef("Rinse FM", "rinse"),
-        MoodStationRef("FIP Electro"),
-        MoodStationRef("1LIVE DIGGI", "ard"),
-        MoodStationRef("98.8 Kiss FM Clubsets", "curated"),
-        MoodStationRef("Allzic Radio Dance Floor", "curated"),
-        MoodStationRef("Bollywood Dance"),
-        MoodStationRef("CLUB DANCE CHILE"),
-        MoodStationRef("ABC Dance"),
+        // International variant, not the UK-only feed.
+        MoodStationRef("BBC Radio 1 Dance (International)", "bbc", "bbc_radio_one_dance_int"),
+        MoodStationRef("Radio FG 98.2", "radio-browser", "4a1bbe28-0675-43bb-98dc-fae037b0b026"),
+        MoodStationRef("54house.fm Clubstream", "radio-browser", "a20e7f55-661e-4f4c-b87f-a087c64633f8"),
+        MoodStationRef("Technolovers - TECHNO", "radio-browser", "2100610c-13c2-4536-879f-6a88ccb07dc8"),
+        // No stable id in the "curated" bucket (providerId is always ""), so this one still
+        // resolves by name.
+        MoodStationRef("Techno.FM", "curated"),
+        MoodStationRef("Bassdrive", "radio-browser", "960cc332-0601-11e8-ae97-52543be04c81"),
+        MoodStationRef("Kool FM", "rinse", "kool"),
+        MoodStationRef("Pure Ibiza Radio", "radio-browser", "26edc6b6-d221-4814-a6a9-0dd5d5d365d2"),
+        MoodStationRef("FIP Electro", "radio-browser", "ceba99fe-a1e5-4f2b-b9af-105d8eb7697d"),
+        MoodStationRef("Point Blank FM", "radio-browser", "9957dc39-7c25-499c-8a9c-5ce871924316"),
     ),
 )
 
@@ -201,7 +210,9 @@ class RegistryRepository(private val dao: RegistryDao) {
 
     suspend fun curatedMoodStations(): Map<String, List<RegistryStation>> {
         val allRefs = CURATED_MOOD_STATIONS.values.flatten()
-        val candidates = dao.getByNames(allRefs.map { it.name }.distinct())
+        val (idRefs, nameRefs) = allRefs.partition { !it.providerId.isNullOrBlank() }
+        val candidates = dao.getByProviderIds(idRefs.map { it.providerId!! }.distinct()) +
+            dao.getByNames(nameRefs.map { it.name }.distinct())
         return CURATED_MOOD_STATIONS.mapValues { (_, refs) ->
             refs.mapNotNull { target ->
                 resolveMoodStation(target, candidates)
@@ -212,11 +223,15 @@ class RegistryRepository(private val dao: RegistryDao) {
     private fun resolveMoodStation(
         target: MoodStationRef,
         candidates: List<RegistryStation>,
-    ): RegistryStation? =
-        target.provider
+    ): RegistryStation? {
+        if (!target.providerId.isNullOrBlank()) {
+            return candidates.firstOrNull { it.provider == target.provider && it.providerId == target.providerId }
+        }
+        return target.provider
             ?.let { provider -> candidates.firstOrNull { it.name == target.name && it.provider == provider } }
             ?: candidates.firstOrNull { it.name == target.name && it.provider == "curated" }
             ?: candidates.firstOrNull { it.name == target.name }
+    }
 
     // A-Z subsection shown as browse suggestions before the user has typed anything.
     // Capped to match the search query limit.

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -45,8 +45,8 @@
     <string name="mood_focus_desc">Konzentriert und produktiv bleiben</string>
     <string name="mood_morning">Morgen</string>
     <string name="mood_morning_desc">Positiv in den Tag starten</string>
-    <string name="mood_driving">Fahren</string>
-    <string name="mood_driving_desc">Gute Begleitung für unterwegs</string>
+    <string name="mood_driving">Unterwegs</string>
+    <string name="mood_driving_desc">Ein bunter Mix für die Reise</string>
     <string name="mood_late_night">Späte Nacht</string>
     <string name="mood_late_night_desc">Musik für ruhige Stunden</string>
     <string name="mood_workout">Workout</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -45,8 +45,8 @@
     <string name="mood_focus_desc">Concéntrate y sé productivo</string>
     <string name="mood_morning">Mañana</string>
     <string name="mood_morning_desc">Empieza el día con energía</string>
-    <string name="mood_driving">Conduciendo</string>
-    <string name="mood_driving_desc">Buena compañía para la ruta</string>
+    <string name="mood_driving">De viaje</string>
+    <string name="mood_driving_desc">Una mezcla variada para el camino</string>
     <string name="mood_late_night">Noche</string>
     <string name="mood_late_night_desc">Música para las horas tranquilas</string>
     <string name="mood_workout">Entreno</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -45,8 +45,8 @@
     <string name="mood_focus_desc">Restez concentré et productif</string>
     <string name="mood_morning">Matin</string>
     <string name="mood_morning_desc">Commencez la journée positivement</string>
-    <string name="mood_driving">Route</string>
-    <string name="mood_driving_desc">De bons compagnons de voyage</string>
+    <string name="mood_driving">En route</string>
+    <string name="mood_driving_desc">Un mélange varié pour le voyage</string>
     <string name="mood_late_night">Tard le soir</string>
     <string name="mood_late_night_desc">Musique pour les heures calmes</string>
     <string name="mood_workout">Entraînement</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -46,7 +46,7 @@
     <string name="mood_morning">Mattina</string>
     <string name="mood_morning_desc">Inizia la giornata con positività</string>
     <string name="mood_driving">In viaggio</string>
-    <string name="mood_driving_desc">Ottima compagnia per la strada</string>
+    <string name="mood_driving_desc">Un mix eclettico per il viaggio</string>
     <string name="mood_late_night">Notte fonda</string>
     <string name="mood_late_night_desc">Musica per le ore tranquille</string>
     <string name="mood_workout">Allenamento</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -45,8 +45,8 @@
     <string name="mood_focus_desc">集中して生産的に</string>
     <string name="mood_morning">朝</string>
     <string name="mood_morning_desc">前向きに一日を始める</string>
-    <string name="mood_driving">ドライブ</string>
-    <string name="mood_driving_desc">道中にぴったりの相棒</string>
+    <string name="mood_driving">旅の途中</string>
+    <string name="mood_driving_desc">旅にぴったりの多彩な音楽</string>
     <string name="mood_late_night">深夜</string>
     <string name="mood_late_night_desc">静かな時間のための音楽</string>
     <string name="mood_workout">ワークアウト</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -45,8 +45,8 @@
     <string name="mood_focus_desc">집중하고 생산적으로 보내기</string>
     <string name="mood_morning">아침</string>
     <string name="mood_morning_desc">긍정적으로 하루를 시작하세요</string>
-    <string name="mood_driving">드라이브</string>
-    <string name="mood_driving_desc">길 위의 좋은 동반자</string>
+    <string name="mood_driving">여행길</string>
+    <string name="mood_driving_desc">여정을 위한 다채로운 음악</string>
     <string name="mood_late_night">늦은 밤</string>
     <string name="mood_late_night_desc">조용한 시간을 위한 음악</string>
     <string name="mood_workout">운동</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -46,7 +46,7 @@
     <string name="mood_morning">Ochtend</string>
     <string name="mood_morning_desc">Begin je dag positief</string>
     <string name="mood_driving">Onderweg</string>
-    <string name="mood_driving_desc">Goede begeleiding voor onderweg</string>
+    <string name="mood_driving_desc">Een gevarieerde mix voor onderweg</string>
     <string name="mood_late_night">Late avond</string>
     <string name="mood_late_night_desc">Muziek voor stille uren</string>
     <string name="mood_workout">Workout</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -45,8 +45,8 @@
     <string name="mood_focus_desc">Concentre-se e seja produtivo</string>
     <string name="mood_morning">Manhã</string>
     <string name="mood_morning_desc">Comece o dia com positividade</string>
-    <string name="mood_driving">Dirigindo</string>
-    <string name="mood_driving_desc">Boa companhia para a estrada</string>
+    <string name="mood_driving">Na estrada</string>
+    <string name="mood_driving_desc">Uma mistura variada para a viagem</string>
     <string name="mood_late_night">Noite adentro</string>
     <string name="mood_late_night_desc">Música para horas tranquilas</string>
     <string name="mood_workout">Treino</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -45,8 +45,8 @@
     <string name="mood_focus_desc">保持专注和高效</string>
     <string name="mood_morning">清晨</string>
     <string name="mood_morning_desc">积极开启新的一天</string>
-    <string name="mood_driving">驾驶</string>
-    <string name="mood_driving_desc">路上的好伙伴</string>
+    <string name="mood_driving">在路上</string>
+    <string name="mood_driving_desc">旅途中的多元音乐</string>
     <string name="mood_late_night">深夜</string>
     <string name="mood_late_night_desc">适合安静时光的音乐</string>
     <string name="mood_workout">锻炼</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,8 +45,8 @@
     <string name="mood_focus_desc">Concentrate and be productive</string>
     <string name="mood_morning">Morning</string>
     <string name="mood_morning_desc">Start your day positively</string>
-    <string name="mood_driving">Driving</string>
-    <string name="mood_driving_desc">Great companions for the road</string>
+    <string name="mood_driving">On The Road</string>
+    <string name="mood_driving_desc">A broad mix for the road</string>
     <string name="mood_late_night">Late night</string>
     <string name="mood_late_night_desc">Music for the quiet hours</string>
     <string name="mood_workout">Workout</string>


### PR DESCRIPTION
## Summary
Part of #66

- Every mood playlist is now a manually curated, smoke-tested set of stations instead of the original placeholder lists.
- `MoodStationRef` now keys by `(provider, providerId)` where the registry has a stable id, instead of by name — a station being renamed upstream on a future registry refresh no longer silently drops it from its mood. Curated-bucket entries (no stable id) still resolve by name.
- Added a `displayName` override so a mood list can show a friendlier label (e.g. dropping a bitrate suffix or "(International)") without touching the underlying registry name — search results still show the real name.
- "Driving" renamed to "On The Road" and broadened into a genre-mixed, largely independent-station set (rock, house, reggae, salsa, etc.) with some international representation, rather than skewing toward one style.
- Every list is ordered so station logos read as a deliberate colour flow rather than a random grid, and so same-broadcaster/same-genre picks aren't adjacent where that still matters.
- Fixed several broken/dead logos and one broken stream found along the way, some of which affected other parts of the app too:
  - FIP's `fipradio.fr` logo URL 301-redirected to the station's homepage (not an image) — this was the root cause of an earlier swipe-pager artwork flash bug.
  - "White Noise Radio"'s stream was actually serving Brown Noise Radio's audio (confirmed via `icy-name`).
  - NTS's `media.nts.live` logo domain doesn't resolve at all.
  - Several stations had no logo, a non-square logo, or a logo hosted on an unstable/expiring URL (Facebook CDN, DuckDuckGo image proxy, etc.).
- Added a few stations not present in the bundled registry snapshot at all (e.g. Veneno) as new curated entries.
- All logo/name/stream fixes and new curated entries are also applied in the sibling `aerial-registry` repo (`stations.toml`) so they survive the next nightly registry regeneration, not just this bundled snapshot.

## Test plan
- [x] `./gradlew assembleDebug assembleRelease testDebugUnitTest`
- [x] Manually tested every mood's station list on device across many iterations: playback, logos, ordering.