### PR TITLE
Fix wasted space and clipped text on Now Playing for non-enriched stations

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
@@ -419,7 +419,13 @@ fun NowPlayingScreen(
                     text = programmeSubtitle?.takeIf { it != programmeTitle } ?: "",
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    minLines = 2,
+                    // Only enriched stations (nowPlayingInfo != null) can ever populate this
+                    // line, and only they need the full 2-line reservation to avoid a jump as
+                    // that data arrives/changes. A station with no enricher at all (most ICY
+                    // stations) never has a subtitle, so reserving a stable 2 blank lines for
+                    // it here was permanently wasted space — most visibly on small screens,
+                    // where it pushed the now-playing track card off the bottom of the pane.
+                    minLines = if (nowPlayingInfo != null) 2 else 1,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.semantics { traversalIndex = 3f },


### PR DESCRIPTION
## Summary
- The programme subtitle text on the Now Playing screen always reserved `minLines = 2`, even when blank. `programmeSubtitle` only ever comes from `nowPlayingInfo`, so for any station without a metadata enricher (most plain ICY stations) it is permanently blank — meaning this reserved space was permanent dead space, not a one-off layout-jump guard.
- On small screens that dead space pushed the now-playing track card off the bottom of the pane, clipping its second line of text — exactly what's shown in the issue screenshot (5.05" Unihertz Jelly Max).
- Fix: only reserve the full 2 lines when an enricher is actually active (`nowPlayingInfo != null`) — that's the only case where this text can ever be non-blank and might need the extra line as it loads/changes. `maxLines` stays 2; since `programmeSubtitle` is only non-null when `nowPlayingInfo` is non-null, the two branches can never conflict (empty text can't wrap to 2 lines).

Closes #86

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` passes
- [x] Verified on-device: temporarily overrode display size/density via `adb shell wm size`/`wm density` to match the reporter's exact 720x1520 resolution, played a non-enriched station (ICY-only), and confirmed the now-playing track card renders fully — both lines visible with room to spare, where before the second line was clipped at the screen edge