### PR TITLE
Fix missing buffering spinner on first play of a session

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -608,10 +608,17 @@ class MainViewModel(
                 }
             }
         }
-        override fun onPlaybackStateChanged(state: Int) {
-            // Only show buffering when the user intends to play; suppress the transient
-            // STATE_BUFFERING that fires during prepare() when restoring a paused station.
-            _isBuffering.value = state == Player.STATE_BUFFERING && controller?.playWhenReady == true
+        override fun onEvents(player: Player, events: Player.Events) {
+            if (events.containsAny(Player.EVENT_PLAYBACK_STATE_CHANGED, Player.EVENT_PLAY_WHEN_READY_CHANGED)) {
+                // Only show buffering when the user intends to play; suppress the transient
+                // STATE_BUFFERING that fires during prepare() when restoring a paused station.
+                // Read both off the player itself (settled as of this batch) rather than off
+                // the individual onPlaybackStateChanged callback, whose isolated playWhenReady
+                // read can still be stale mid-batch — e.g. the very first play() of a session,
+                // where STATE_BUFFERING can be delivered before playWhenReady=true has
+                // propagated, silently dropping the buffering spinner for that first play.
+                _isBuffering.value = player.playbackState == Player.STATE_BUFFERING && player.playWhenReady
+            }
         }
         override fun onPlayerError(error: PlaybackException) {
             _isBuffering.value = false


### PR DESCRIPTION
## Summary
- `isBuffering` was derived in `onPlaybackStateChanged` from `state == STATE_BUFFERING && controller?.playWhenReady == true`. That `playWhenReady` read can be stale relative to the state-change callback it's paired with — most visibly the very first `play()` of a session, where Media3 can deliver `STATE_BUFFERING` before that same `play()` call's `playWhenReady = true` has propagated to the controller, so the buffering spinner never showed for that first play. Subsequent plays worked because `playWhenReady` was already `true` from the prior station.
- Switched to `Player.Listener.onEvents`, which fires after the individual per-property callbacks in a batch — reading `player.playbackState` and `player.playWhenReady` there reflects fully-settled state instead of a possibly-stale field, so the spinner shows correctly regardless of which property change is delivered first.
- Preserves the existing behavior of suppressing the spinner during a paused-station restore on cold start (`playWhenReady == false`).

Closes #89

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` passes
- [x] Force-stopped the app for a clean "nothing playing" state, searched, played a result, confirmed the buffering spinner now appears on that first play
- [x] Played a second station afterward, confirmed the spinner still appears as before (no regression)