### PR TITLE
fix(player): remove audio offload, widen buffer, harden HTTP config for radio streams

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/AerialApp.kt
+++ b/app/src/main/java/com/shapeshed/aerial/AerialApp.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.shapeshed.aerial.data.AERIAL_USER_AGENT
 import com.shapeshed.aerial.data.BauerProvider
 import com.shapeshed.aerial.data.BbcProvider
 import com.shapeshed.aerial.data.GlobalPlayerProvider
@@ -39,7 +40,7 @@ class AerialApp : Application(), SingletonImageLoader.Factory {
         .addInterceptor { chain ->
             chain.proceed(
                 chain.request().newBuilder()
-                    .header("User-Agent", "Aerial/${BuildConfig.VERSION_NAME} (Android)")
+                    .header("User-Agent", AERIAL_USER_AGENT)
                     .build(),
             )
         }

--- a/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
+++ b/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
@@ -8,18 +8,20 @@ import android.os.SystemClock
 import android.util.Log
 import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Metadata
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
-import androidx.media3.common.TrackSelectionParameters.AudioOffloadPreferences
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.extractor.metadata.icy.IcyInfo
 import androidx.media3.extractor.metadata.id3.ApicFrame
 import androidx.media3.extractor.metadata.id3.TextInformationFrame
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.session.CommandButton
 import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaSession
@@ -31,6 +33,7 @@ import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_CANCEL
 import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_SET
+import com.shapeshed.aerial.data.AERIAL_USER_AGENT
 import com.shapeshed.aerial.data.Provider
 import com.shapeshed.aerial.data.NowPlayingInfo
 import com.shapeshed.aerial.data.NowPlayingStore
@@ -88,6 +91,13 @@ class PlayerService : MediaSessionService() {
             }
         )
         repository = (application as AerialApp).repository
+        val httpDataSourceFactory = DefaultHttpDataSource.Factory()
+            .setUserAgent(AERIAL_USER_AGENT)
+            .setAllowCrossProtocolRedirects(true)
+            .setConnectTimeoutMs(HTTP_TIMEOUT_MS)
+            .setReadTimeoutMs(HTTP_TIMEOUT_MS)
+        val mediaSourceFactory = DefaultMediaSourceFactory(this)
+            .setDataSourceFactory(httpDataSourceFactory)
         val loadControl = DefaultLoadControl.Builder()
             .setBufferDurationsMs(
                 MIN_BUFFER_MS,
@@ -97,11 +107,17 @@ class PlayerService : MediaSessionService() {
             )
             .build()
         player = ExoPlayer.Builder(this)
+            .setMediaSourceFactory(mediaSourceFactory)
             .setLoadControl(loadControl)
-            .setAudioAttributes(AudioAttributes.DEFAULT, true)
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(C.USAGE_MEDIA)
+                    .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
+                    .build(),
+                true,
+            )
             .setHandleAudioBecomingNoisy(true)
             .build()
-            .apply { enableAudioOffload() }
         player.addListener(icyListener)
         mediaSession = MediaSession.Builder(this, player)
             .setSessionActivity(pendingIntent())
@@ -249,17 +265,6 @@ class PlayerService : MediaSessionService() {
             log("onPlayerError code=${error.errorCode} message=${error.message}")
             reconnectCurrentStream("player error ${error.errorCode}")
         }
-    }
-
-    private fun ExoPlayer.enableAudioOffload() {
-        trackSelectionParameters = trackSelectionParameters
-            .buildUpon()
-            .setAudioOffloadPreferences(
-                AudioOffloadPreferences.Builder()
-                    .setAudioOffloadMode(AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_ENABLED)
-                    .build()
-            )
-            .build()
     }
 
     private val sessionCallback = object : MediaSession.Callback {
@@ -531,10 +536,11 @@ class PlayerService : MediaSessionService() {
         const val ACTION_TOGGLE_FAVORITE = "com.shapeshed.aerial.action.TOGGLE_FAVORITE"
         const val FADE_STEP_MS = 200L
         const val STALE_BUFFER_THRESHOLD_MS = 3_000L
-        const val MIN_BUFFER_MS = 5_000
-        const val MAX_BUFFER_MS = 8_000
+        const val MIN_BUFFER_MS = 15_000
+        const val MAX_BUFFER_MS = 30_000
         const val BUFFER_FOR_PLAYBACK_MS = 1_500
-        const val BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS = 3_000
+        const val BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS = 5_000
         const val RECONNECT_RETRY_COOLDOWN_MS = 10_000L
+        const val HTTP_TIMEOUT_MS = 8_000
     }
 }

