### PR TITLE
Add contributing guide, security policy, and issue/PR templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing
+
+Thanks for considering contributing to Aerial.
+
+## Code Of Conduct
+
+This project follows the [Code of Conduct](CODE_OF_CONDUCT.md). By
+participating, you are expected to uphold it.
+
+## Reporting Bugs And Requesting Features
+
+Please use the [issue tracker](https://github.com/shapeshed/aerial/issues).
+Search existing issues first to avoid duplicates. For security
+vulnerabilities, see [SECURITY.md](SECURITY.md) instead of opening a public
+issue.
+
+## Development Setup
+
+Build, test, and release instructions live in
+[DEVELOPERS.md](../DEVELOPERS.md). In short:
+
+```sh
+./gradlew quality        # compile, lint, and unit tests
+./gradlew assembleDebug
+```
+
+## Submitting A Pull Request
+
+1. Fork the repository and create a branch off `main`.
+2. Make your change. Keep pull requests focused on a single change where
+   possible.
+3. Run `./gradlew quality` locally before pushing; CI runs the same check.
+4. Write commit messages in the
+   [Conventional Commits](https://www.conventionalcommits.org/) style used
+   throughout the project's history, for example `fix(player): ...` or
+   `feat(home): ...`.
+5. Open a pull request describing what changed and why. Link any related
+   issue.
+
+## Station Registry Changes
+
+Aerial's bundled station registry is generated in a separate repository,
+[aerial-registry](https://github.com/shapeshed/aerial-registry). Changes to
+curated stations, logos, or provider coverage belong there rather than in
+this repository — see that project's own contributing guidelines.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under
+the project's [Apache License 2.0](../LICENSE).

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+ko_fi: shapeshed
+custom: ["https://buymeacoffee.com/shapeshed", "https://www.paypal.com/donate/?hosted_button_id=MZVB3E2RYYWV8"]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: Bug report
+description: Report something that isn't working correctly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please do not use this
+        form for security vulnerabilities — see [SECURITY.md](https://github.com/shapeshed/aerial/blob/main/.github/SECURITY.md)
+        instead.
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open Aerial
+        2. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: Aerial version
+      description: Settings screen shows the current version.
+    validations:
+      required: true
+  - type: input
+    id: android-version
+    attributes:
+      label: Android version and device
+      placeholder: "e.g. Android 14, Pixel 7"
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Screenshots, logs, or anything else relevant.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/shapeshed/aerial/security/advisories/new
+    about: Please report security issues privately rather than as a public issue.
+  - name: Station registry issue (wrong logo, dead stream, missing station)
+    url: https://github.com/shapeshed/aerial-registry/issues/new
+    about: Curated station data lives in a separate repository — report data issues there.
+  - name: Support Aerial
+    url: https://buymeacoffee.com/shapeshed
+    about: If you'd like to support development rather than file an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest an idea or improvement for Aerial
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: What are you trying to do that Aerial doesn't support today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches or workarounds you've tried.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- What does this change do, and why? -->
+
+## Test Plan
+
+<!-- How did you verify this? e.g. ./gradlew quality, manual testing on device -->
+
+- [ ] `./gradlew quality`
+- [ ] Tested on device
+
+## Related Issues
+
+<!-- Closes #123, or "None" -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported Versions
+
+Aerial has one active release line. Security fixes are made against the
+latest release; older versions are not patched separately.
+
+## Reporting a Vulnerability
+
+Please do not open a public GitHub issue for security vulnerabilities.
+
+Instead, report it privately using
+[GitHub's private vulnerability reporting](https://github.com/shapeshed/aerial/security/advisories/new),
+or by emailing:
+
+aerial@shapeshed.com
+
+Please include:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce it
+- The Aerial version or commit affected
+
+You should expect an initial response within 5 business days. If the report
+is confirmed, a fix will be prepared before any public disclosure. Please
+allow time for a fix to be released before disclosing the issue publicly.
+
+## Scope
+
+Aerial does not include advertising, analytics, tracking SDKs, Firebase,
+Crashlytics, Google Play Services, or user accounts (see
+[PRIVACY.md](../PRIVACY.md)). Reports about third-party radio stream
+providers or logo hosts reached by the app are outside this policy's scope —
+please report those directly to the operator concerned.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ maintained.
 
 ## Development
 
-Developer documentation lives in [DEVELOPERS.md](DEVELOPERS.md).
+Developer documentation lives in [DEVELOPERS.md](DEVELOPERS.md). See
+[CONTRIBUTING.md](.github/CONTRIBUTING.md) for how to propose changes, and
+[SECURITY.md](.github/SECURITY.md) to report a vulnerability privately.
 
 ## Privacy
 


### PR DESCRIPTION
## Summary
Rounds out GitHub's community health files. CODEOWNERS and CODE_OF_CONDUCT.md already existed; this adds the rest:

- `SECURITY.md` — private vulnerability reporting via GitHub advisories or `aerial@shapeshed.com`.
- `CONTRIBUTING.md` — PR process, commit style (Conventional Commits, matching the project's history), and a pointer to the separate [aerial-registry](https://github.com/shapeshed/aerial-registry) repo for curated station/logo data changes.
- `.github/ISSUE_TEMPLATE/bug_report.yml` and `feature_request.yml` — structured issue forms.
- `.github/ISSUE_TEMPLATE/config.yml` — routes security reports and station-data issues away from the general tracker, disables blank issues.
- `.github/PULL_REQUEST_TEMPLATE.md` — summary/test-plan/related-issues checklist.
- `.github/FUNDING.yml` — reuses the existing Ko-fi/Buy Me a Coffee/PayPal links already in the README.
- README now links to CONTRIBUTING.md and SECURITY.md alongside the existing DEVELOPERS.md link.

## Test plan
- [x] All new YAML files validated to parse correctly.
- [x] No app code changed — docs/templates only.