### PR TITLE
Drop Google Play internal testing from nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,35 +65,14 @@ jobs:
           fi
           printf '%s' "$AERIAL_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/aerial-release.jks"
 
-      - name: Decode Play service account credentials
-        if: steps.check.outputs.skip != 'true'
-        env:
-          AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64 }}
-        run: |
-          if [ -z "$AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64" ]; then
-            echo "AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64 is required to publish to Google Play." >&2
-            exit 1
-          fi
-          printf '%s' "$AERIAL_PLAY_SERVICE_ACCOUNT_JSON_BASE64" | base64 --decode > "$RUNNER_TEMP/play-service-account.json"
-          echo "AERIAL_PLAY_SERVICE_ACCOUNT_JSON_FILE=$RUNNER_TEMP/play-service-account.json" >> "$GITHUB_ENV"
-
-      - name: Build signed release APK and bundle
+      - name: Build signed release APK
         if: steps.check.outputs.skip != 'true'
         env:
           AERIAL_KEYSTORE_FILE: ${{ runner.temp }}/aerial-release.jks
           AERIAL_KEYSTORE_PASSWORD: ${{ secrets.AERIAL_KEYSTORE_PASSWORD }}
           AERIAL_KEY_ALIAS: ${{ secrets.AERIAL_KEY_ALIAS }}
           AERIAL_KEY_PASSWORD: ${{ secrets.AERIAL_KEY_PASSWORD }}
-        run: ./gradlew assembleRelease bundleRelease
-
-      - name: Publish nightly to Google Play (internal testing)
-        if: steps.check.outputs.skip != 'true'
-        env:
-          AERIAL_KEYSTORE_FILE: ${{ runner.temp }}/aerial-release.jks
-          AERIAL_KEYSTORE_PASSWORD: ${{ secrets.AERIAL_KEYSTORE_PASSWORD }}
-          AERIAL_KEY_ALIAS: ${{ secrets.AERIAL_KEY_ALIAS }}
-          AERIAL_KEY_PASSWORD: ${{ secrets.AERIAL_KEY_PASSWORD }}
-        run: ./gradlew publishBundle --track internal
+        run: ./gradlew assembleRelease
 
       - name: Rename APK
         if: steps.check.outputs.skip != 'true'

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -223,13 +223,12 @@ CI publishes to Google Play automatically using the [Gradle Play
 Publisher](https://github.com/Triple-T/gradle-play-publisher) plugin — there
 is no manual upload step.
 
-- The nightly workflow (`.github/workflows/nightly.yml`) builds an AAB from
-  `main` every day and publishes it to the **internal testing** track.
-- The release workflow (`.github/workflows/release.yml`) builds an AAB when a
-  `v*` tag is pushed and publishes it to the **production** track at 100%
-  rollout.
-
-There is no beta track in use currently.
+The release workflow (`.github/workflows/release.yml`) builds an AAB when a
+`v*` tag is pushed and publishes it to the **production** track at 100%
+rollout. There is no beta or internal testing track in use — nightly builds
+(`.github/workflows/nightly.yml`) only produce a GitHub release APK, they do
+not publish to Play. Use the GitHub `nightly` release, or an F-Droid build
+from source, for pre-release testing instead.
 
 Version codes are resolved automatically against Play
 (`resolutionStrategy = AUTO` in `app/build.gradle`) whenever Play credentials
@@ -252,9 +251,8 @@ Required GitHub repository secret:
      enabled).
   4. In Play Console, go to **Users and permissions**, invite the service
      account's email (the `client_email` field in the JSON key), and grant it
-     app permissions for Aerial: release to production, release to testing
-     tracks, and view app information. Permissions can take a few minutes to
-     propagate.
+     app permissions for Aerial: release to production, and view app
+     information. Permissions can take a few minutes to propagate.
   5. Encode the key and store it as the secret:
 
      ```sh
@@ -273,7 +271,7 @@ of the JSON key alongside the release-signing env vars:
 ```sh
 source local/release-signing.env
 export AERIAL_PLAY_SERVICE_ACCOUNT_JSON_FILE=/path/to/play-service-account.json
-./gradlew publishBundle --track internal
+./gradlew publishBundle --track production
 ```
 
 ## F-Droid


### PR DESCRIPTION
## Summary
- Nightly builds no longer publish to Google Play's internal testing track — it hit version-code conflicts against Play's artifact library and needed its own separate tester list for no real benefit
- Nightly is back to just building and publishing the GitHub release APK (as before Play automation)
- Google Play publishing is now production-only, driven by `v*` tags

## Test plan
- [x] `./gradlew help` — config evaluates cleanly
- [ ] Merge and trigger a nightly run to confirm it builds/publishes the GitHub release APK with no Play step