--- a/app/src/main/java/com/shapeshed/aerial/data/HttpUtils.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/HttpUtils.kt
@@ -5,7 +5,7 @@ import com.shapeshed.aerial.BuildConfig
 import java.net.HttpURLConnection
 import java.net.URL
 
-private val USER_AGENT = "Aerial/${BuildConfig.VERSION_NAME} (Android)"
+internal val AERIAL_USER_AGENT = "Aerial/${BuildConfig.VERSION_NAME} (Android)"
 
 /**
  * GET [url] and return the response body as a string, or null on any error or non-2xx status.
@@ -16,7 +16,7 @@ internal fun httpGetJson(url: String, extraHeaders: Map<String, String> = emptyM
         val conn = URL(url).openConnection() as HttpURLConnection
         conn.connectTimeout = 10_000
         conn.readTimeout = 10_000
-        conn.setRequestProperty("User-Agent", USER_AGENT)
+        conn.setRequestProperty("User-Agent", AERIAL_USER_AGENT)
         extraHeaders.forEach { (k, v) -> conn.setRequestProperty(k, v) }
         try {
             if (conn.responseCode !in 200..299) return null
@@ -41,7 +41,7 @@ internal fun httpPostJson(url: String, body: String, extraHeaders: Map<String, S
         conn.readTimeout = 10_000
         conn.doOutput = true
         conn.setRequestProperty("Content-Type", "application/json")
-        conn.setRequestProperty("User-Agent", USER_AGENT)
+        conn.setRequestProperty("User-Agent", AERIAL_USER_AGENT)
         extraHeaders.forEach { (k, v) -> conn.setRequestProperty(k, v) }
         try {
             conn.outputStream.use { it.write(body.toByteArray()) }
@@ -65,7 +65,7 @@ internal fun httpFetchBytes(url: String, cache: LruCache<String, ByteArray>): By
         val conn = URL(url).openConnection() as HttpURLConnection
         conn.connectTimeout = 10_000
         conn.readTimeout = 10_000
-        conn.setRequestProperty("User-Agent", USER_AGENT)
+        conn.setRequestProperty("User-Agent", AERIAL_USER_AGENT)
         try {
             if (conn.responseCode !in 200..299) return null
             conn.inputStream.use { input ->

--- a/app/src/main/java/com/shapeshed/aerial/data/MusicBrainzProvider.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/MusicBrainzProvider.kt
@@ -1,7 +1,6 @@
 package com.shapeshed.aerial.data
 
 import android.util.Log
-import com.shapeshed.aerial.BuildConfig
 import java.net.HttpURLConnection
 import java.net.URL
 import java.net.URLEncoder
@@ -11,7 +10,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.json.JSONObject
 
-private val MB_USER_AGENT = "Aerial/${BuildConfig.VERSION_NAME} (Android)"
 private const val TAG = "MusicBrainzProvider"
 
 class MusicBrainzProvider : Provider {
@@ -109,7 +107,7 @@ private fun fetchMbBytes(url: String): ByteArray? {
             conn.connectTimeout = 10_000
             conn.readTimeout = 10_000
             conn.instanceFollowRedirects = false
-            conn.setRequestProperty("User-Agent", MB_USER_AGENT)
+            conn.setRequestProperty("User-Agent", AERIAL_USER_AGENT)
             try {
                 val code = conn.responseCode
                 when {


### PR DESCRIPTION
## Summary

- Removes `enableAudioOffload()`, applied unconditionally to every stream since the first commit with no documented rationale. Audio offload is off by default in Media3 and unused by every comparable open-source radio/podcast player checked (RadioDroid, RadioTime, RadioWave, acoustic-radio, AntennaPod).
- Widens the buffer window from 5s/8s to 15s/30s (min/max), and buffer-for-playback-after-rebuffer from 3s to 5s. Media3's own streaming default is 50s/50s — the prior window left almost no cushion for network hiccups.
- Adds explicit `DefaultHttpDataSource` configuration (user agent, cross-protocol redirects, explicit timeouts) via a custom `DefaultMediaSourceFactory`, matching AntennaPod's pattern.
- Makes `AudioAttributes` explicit (`USAGE_MEDIA` / `AUDIO_CONTENT_TYPE_MUSIC`) instead of relying on `AudioAttributes.DEFAULT`.
- Consolidates three duplicate `"Aerial/<version> (Android)"` user-agent strings into one shared `AERIAL_USER_AGENT` constant, now reused by the player too.

Refs #68 — left open, pending confirmation from the reporter on-device.

## Test plan

- [x] `./gradlew test lint assembleDebug` passes
- [x] Installed on a local device
- [ ] Confirm the two stations from #68 (Hit FM, Kiss-FM Madrid) no longer drop out