### PR TITLE
Add Google Play badge and automate Play publishing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,14 +65,35 @@ jobs:
           fi
           printf '%s' "$AERIAL_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/aerial-release.jks"
 
-      - name: Build signed release APK
+      - name: Decode Play service account credentials
+        if: steps.check.outputs.skip != 'true'
+        env:
+          AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64 }}
+        run: |
+          if [ -z "$AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64" ]; then
+            echo "AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64 is required to publish to Google Play." >&2
+            exit 1
+          fi
+          printf '%s' "$AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64" | base64 --decode > "$RUNNER_TEMP/play-service-account.json"
+          echo "AERIAL_PLAY_SERVICE_ACCOUNT_JSON_FILE=$RUNNER_TEMP/play-service-account.json" >> "$GITHUB_ENV"
+
+      - name: Build signed release APK and bundle
         if: steps.check.outputs.skip != 'true'
         env:
           AERIAL_KEYSTORE_FILE: ${{ runner.temp }}/aerial-release.jks
           AERIAL_KEYSTORE_PASSWORD: ${{ secrets.AERIAL_KEYSTORE_PASSWORD }}
           AERIAL_KEY_ALIAS: ${{ secrets.AERIAL_KEY_ALIAS }}
           AERIAL_KEY_PASSWORD: ${{ secrets.AERIAL_KEY_PASSWORD }}
-        run: ./gradlew assembleRelease
+        run: ./gradlew assembleRelease bundleRelease
+
+      - name: Publish nightly to Google Play (beta)
+        if: steps.check.outputs.skip != 'true'
+        env:
+          AERIAL_KEYSTORE_FILE: ${{ runner.temp }}/aerial-release.jks
+          AERIAL_KEYSTORE_PASSWORD: ${{ secrets.AERIAL_KEYSTORE_PASSWORD }}
+          AERIAL_KEY_ALIAS: ${{ secrets.AERIAL_KEY_ALIAS }}
+          AERIAL_KEY_PASSWORD: ${{ secrets.AERIAL_KEY_PASSWORD }}
+        run: ./gradlew publishBundle --track beta
 
       - name: Rename APK
         if: steps.check.outputs.skip != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,18 @@ jobs:
           fi
           printf '%s' "$AERIAL_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/aerial-release.jks"
 
+      - name: Decode Play service account credentials
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64 }}
+        run: |
+          if [ -z "$AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64" ]; then
+            echo "AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64 is required to publish to Google Play." >&2
+            exit 1
+          fi
+          printf '%s' "$AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64" | base64 --decode > "$RUNNER_TEMP/play-service-account.json"
+          echo "AERIAL_PLAY_SERVICE_ACCOUNT_JSON_FILE=$RUNNER_TEMP/play-service-account.json" >> "$GITHUB_ENV"
+
       - name: Run release checks
         env:
           AERIAL_KEYSTORE_FILE: ${{ runner.temp }}/aerial-release.jks
