### PR TITLE
fix(favorites): download logo locally when favouriting from search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Fixed
+
+- Favouriting a station played from search now downloads its logo to local storage immediately, instead of only saving the remote URL — so the image is included in backups and survives a restore. (#100)
+
 ## [0.4.3] - 2026-07-12
 
 ### Added

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -573,15 +573,16 @@ class MainViewModel(
                 // Ephemeral station (played without saving) — persist it as a favourite.
                 // Set currentStationId first, then wait for _allStations to contain the new
                 // row before clearing ephemeral, so currentStation never drops to null.
-                val id = repository.saveAsFavorite(station)
+                val id = repository.saveAsFavorite(ensureLocalLogo(station))
                 _currentStationId.value = id
                 _allStations.first { list -> list.any { it.id == id } }
                 _ephemeralStation.value = null
                 return@launch
             }
             if (!station.isFavorite) {
-                // Saved but unflagged (e.g. imported): favouriting just sets the flag.
-                repository.update(station.copy(isFavorite = true))
+                // Saved but unflagged (e.g. imported): favouriting sets the flag and, if
+                // the logo is still a remote URL, downloads it so it survives backups.
+                repository.update(ensureLocalLogo(station).copy(isFavorite = true))
                 return@launch
             }
             // Unfavouriting removes the saved row — home and search both treat row
@@ -741,6 +742,14 @@ class MainViewModel(
         if (_recentlyAddedStationId.value == stationId) {
             _recentlyAddedStationId.value = null
         }
+    }
+
+    // Favouriting must leave the logo cached under filesDir/logos so it survives backup/
+    // restore — a bare remote URL isn't embedded in the backup zip (see SettingsViewModel).
+    private suspend fun ensureLocalLogo(station: Station): Station {
+        if (!station.logoPath.startsWith("http")) return station
+        val localPath = withContext(Dispatchers.IO) { downloadLogo(station.logoPath) } ?: return station
+        return station.copy(logoPath = localPath)
     }
 
     private suspend fun downloadLogo(url: String): String? {


### PR DESCRIPTION
## Summary
- Favouriting a station via the search "+" button (`addFromRegistry`) already downloaded its logo to local storage, but favouriting a *played* search result via the heart icon (`toggleFavorite`) only persisted the raw remote URL.
- Since backup export only embeds image bytes for stations whose `logoPath` is a local file (not an `http(s)://` URL), these favourites lost their artwork after a backup/restore cycle.
- Added `ensureLocalLogo()` in `MainViewModel`, reusing the existing `downloadLogo()` helper, and call it before persisting a favourite in both `toggleFavorite` branches (ephemeral station, and saved-but-unflagged/imported station).

Fixes #100

## Test plan
- [x] `./gradlew compileDebugKotlin` — compiles cleanly
- [x] `./gradlew test lint` — all unit tests and lint pass
- [ ] Manual repro: favourite a station from search results (via play + heart icon), back up stations, clear app data, restore, confirm the image is present