### PR TITLE
chore(release): v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-07-12
+
+### Added
+
+- The mini player can now be swiped away to stop playback and clear the current station, matching the notification/Quick Settings media card's lifecycle.
+
+### Fixed
+
+- Removed hardware audio offload from the radio player, widened the buffer to match Media3's own streaming default, and hardened the HTTP data source (user agent, cross-protocol redirects, timeouts) — fixing playback dropouts on some devices and streams.
+- The favourites list now keeps the now-playing indicator visible while scrolling instead of reverting to a plain play icon.
+- The buffering spinner now shows correctly on the very first play of a session, such as playing a search result when nothing else is playing.
+- Fixed wasted vertical space and clipped track info on the Now Playing screen for stations without metadata enrichment, most visible on small screens.
+
 ## [0.4.2] - 2026-07-09
 
 ### Fixed

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,8 +28,8 @@ android {
         applicationId "com.shapeshed.aerial"
         minSdk 26
         targetSdk 37
-        versionCode 7
-        versionName "0.4.2"
+        versionCode 8
+        versionName "0.4.3"
     }
 
     signingConfigs {

--- a/fastlane/metadata/android/en-US/changelogs/8.txt
+++ b/fastlane/metadata/android/en-US/changelogs/8.txt
@@ -1,0 +1,5 @@
+- Swipe the mini player away to stop playback and clear the station.
+- Fixed radio playback dropouts by removing hardware audio offload and widening the stream buffer.
+- Fixed the now-playing indicator disappearing while scrolling favourites.
+- Fixed the buffering spinner not showing on the first play of a session.
+- Fixed clipped track info on the Now Playing screen on small screens.


### PR DESCRIPTION
## Summary
Version bump and changelog for v0.4.3, covering everything merged since v0.4.2:

- Removed hardware audio offload, widened the buffer, hardened HTTP data source config for radio streams (#83)
- Mini player is now swipeable to stop playback and dismiss it (#85)
- Favourites now-playing indicator stays visible while scrolling (#88)
- Buffering spinner now shows on the first play of a session (#90)
- Fixed wasted vertical space / clipped track info on Now Playing for non-enriched stations on small screens (#91)

`versionCode` 7→8, `versionName` 0.4.2→0.4.3.

## Test plan
- [x] `./scripts/prepare-release.sh --skip-fdroid` — `./gradlew test lint assembleRelease bundleRelease` all pass
- [x] CHANGELOG.md section and fastlane changelog (`8.txt`) verified against the script's extracted release notes
- [ ] F-Droid metadata sync/lint not run (no local `fdroiddata` checkout / `fdroid` CLI available in this environment) — `.fdroid.yml` itself is unchanged
- [ ] After merge: tag `v0.4.3` on main and push the tag to trigger the signed release build