@@ -106,7 +118,15 @@ jobs:
         with:
           files: |
             app/build/release-assets/*
-            app/build/play-assets/*
           overwrite_files: true
           draft: true
           generate_release_notes: true
+
+      - name: Publish release to Google Play (production)
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          AERIAL_KEYSTORE_FILE: ${{ runner.temp }}/aerial-release.jks
+          AERIAL_KEYSTORE_PASSWORD: ${{ secrets.AERIAL_KEYSTORE_PASSWORD }}
+          AERIAL_KEY_ALIAS: ${{ secrets.AERIAL_KEY_ALIAS }}
+          AERIAL_KEY_PASSWORD: ${{ secrets.AERIAL_KEY_PASSWORD }}
+        run: ./gradlew publishBundle --track production

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -217,6 +217,42 @@ base64 -w 0 aerial-release.jks
 Do not commit keystores, passwords, generated signed APKs, or Play Console
 credentials.
 
+## Google Play publishing
+
+CI publishes to Google Play automatically using the [Gradle Play
+Publisher](https://github.com/Triple-T/gradle-play-publisher) plugin — there
+is no manual upload step.
+
+- The nightly workflow (`.github/workflows/nightly.yml`) builds an AAB from
+  `main` every day and publishes it to the **beta** track.
+- The release workflow (`.github/workflows/release.yml`) builds an AAB when a
+  `v*` tag is pushed and publishes it to the **production** track at 100%
+  rollout.
+
+Version codes are resolved automatically (`resolutionStrategy = AUTO` in
+`app/build.gradle`), so the checked-in `versionCode` does not need to be
+bumped for each release.
+
+Required GitHub repository secret:
+
+- `AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64`: base64 encoded Google Cloud
+  service account JSON key. Create the service account in Google Cloud
+  Console, link it in Play Console under **Setup > API access**, and grant it
+  release permissions for this app. Encode it the same way as the keystore:
+
+  ```sh
+  base64 -w 0 play-service-account.json
+  ```
+
+For a local publish, set `AERIAL_PLAY_SERVICE_ACCOUNT_JSON_FILE` to the path
+of the JSON key alongside the release-signing env vars:
+
+```sh
+source local/release-signing.env
+export AERIAL_PLAY_SERVICE_ACCOUNT_JSON_FILE=/path/to/play-service-account.json
+./gradlew publishBundle --track beta
+```
+
 ## F-Droid
 
 Aerial is licensed under Apache-2.0 and does not include advertising,

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Just radio for Android.
 ## Install
 
 <p>
+<a href="https://play.google.com/store/apps/details?id=com.shapeshed.aerial"><img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="80"></a>
+&nbsp;&nbsp;
 <a href="https://f-droid.org/packages/com.shapeshed.aerial"><img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="80"></a>
 </p>
 
@@ -20,20 +22,6 @@ Just radio for Android.
 - Set a sleep timer so playback stops automatically.
 - No sign-up. You are not the product, just listen to radio.
 - Keep listening privately with no ads, analytics, tracking SDKs, Firebase, or accounts.
-
-## Funding
-
-Enjoying Aerial? You can help fund the project by buying me a coffee or sending
-a small contribution through Ko-fi or PayPal. Funding is optional, but it helps
-with the time and costs involved in keeping Aerial maintained.
-
-<p>
-  <a href="https://buymeacoffee.com/shapeshed"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me a Coffee" height="45"></a>
-  &nbsp;&nbsp;
-  <a href="https://ko-fi.com/shapeshed"><img src="https://storage.ko-fi.com/cdn/brandasset/v2/support_me_on_kofi_beige.png" alt="Support Aerial on Ko-fi" height="45"></a>
-  &nbsp;&nbsp;
-  <a href="https://www.paypal.com/donate/?hosted_button_id=MZVB3E2RYYWV8"><img src="docs/badges/paypal-donate.png" alt="Donate with PayPal" height="45"></a>
-</p>
 
 ## Development
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,11 @@
+import com.github.triplet.gradle.androidpublisher.ReleaseStatus
+import com.github.triplet.gradle.androidpublisher.ResolutionStrategy
+
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.plugin.compose'
     id 'com.google.devtools.ksp'
+    id 'com.github.triplet.play'
 }
 
 def registrySourceFile = layout.projectDirectory.file("src/main/registry/registry.json")
@@ -88,6 +92,18 @@ android {
     lint {
         fatal 'UnusedResources'
     }
+}
+
+def playServiceAccountJsonFile = System.getenv("AERIAL_PLAY_SERVICE_ACCOUNT_JSON_FILE")
+
+play {
+    if (playServiceAccountJsonFile) {
+        serviceAccountCredentials.set(file(playServiceAccountJsonFile))
+    }
+    defaultToAppBundles.set(true)
+    track.set("production")
+    releaseStatus.set(ReleaseStatus.COMPLETED)
+    resolutionStrategy.set(ResolutionStrategy.AUTO)
 }
 
 def generateRegistryAsset = tasks.register("generateRegistryAsset", Exec) {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.application' version '9.3.0' apply false
     id 'org.jetbrains.kotlin.plugin.compose' version '2.4.10' apply false
     id 'com.google.devtools.ksp' version '2.3.10' apply false
+    id 'com.github.triplet.play' version '4.0.0' apply false
 }
 
 tasks.register('quality') {


### PR DESCRIPTION
## Summary
- Add a Google Play badge to the README (before F-Droid) and drop the Funding section now that GitHub Sponsors is set up
- Automate Google Play publishing via Gradle Play Publisher: nightly builds go to the beta track, `v*` tags publish to production at 100% rollout, version codes resolve automatically

## Test plan
- [x] `./gradlew help` — build config evaluates cleanly with the new plugin
- [x] `./gradlew :app:tasks --group publishing` — confirms publish tasks only apply to the release variant, debug is untouched
- [ ] Merge and trigger a nightly run to confirm it publishes to the beta track