### PR TITLE
Sign the nightly APK instead of shipping it unsigned

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,17 +48,39 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         run: chmod +x ./gradlew
 
-      - name: Build unsigned release APK
+      - name: Decode release keystore
         if: steps.check.outputs.skip != 'true'
+        env:
+          AERIAL_KEYSTORE_BASE64: ${{ secrets.AERIAL_KEYSTORE_BASE64 }}
+          AERIAL_KEYSTORE_PASSWORD: ${{ secrets.AERIAL_KEYSTORE_PASSWORD }}
+          AERIAL_KEY_ALIAS: ${{ secrets.AERIAL_KEY_ALIAS }}
+          AERIAL_KEY_PASSWORD: ${{ secrets.AERIAL_KEY_PASSWORD }}
+        run: |
+          if [ -z "$AERIAL_KEYSTORE_BASE64" ] ||
+             [ -z "$AERIAL_KEYSTORE_PASSWORD" ] ||
+             [ -z "$AERIAL_KEY_ALIAS" ] ||
+             [ -z "$AERIAL_KEY_PASSWORD" ]; then
+            echo "All Aerial signing secrets are required for nightly builds — an unsigned APK cannot be installed." >&2
+            exit 1
+          fi
+          printf '%s' "$AERIAL_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/aerial-release.jks"
+
+      - name: Build signed release APK
+        if: steps.check.outputs.skip != 'true'
+        env:
+          AERIAL_KEYSTORE_FILE: ${{ runner.temp }}/aerial-release.jks
+          AERIAL_KEYSTORE_PASSWORD: ${{ secrets.AERIAL_KEYSTORE_PASSWORD }}
+          AERIAL_KEY_ALIAS: ${{ secrets.AERIAL_KEY_ALIAS }}
+          AERIAL_KEY_PASSWORD: ${{ secrets.AERIAL_KEY_PASSWORD }}
         run: ./gradlew assembleRelease
 
       - name: Rename APK
         if: steps.check.outputs.skip != 'true'
         run: |
           set -eu
-          apk="app/build/outputs/apk/release/app-release-unsigned.apk"
+          apk="app/build/outputs/apk/release/app-release.apk"
           if [ ! -f "$apk" ]; then
-            echo "Expected unsigned APK at $apk" >&2
+            echo "Expected signed APK at $apk" >&2
             exit 1
           fi
           short_sha=$(echo "${{ github.sha }}" | cut -c1-7)
@@ -80,4 +102,4 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --prerelease \
             --title "Aerial Nightly" \
-            --notes "Automated, unsigned build from \`main\` @ ${{ github.sha }}. For testing only — not signed with the release key, and this tag is force-updated on every nightly build."
+            --notes "Automated build from \`main\` @ ${{ github.sha }}. Signed with the same key as tagged releases, so it installs cleanly as an update over a previous nightly (but not over a Play Store install, which uses Play App Signing). For testing only — this tag is force-updated on every nightly build."


### PR DESCRIPTION
## Summary
Fixes the nightly build published in #72 — the APK it produced (`./gradlew assembleRelease` with no signing secrets) was completely unsigned, and Android's installer flatly refuses to install any unsigned APK ("You can't install this app on your device"). This is different from a signature-mismatch error; it means the current published `nightly` release literally cannot be installed by anyone.

- Sign nightly builds with the same production keystore `release.yml` already uses — same repository secrets, no new setup needed.
- Fails fast with a clear error if the signing secrets aren't configured, matching `release.yml`'s existing guard.
- Updated the release notes text to reflect that it's now signed, and to note it installs cleanly over a previous nightly but not over a Play Store install (Play App Signing uses its own key).

## Test plan
- [x] `actionlint` passes.
- [ ] After merge, manually re-run the workflow (`workflow_dispatch`) to replace the currently-broken `nightly` release with a signed, installable APK.