### PR TITLE
Publish nightly to internal track, fix Play version-code regression

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -86,14 +86,14 @@ jobs:
           AERIAL_KEY_PASSWORD: ${{ secrets.AERIAL_KEY_PASSWORD }}
         run: ./gradlew assembleRelease bundleRelease
 
-      - name: Publish nightly to Google Play (beta)
+      - name: Publish nightly to Google Play (internal testing)
         if: steps.check.outputs.skip != 'true'
         env:
           AERIAL_KEYSTORE_FILE: ${{ runner.temp }}/aerial-release.jks
           AERIAL_KEYSTORE_PASSWORD: ${{ secrets.AERIAL_KEYSTORE_PASSWORD }}
           AERIAL_KEY_ALIAS: ${{ secrets.AERIAL_KEY_ALIAS }}
           AERIAL_KEY_PASSWORD: ${{ secrets.AERIAL_KEY_PASSWORD }}
-        run: ./gradlew publishBundle --track beta
+        run: ./gradlew publishBundle --track internal
 
       - name: Rename APK
         if: steps.check.outputs.skip != 'true'

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -224,25 +224,48 @@ Publisher](https://github.com/Triple-T/gradle-play-publisher) plugin — there
 is no manual upload step.
 
 - The nightly workflow (`.github/workflows/nightly.yml`) builds an AAB from
-  `main` every day and publishes it to the **beta** track.
+  `main` every day and publishes it to the **internal testing** track.
 - The release workflow (`.github/workflows/release.yml`) builds an AAB when a
   `v*` tag is pushed and publishes it to the **production** track at 100%
   rollout.
 
-Version codes are resolved automatically (`resolutionStrategy = AUTO` in
-`app/build.gradle`), so the checked-in `versionCode` does not need to be
-bumped for each release.
+There is no beta track in use currently.
+
+Version codes are resolved automatically against Play
+(`resolutionStrategy = AUTO` in `app/build.gradle`) whenever Play credentials
+are present, so the checked-in `versionCode` does not need to be bumped for
+each release. When no credentials are configured — local builds without
+`AERIAL_PLAY_SERVICE_ACCOUNT_JSON_FILE` set, and F-Droid's reproducible
+build — the plugin falls back to the static checked-in `versionCode`, with no
+network call and no credentials required.
 
 Required GitHub repository secret:
 
 - `AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64`: base64 encoded Google Cloud
-  service account JSON key. Create the service account in Google Cloud
-  Console, link it in Play Console under **Setup > API access**, and grant it
-  release permissions for this app. Encode it the same way as the keystore:
+  service account JSON key.
 
-  ```sh
-  base64 -w 0 play-service-account.json
-  ```
+  1. Create a service account in Google Cloud Console and enable the Google
+     Play Android Developer API for that project.
+  2. Create a JSON key for it and download it.
+  3. In Play Console, go to account-level **Setup > API access** and link the
+     Google Cloud project (it should be auto-detected once the API is
+     enabled).
+  4. In Play Console, go to **Users and permissions**, invite the service
+     account's email (the `client_email` field in the JSON key), and grant it
+     app permissions for Aerial: release to production, release to testing
+     tracks, and view app information. Permissions can take a few minutes to
+     propagate.
+  5. Encode the key and store it as the secret:
+
+     ```sh
+     # macOS (BSD base64, no -w flag)
+     base64 -i play-service-account.json | gh secret set AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64
+
+     # Linux (GNU base64)
+     base64 -w 0 play-service-account.json | gh secret set AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64
+     ```
+
+  Delete the local JSON key file once it's stored as a secret.
 
 For a local publish, set `AERIAL_PLAY_SERVICE_ACCOUNT_JSON_FILE` to the path
 of the JSON key alongside the release-signing env vars:
@@ -250,7 +273,7 @@ of the JSON key alongside the release-signing env vars:
 ```sh
 source local/release-signing.env
 export AERIAL_PLAY_SERVICE_ACCOUNT_JSON_FILE=/path/to/play-service-account.json
-./gradlew publishBundle --track beta
+./gradlew publishBundle --track internal
 ```
 
 ## F-Droid

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -99,11 +99,11 @@ def playServiceAccountJsonFile = System.getenv("AERIAL_PLAY_SERVICE_ACCOUNT_JSON
 play {
     if (playServiceAccountJsonFile) {
         serviceAccountCredentials.set(file(playServiceAccountJsonFile))
+        resolutionStrategy.set(ResolutionStrategy.AUTO)
     }
     defaultToAppBundles.set(true)
     track.set("production")
     releaseStatus.set(ReleaseStatus.COMPLETED)
-    resolutionStrategy.set(ResolutionStrategy.AUTO)
 }
 
 def generateRegistryAsset = tasks.register("generateRegistryAsset", Exec) {


### PR DESCRIPTION
## Summary
- Nightly builds now publish to Google Play's **internal testing** track instead of beta — no beta track is in use for now
- Fix a regression from #105: `resolutionStrategy = AUTO` was applied unconditionally, causing `assembleRelease`/`bundleRelease` to hard-fail with no Play credentials configured — this broke F-Droid's reproducible build and any local release build without the secret. It now only applies when Play credentials are present, otherwise falling back to the static checked-in `versionCode`
- Update DEVELOPERS.md accordingly

## Test plan
- [x] `./gradlew assembleRelease` with no Play credentials set — now succeeds (previously failed with `No credentials specified`)
- [x] `./gradlew help` — config evaluates cleanly
- [ ] Merge and trigger a nightly run to confirm it publishes to internal