### PR TITLE
Make mini player swipeable to stop and dismiss

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.material.icons.rounded.Radio
 import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material.icons.rounded.Stop
 import androidx.compose.material.icons.rounded.WifiOff
 import androidx.compose.material.icons.rounded.WbSunny
 import androidx.compose.material.icons.rounded.BeachAccess
@@ -114,6 +115,8 @@ import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.SearchBarValue
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Surface
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.ToggleButton
@@ -123,6 +126,7 @@ import androidx.compose.material3.WideNavigationRailItem
 import androidx.compose.material3.ToggleButtonDefaults
 import androidx.compose.material3.rememberContainedSearchBarState
 import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -637,6 +641,43 @@ fun MainScreen(
                 val miniPlayerTitle = nowPlayingDisplay.title.ifBlank { station.name }
                 val miniPlayerSubtitle = playbackError
                     ?: if (isBuffering) stringResource(R.string.buffering) else nowPlayingDisplay.subtitle
+                // Swipe in either direction to stop playback and dismiss the player, matching
+                // the Quick Settings / notification media card's own lifecycle: both disappear
+                // together since clearing the controller's media items removes the notification.
+                val dismissState = rememberSwipeToDismissBoxState(
+                    confirmValueChange = { value ->
+                        if (value != SwipeToDismissBoxValue.Settled) {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            viewModel.stopAndClear()
+                        }
+                        true
+                    },
+                )
+                SwipeToDismissBox(
+                    state = dismissState,
+                    backgroundContent = {
+                        Surface(
+                            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                            shape = FloatingToolbarDefaults.ContainerShape,
+                            modifier = Modifier.fillMaxSize(),
+                        ) {
+                            Box(
+                                contentAlignment = if (dismissState.dismissDirection == SwipeToDismissBoxValue.StartToEnd) {
+                                    Alignment.CenterStart
+                                } else {
+                                    Alignment.CenterEnd
+                                },
+                                modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp),
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.Stop,
+                                    contentDescription = stringResource(R.string.stop),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    },
+                ) {
                 BoxWithConstraints {
                     val isActive = isPlaying || isBuffering
                     val playPauseCorner by animateDpAsState(
@@ -751,6 +792,7 @@ fun MainScreen(
                         }
                 }
             }
+                }
             }
         }
             }

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -602,8 +602,10 @@ class MainViewModel(
     private val playerListener = object : Player.Listener {
         override fun onIsPlayingChanged(isPlaying: Boolean) {
             _isPlaying.value = isPlaying
-            currentStation.value?.let { station ->
-                persistLastPlayedStation(station)
+            if (!suppressLastPlayedPersist) {
+                currentStation.value?.let { station ->
+                    persistLastPlayedStation(station)
+                }
             }
         }
         override fun onPlaybackStateChanged(state: Int) {
@@ -691,6 +693,37 @@ class MainViewModel(
                 _playbackError.value = null
                 it.play()
             }
+        }
+    }
+
+    // True while stopAndClear() is unwinding playback, so the isPlaying listener below doesn't
+    // re-persist the station we're in the middle of forgetting.
+    private var suppressLastPlayedPersist = false
+
+    // Swiping the mini player away: stop playback, clear the current/ephemeral station, and
+    // forget it so app restart doesn't resume it. Clearing the controller's media items (rather
+    // than just stop()) also drops the media notification and its Quick Settings / lock screen
+    // media card, since Media3 only shows those while a current media item exists. A fresh
+    // play() afterwards goes through the same path as starting a station with no player active.
+    fun stopAndClear() {
+        suppressLastPlayedPersist = true
+        controller?.apply {
+            stop()
+            clearMediaItems()
+        }
+        _currentStationId.value = null
+        _ephemeralStation.value = null
+        _currentTrackTitle.value = null
+        _currentTrackArtist.value = null
+        _currentTrackArtworkUrl.value = null
+        _currentTrackArtworkData.value = null
+        _currentBitrateKbps.value = null
+        _playbackError.value = null
+        _isPlaying.value = false
+        _isBuffering.value = false
+        viewModelScope.launch {
+            dataStore.edit { prefs -> prefs.remove(LAST_PLAYED_STATION_KEY) }
+            suppressLastPlayedPersist = false
         }
     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -16,6 +16,7 @@
     <string name="buffering">Wird gepuffert…</string>
     <string name="play">Abspielen</string>
     <string name="pause">Pause</string>
+    <string name="stop">Stopp</string>
     <string name="filter_country">Land</string>
     <string name="filter_genre">Genre</string>
     <string name="search_countries">Länder suchen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -16,6 +16,7 @@
     <string name="buffering">Cargando…</string>
     <string name="play">Reproducir</string>
     <string name="pause">Pausar</string>
+    <string name="stop">Detener</string>
     <string name="filter_country">País</string>
     <string name="filter_genre">Género</string>
     <string name="search_countries">Buscar países</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -16,6 +16,7 @@
     <string name="buffering">Mise en mémoire tampon…</string>
     <string name="play">Lire</string>
     <string name="pause">Pause</string>
+    <string name="stop">Arrêter</string>
     <string name="filter_country">Pays</string>
     <string name="filter_genre">Genre</string>
     <string name="search_countries">Rechercher des pays</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -16,6 +16,7 @@
     <string name="buffering">Buffering…</string>
     <string name="play">Riproduci</string>
     <string name="pause">Pausa</string>
+    <string name="stop">Interrompi</string>
     <string name="filter_country">Paese</string>
     <string name="filter_genre">Genere</string>
     <string name="search_countries">Cerca paesi</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -16,6 +16,7 @@
     <string name="buffering">バッファ中…</string>
     <string name="play">再生</string>
     <string name="pause">一時停止</string>
+    <string name="stop">停止</string>
     <string name="filter_country">国</string>
     <string name="filter_genre">ジャンル</string>
     <string name="search_countries">国を検索</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -16,6 +16,7 @@
     <string name="buffering">버퍼링 중…</string>
     <string name="play">재생</string>
     <string name="pause">일시정지</string>
+    <string name="stop">정지</string>
     <string name="filter_country">국가</string>
     <string name="filter_genre">장르</string>
     <string name="search_countries">국가 검색</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -16,6 +16,7 @@
     <string name="buffering">Bufferen…</string>
     <string name="play">Afspelen</string>
     <string name="pause">Pauzeren</string>
+    <string name="stop">Stoppen</string>
     <string name="filter_country">Land</string>
     <string name="filter_genre">Genre</string>
     <string name="search_countries">Landen zoeken</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -16,6 +16,7 @@
     <string name="buffering">Carregando…</string>
     <string name="play">Reproduzir</string>
     <string name="pause">Pausar</string>
+    <string name="stop">Parar</string>
     <string name="filter_country">País</string>
     <string name="filter_genre">Gênero</string>
     <string name="search_countries">Buscar países</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -16,6 +16,7 @@
     <string name="buffering">缓冲中…</string>
     <string name="play">播放</string>
     <string name="pause">暂停</string>
+    <string name="stop">停止</string>
     <string name="filter_country">国家/地区</string>
     <string name="filter_genre">类型</string>
     <string name="search_countries">搜索国家/地区</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="buffering">Buffering…</string>
     <string name="play">Play</string>
     <string name="pause">Pause</string>
+    <string name="stop">Stop</string>
     <string name="filter_country">Country</string>
     <string name="filter_genre">Genre</string>
     <string name="search_countries">Search countries</string>


### PR DESCRIPTION
## Summary
- Swiping the mini player in either direction now stops playback, clears the current/ephemeral station, and forgets it so it isn't restored on next launch.
- Clearing the controller's media items (rather than just `stop()`) also drops the media notification and its Quick Settings / lock screen media card, since Media3 only shows those while a current media item exists.
- Starting a new station after a swipe goes through the same `play()` path as starting one with no player active — no special-casing needed.
- Uses Material3's `SwipeToDismissBox`, with the background reveal matching `HorizontalFloatingToolbar`'s own `FloatingToolbarDefaults.ContainerShape` so the corners line up, a neutral `surfaceContainerHigh`/`onSurfaceVariant` tone, and a `Stop` glyph consistent with the existing transport icons.

Closes #65

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` passes
- [x] Installed on a physical device; verified swipe-to-dismiss stops playback, clears the mini player, and removes the notification/Quick Settings media card
- [x] Verified starting a new station after a swipe-dismiss behaves like starting one from a cold app state
- [ ] Reviewer to confirm restart-without-restore behavior on their own device