### PR TITLE
Android Auto support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 ### Added
 
 - Android Auto support: browse Favorites, Moods, and Recently Played, voice/typed search, and playback queues — tapping a station queues its list with skip next/previous wrapping around.
+- A favourite toggle on the Android Auto now-playing screen adds or removes the current station, including stations played straight from mood folders or search.
 - Recently Played now tracks any station played, favourited or not, in a new play-history table resolved against the station registry, and updates live on the car screen.
 - The home screen shows a Recently Played row above the For You section once at least one station has been played, updating live as stations play.
 - Station logos render in Android Auto browse lists even when the source is an SVG or a cleartext http URL, served as cached PNGs through a read-only content provider.
+- The phone's mini player and Now Playing screen follow playback started elsewhere — Android Auto, voice search, or a queue skip — instead of only playback started in-app.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- Android Auto support: browse Favorites, Moods, and Recently Played, voice/typed search, and playback queues — tapping a station queues its list with skip next/previous wrapping around.
+- Recently Played now tracks any station played, favourited or not, in a new play-history table resolved against the station registry, and updates live on the car screen.
+- The home screen shows a Recently Played row above the For You section once at least one station has been played, updating live as stations play.
+- Station logos render in Android Auto browse lists even when the source is an SVG or a cleartext http URL, served as cached PNGs through a read-only content provider.
+
 ### Fixed
 
 - Favouriting a station played from search now downloads its logo to local storage immediately, instead of only saving the remote URL — so the image is included in backups and survives a restore. (#100)

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -333,3 +333,8 @@ legacy session bridge (`MediaSessionLegacyStub.createPlaybackStateCompat`
 checks `isCurrentMediaItemLive()`), so Android Auto's queue equalizer
 indicator shows static bars rather than animating. This is expected for all
 media3 live-radio apps, not a bug.
+
+The Recently Played folder reorders on re-entry but not while it stays on
+screen: `notifyChildrenChanged("recent")` fires after each recorded play
+(visible in logcat), but the Auto host decides whether to re-query a folder
+it is currently displaying, and the DHU does not. Not fixable app-side.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -291,3 +291,31 @@ F-Droid builds should use the unsigned release path:
 ```
 
 The release build must not require local signing environment variables.
+
+## Android Auto
+
+`PlayerService` is a `media3` `MediaLibraryService` exposing a browse tree:
+root -> Favorites | Moods | Recently Played, plus voice/typed search. The
+tree-building logic lives in `data/MediaBrowseTree.kt` (plain suspend
+functions over `StationRepository`/`RegistryRepository`, no session types) so
+it's unit-testable without Robolectric — see
+`app/src/test/java/com/shapeshed/aerial/data/MediaBrowseTreeTest.kt`. It's
+named/placed generically (not car-specific) since Google TV support is
+planned next and will reuse it.
+
+Android Auto renders the browse tree itself — there's no custom UI to build
+or theme; the only app-controlled surfaces are the browse tree's content and
+the accent colour/icon declared in the manifest (`res/xml/automotive_app_desc.xml`,
+`Theme.Aerial.Car` in `themes.xml`).
+
+This can't be rendered or screenshotted in a normal dev environment. To test:
+
+```sh
+./gradlew installDebug
+```
+
+then connect via the [Desktop Head Unit](https://developer.android.com/training/cars/testing)
+or a real Android Auto host, and check: the app appears in Android Auto's app
+list, the root shows Favorites/Moods/Recently Played, mood folders show their
+stations, tapping a station plays it, and voice search ("Ok Google, play
+`<station>` on Aerial") resolves and plays.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -308,14 +308,28 @@ or theme; the only app-controlled surfaces are the browse tree's content and
 the accent colour/icon declared in the manifest (`res/xml/automotive_app_desc.xml`,
 `Theme.Aerial.Car` in `themes.xml`).
 
-This can't be rendered or screenshotted in a normal dev environment. To test:
+This can't be rendered or screenshotted in a normal dev environment. To test
+with the [Desktop Head Unit](https://developer.android.com/training/cars/testing):
 
 ```sh
 ./gradlew installDebug
+adb forward tcp:5277 tcp:5277
 ```
 
-then connect via the [Desktop Head Unit](https://developer.android.com/training/cars/testing)
-or a real Android Auto host, and check: the app appears in Android Auto's app
-list, the root shows Favorites/Moods/Recently Played, mood folders show their
-stations, tapping a station plays it, and voice search ("Ok Google, play
+On the phone, open the Android Auto app's settings and enable
+**Developer settings > Start head unit server** — without this the DHU
+connects but sits at "waiting for phone". Then launch the DHU binary
+(`extras/google/auto/desktop-head-unit` in the Android SDK). If the phone-side
+toggle was enabled after the DHU connected, restart the DHU.
+
+Check: the app appears in Android Auto's app list, the root shows
+Favorites/Moods/Recently Played, mood folders show their stations with logos,
+tapping a station plays it and queues its list (skip next/previous wraps
+around), playing updates Recently Played, and voice search ("Ok Google, play
 `<station>` on Aerial") resolves and plays.
+
+Live streams always report `speed=0` / unknown position through media3's
+legacy session bridge (`MediaSessionLegacyStub.createPlaybackStateCompat`
+checks `isCurrentMediaItemLive()`), so Android Auto's queue equalizer
+indicator shows static bars rather than animating. This is expected for all
+media3 live-radio apps, not a bug.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,6 +92,14 @@ android {
     lint {
         fatal 'UnusedResources'
     }
+
+    testOptions {
+        unitTests {
+            // Some framework calls (e.g. Uri.parse, used by media3's MediaItem.Builder) would
+            // otherwise throw "not mocked" in plain JUnit tests with no Robolectric.
+            returnDefaultValues = true
+        }
+    }
 }
 
 def playServiceAccountJsonFile = System.getenv("AERIAL_PLAY_SERVICE_ACCOUNT_JSON_FILE")
@@ -167,4 +175,5 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.json:json:20240303'
+    testImplementation 'org.mockito.kotlin:mockito-kotlin:6.3.0'
 }

--- a/app/schemas/com.shapeshed.aerial.data.StationDatabase/16.json
+++ b/app/schemas/com.shapeshed.aerial.data.StationDatabase/16.json
@@ -1,0 +1,205 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 16,
+    "identityHash": "f3f4eaea7ebfda09d9982b028cddb41a",
+    "entities": [
+      {
+        "tableName": "stations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `streamUrl` TEXT NOT NULL, `logoPath` TEXT NOT NULL, `isFavorite` INTEGER NOT NULL, `provider` TEXT NOT NULL, `providerId` TEXT NOT NULL, `tags` TEXT NOT NULL, `description` TEXT NOT NULL, `country` TEXT NOT NULL, `countryCode` TEXT NOT NULL, `playCount` INTEGER NOT NULL, `lastPlayedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoPath",
+            "columnName": "logoPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerId",
+            "columnName": "providerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countryCode",
+            "columnName": "countryCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "playCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "lastPlayedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stations_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, `streamUrl` TEXT NOT NULL, `provider` TEXT NOT NULL, `providerId` TEXT NOT NULL, `tags` TEXT NOT NULL, `description` TEXT NOT NULL, `country` TEXT NOT NULL, tokenize=unicode61 `remove_diacritics=1`, content=`stations`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerId",
+            "columnName": "providerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [
+            "remove_diacritics=1"
+          ],
+          "contentTable": "stations",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_BEFORE_UPDATE BEFORE UPDATE ON `stations` BEGIN DELETE FROM `stations_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_BEFORE_DELETE BEFORE DELETE ON `stations` BEGIN DELETE FROM `stations_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_AFTER_UPDATE AFTER UPDATE ON `stations` BEGIN INSERT INTO `stations_fts`(`docid`, `name`, `streamUrl`, `provider`, `providerId`, `tags`, `description`, `country`) VALUES (NEW.`rowid`, NEW.`name`, NEW.`streamUrl`, NEW.`provider`, NEW.`providerId`, NEW.`tags`, NEW.`description`, NEW.`country`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_stations_fts_AFTER_INSERT AFTER INSERT ON `stations` BEGIN INSERT INTO `stations_fts`(`docid`, `name`, `streamUrl`, `provider`, `providerId`, `tags`, `description`, `country`) VALUES (NEW.`rowid`, NEW.`name`, NEW.`streamUrl`, NEW.`provider`, NEW.`providerId`, NEW.`tags`, NEW.`description`, NEW.`country`); END"
+        ]
+      },
+      {
+        "tableName": "play_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`provider` TEXT NOT NULL, `providerId` TEXT NOT NULL, `playedAt` INTEGER NOT NULL, PRIMARY KEY(`provider`, `providerId`))",
+        "fields": [
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerId",
+            "columnName": "providerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playedAt",
+            "columnName": "playedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "provider",
+            "providerId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f3f4eaea7ebfda09d9982b028cddb41a')"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,14 @@
             android:name="com.google.android.gms.car.application.theme"
             android:resource="@style/Theme.Aerial.Car" />
 
+        <!-- Serves rasterized station logos to Android Auto / Bluetooth / System UI as stable
+             content:// artwork URIs, so those consumers can cache decoded icons by URI.
+             Read-only and restricted to the registry_artwork cache directory. -->
+        <provider
+            android:name=".ArtworkProvider"
+            android:authorities="${applicationId}.artwork"
+            android:exported="true" />
+
         <!-- Persists the per-app locale on pre-Android-13 via AppCompat. -->
         <service
             android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,14 @@
         android:localeConfig="@xml/locales_config"
         android:theme="@style/Theme.Aerial">
 
+        <!-- Declares Aerial as a media app for Android Auto / Android Automotive OS. -->
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc" />
+        <meta-data
+            android:name="com.google.android.gms.car.application.theme"
+            android:resource="@style/Theme.Aerial.Car" />
+
         <!-- Persists the per-app locale on pre-Android-13 via AppCompat. -->
         <service
             android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
@@ -50,6 +58,10 @@
             </intent-filter>
             <intent-filter>
                 <action android:name="android.media.browse.MediaBrowserService" />
+            </intent-filter>
+            <!-- Lets Android Auto/Assistant voice search ("play X on Aerial") reach this service. -->
+            <intent-filter>
+                <action android:name="android.media.action.MEDIA_PLAY_FROM_SEARCH" />
             </intent-filter>
         </service>
 

--- a/app/src/main/java/com/shapeshed/aerial/AerialApp.kt
+++ b/app/src/main/java/com/shapeshed/aerial/AerialApp.kt
@@ -47,7 +47,7 @@ class AerialApp : Application(), SingletonImageLoader.Factory {
         .build()
     private val db by lazy { StationDatabase.get(this) }
     private val registryDb by lazy { RegistryDatabase.get(this, BuildConfig.VERSION_CODE) }
-    val repository by lazy { StationRepository(db.stationDao()) }
+    val repository by lazy { StationRepository(db.stationDao(), db.playHistoryDao()) }
     val registryRepository by lazy { RegistryRepository(registryDb.registryDao()) }
     val settingsDataStore get() = dataStore
     val networkMonitor by lazy { NetworkMonitor(this) }

--- a/app/src/main/java/com/shapeshed/aerial/ArtworkProvider.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ArtworkProvider.kt
@@ -1,0 +1,57 @@
+package com.shapeshed.aerial
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import java.io.File
+import java.io.FileNotFoundException
+
+/**
+ * Read-only provider serving rasterized registry logos (SVG -> PNG, see
+ * [com.shapeshed.aerial.ui.cachedRegistryArtworkUri]) to external artwork consumers — Android
+ * Auto's browse lists, Bluetooth AVRCP, System UI. A stable content:// artworkUri lets those
+ * consumers decode once and cache by URI (embedded artworkData bytes can't be cached that way,
+ * which shows up as icons flashing in on every list render). Exported because media artwork
+ * URIs offer no permission-grant handshake; it can only ever open files inside the
+ * registry_artwork cache directory.
+ */
+class ArtworkProvider : ContentProvider() {
+
+    override fun onCreate(): Boolean = true
+
+    override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor {
+        val context = context ?: throw FileNotFoundException(uri.toString())
+        val fileName = uri.lastPathSegment ?: throw FileNotFoundException(uri.toString())
+        val dir = File(context.cacheDir, ARTWORK_CACHE_DIR)
+        val file = File(dir, fileName)
+        if (file.canonicalFile.parentFile != dir.canonicalFile || !file.exists()) {
+            throw FileNotFoundException(uri.toString())
+        }
+        return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+    }
+
+    override fun getType(uri: Uri): String = "image/png"
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor? = null
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<out String>?): Int = 0
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
+
+    companion object {
+        const val ARTWORK_CACHE_DIR = "registry_artwork"
+
+        fun uriFor(context: android.content.Context, fileName: String): Uri =
+            Uri.parse("content://${context.packageName}.artwork/$fileName")
+    }
+}

--- a/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
+++ b/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
@@ -292,7 +292,6 @@ class PlayerService : MediaLibraryService() {
             session: MediaSession,
             controller: MediaSession.ControllerInfo,
         ): MediaSession.ConnectionResult {
-            log("onConnect package=${controller.packageName} trusted=${controller.isTrusted}")
             return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
                 .setAvailableSessionCommands(
                     MediaSession.ConnectionResult.DEFAULT_SESSION_AND_LIBRARY_COMMANDS
@@ -353,7 +352,6 @@ class PlayerService : MediaLibraryService() {
             browser: MediaSession.ControllerInfo,
             params: LibraryParams?,
         ): ListenableFuture<LibraryResult<MediaItem>> {
-            log("onGetLibraryRoot package=${browser.packageName}")
             // Folders (Favorites/Moods/Recently Played) read as a list; station logos read well
             // as a grid, similar to most radio/podcast apps on Android Auto.
             val rootExtras = Bundle().apply {
@@ -388,7 +386,6 @@ class PlayerService : MediaLibraryService() {
             params: LibraryParams?,
         ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> = serviceFuture {
             val children = mediaBrowseTree.children(parentId)
-            log("onGetChildren parentId=$parentId count=${children?.size}")
             if (children == null) {
                 LibraryResult.ofError(SessionError.ERROR_BAD_VALUE)
             } else {
@@ -507,7 +504,6 @@ class PlayerService : MediaLibraryService() {
                 // Refreshes Android Auto's Recently Played list live, for any browser
                 // currently subscribed to it (not just on next re-entry into the folder).
                 val recentCount = mediaBrowseTree.children(RECENT_ID)?.size ?: 0
-                log("recorded play mediaId=$mediaId, notifyChildrenChanged recent count=$recentCount")
                 mediaSession.notifyChildrenChanged(RECENT_ID, recentCount, null)
             }
         }

--- a/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
+++ b/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
@@ -44,6 +44,8 @@ import com.shapeshed.aerial.data.MediaBrowseTree
 import com.shapeshed.aerial.data.Provider
 import com.shapeshed.aerial.data.NowPlayingInfo
 import com.shapeshed.aerial.data.NowPlayingStore
+import com.shapeshed.aerial.data.PlayHistoryEntry
+import com.shapeshed.aerial.data.RECENT_ID
 import com.shapeshed.aerial.data.RegistryRepository
 import com.shapeshed.aerial.data.SLEEP_TIMER_DURATION_MS
 import com.shapeshed.aerial.data.SleepTimerState
@@ -80,6 +82,8 @@ class PlayerService : MediaLibraryService() {
     private lateinit var registryRepository: RegistryRepository
     private lateinit var mediaBrowseTree: MediaBrowseTree
     private var stations: List<Station> = emptyList()
+    private val parentIdByMediaId = mutableMapOf<String, String>()
+    private var lastRecordedMediaId: String? = null
     private var lastIcyTitle: String? = null
     private var lastId3Title: String? = null
     private var activeEnricher: Provider? = null
@@ -130,6 +134,9 @@ class PlayerService : MediaLibraryService() {
             )
             .setHandleAudioBecomingNoisy(true)
             .build()
+        // Wraps skip next/previous around a browsed list's queue (e.g. Android Auto's mood
+        // folders), matching the phone UI's circular swipe-through-favourites pager.
+        player.repeatMode = Player.REPEAT_MODE_ALL
         player.addListener(icyListener)
         mediaSession = MediaLibrarySession.Builder(this, player, librarySessionCallback)
             .setSessionActivity(pendingIntent())
@@ -186,6 +193,7 @@ class PlayerService : MediaLibraryService() {
         override fun onIsPlayingChanged(isPlaying: Boolean) {
             log("onIsPlayingChanged=$isPlaying")
             if (isPlaying) {
+                recordPlayOnce()
                 currentStation()?.let { activeEnricher?.start(it, serviceScope) }
             } else {
                 activeEnricher?.pause()
@@ -199,8 +207,9 @@ class PlayerService : MediaLibraryService() {
             lastAppliedNowPlayingSignature = null
             activeEnricher?.stop()
             activeEnricher = null
+            val station = stationForMediaItem(mediaItem)
             if (enrichMetadataEnabled) {
-                stationForMediaItem(mediaItem)?.let { station ->
+                station?.let {
                     val enricher = (application as AerialApp).providers.firstOrNull { it.canEnrich(station) }
                     activeEnricher = enricher
                     if (player.isPlaying) enricher?.start(station, serviceScope)
@@ -283,9 +292,10 @@ class PlayerService : MediaLibraryService() {
             session: MediaSession,
             controller: MediaSession.ControllerInfo,
         ): MediaSession.ConnectionResult {
+            log("onConnect package=${controller.packageName} trusted=${controller.isTrusted}")
             return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
                 .setAvailableSessionCommands(
-                    MediaSession.ConnectionResult.DEFAULT_SESSION_COMMANDS
+                    MediaSession.ConnectionResult.DEFAULT_SESSION_AND_LIBRARY_COMMANDS
                         .buildUpon()
                         .add(favoriteCommand)
                         .add(sleepTimerSetCommand)
@@ -343,6 +353,7 @@ class PlayerService : MediaLibraryService() {
             browser: MediaSession.ControllerInfo,
             params: LibraryParams?,
         ): ListenableFuture<LibraryResult<MediaItem>> {
+            log("onGetLibraryRoot package=${browser.packageName}")
             // Folders (Favorites/Moods/Recently Played) read as a list; station logos read well
             // as a grid, similar to most radio/podcast apps on Android Auto.
             val rootExtras = Bundle().apply {
@@ -380,6 +391,16 @@ class PlayerService : MediaLibraryService() {
             if (children == null) {
                 LibraryResult.ofError(SessionError.ERROR_BAD_VALUE)
             } else {
+                // Remembered per mediaId (not just "whichever folder was browsed last") so a tap
+                // on one of these (via onSetMediaItems) can queue the tapped item's whole folder,
+                // giving Android Auto skip next/previous and an Up Next queue between stations
+                // instead of a single-item timeline. Auto prefetches sibling folders' contents in
+                // the background (e.g. for artwork), so a single last-folder variable would get
+                // clobbered before the user actually taps play. Only the mediaId -> folder
+                // mapping is kept; the folder's contents are rebuilt fresh at play time.
+                if (children.isNotEmpty() && children.all { it.mediaMetadata.isPlayable == true }) {
+                    children.forEach { parentIdByMediaId[it.mediaId] = parentId }
+                }
                 LibraryResult.ofItemList(children.paginated(page, pageSize), params)
             }
         }
@@ -418,8 +439,28 @@ class PlayerService : MediaLibraryService() {
             startIndex: Int,
             startPositionMs: Long,
         ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> = serviceFuture {
-            val resolved = mediaItems.map { item -> mediaBrowseTree.resolve(item.mediaId) ?: item }
-            MediaSession.MediaItemsWithStartPosition(resolved, startIndex, startPositionMs)
+            // startIndex arrives as C.INDEX_UNSET (-1) — "unspecified" — for a single-item legacy
+            // play request, not an actual out-of-range index.
+            val effectiveIndex = startIndex.takeIf { it in mediaItems.indices } ?: 0
+            val tappedId = mediaItems.getOrNull(effectiveIndex)?.mediaId
+            // Queue expansion is for browse-driven controllers (Android Auto) only — the in-app
+            // controller sends deliberate single-item plays, and its mediaIds are the same
+            // numeric row ids Auto browses, so without the package check a phone tap would be
+            // silently expanded into whatever folder Auto last prefetched.
+            val parentId = tappedId
+                ?.takeIf { mediaItems.size == 1 && controller.packageName != packageName }
+                ?.let { parentIdByMediaId[it] }
+            // Rebuilt fresh (not served from a browse-time cache) so a folder edited since it
+            // was browsed — an unfavorited station, a changed stream URL — can't queue stale
+            // entries.
+            val siblings = parentId?.let { mediaBrowseTree.children(it) }
+            val siblingIndex = siblings?.indexOfFirst { it.mediaId == tappedId } ?: -1
+            if (siblings != null && siblingIndex >= 0) {
+                MediaSession.MediaItemsWithStartPosition(siblings, siblingIndex, startPositionMs)
+            } else {
+                val resolved = mediaItems.map { item -> mediaBrowseTree.resolve(item.mediaId) ?: item }
+                MediaSession.MediaItemsWithStartPosition(resolved, startIndex, startPositionMs)
+            }
         }
     }
 
@@ -438,6 +479,36 @@ class PlayerService : MediaLibraryService() {
         val from = (page * pageSize).coerceIn(0, size)
         val to = (from + pageSize).coerceIn(from, size)
         return subList(from, to)
+    }
+
+    // Records a listen the moment audio actually starts (onIsPlayingChanged=true) — the single
+    // choke point every surface's playback passes through (phone, Android Auto, Google TV
+    // later). Recording on onMediaItemTransition instead would count plays that never happen:
+    // the paused last-station restore on every app launch, and REPEAT_MODE_ALL re-transitions
+    // when a live stream drops. Deduped per mediaId so buffering pauses and same-station
+    // restarts don't double-count; playing a different station in between resets the guard.
+    private fun recordPlayOnce() {
+        val mediaId = player.currentMediaItem?.mediaId ?: return
+        if (mediaId == lastRecordedMediaId) return
+        val station = stationForMediaItem(player.currentMediaItem) ?: return
+        lastRecordedMediaId = mediaId
+        val playedAt = System.currentTimeMillis()
+        // Ephemeral stations (id=0, not yet saved locally) have no row to update.
+        if (station.id != 0L) {
+            serviceScope.launch { repository.recordPlay(station.id, playedAt) }
+        }
+        // Recently Played (any station played, favorited or not) only resolves for
+        // registry-backed stations — a locally-added custom station has no provider
+        // identity to record it by.
+        if (station.provider.isNotBlank() && station.providerId.isNotBlank()) {
+            serviceScope.launch {
+                repository.recordHistoryPlay(PlayHistoryEntry(station.provider, station.providerId, playedAt))
+                // Refreshes Android Auto's Recently Played list live, for any browser
+                // currently subscribed to it (not just on next re-entry into the folder).
+                val recentCount = mediaBrowseTree.children(RECENT_ID)?.size ?: 0
+                mediaSession.notifyChildrenChanged(RECENT_ID, recentCount, null)
+            }
+        }
     }
 
     private fun updateFavoriteButton() {
@@ -502,17 +573,29 @@ class PlayerService : MediaLibraryService() {
     private fun currentStation(): Station? = stationForMediaItem(player.currentMediaItem)
 
     private fun stationForMediaItem(mediaItem: MediaItem?): Station? {
-        val id = mediaItem?.mediaId?.toLongOrNull() ?: return null
-        stations.firstOrNull { it.id == id }?.let { return it }
-        // Ephemeral station (id=0): reconstruct from MediaItem extras so enrichers can run.
+        if (mediaItem == null) return null
+        mediaItem.mediaId.toLongOrNull()?.let { id ->
+            stations.firstOrNull { it.id == id }?.let { return it }
+        }
         val extras = mediaItem.mediaMetadata.extras ?: return null
         val streamUrl = extras.getString("streamUrl")?.takeIf { it.isNotBlank() } ?: return null
+        // A station playing under an ephemeral mediaId ("0" from the phone, "reg:4492" from
+        // the Android Auto browse tree) may still exist as a saved row — matched the same way
+        // StationRepository.findExisting does — and must resolve to it, or the favorite toggle
+        // would see isFavorite=false forever and re-save instead of unfavoriting.
+        val provider = extras.getString("provider").orEmpty()
+        val providerId = extras.getString("providerId").orEmpty()
+        if (provider.isNotBlank() && providerId.isNotBlank()) {
+            stations.firstOrNull { it.provider == provider && it.providerId == providerId }?.let { return it }
+        }
+        stations.firstOrNull { it.streamUrl == streamUrl }?.let { return it }
         return Station(
             id = 0,
             name = mediaItem.mediaMetadata.title?.toString() ?: "",
             streamUrl = streamUrl,
-            provider = extras.getString("provider") ?: "",
-            providerId = extras.getString("providerId") ?: "",
+            logoPath = extras.getString("logoPath").orEmpty(),
+            provider = provider,
+            providerId = providerId,
         )
     }
 

--- a/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
+++ b/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
@@ -388,6 +388,7 @@ class PlayerService : MediaLibraryService() {
             params: LibraryParams?,
         ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> = serviceFuture {
             val children = mediaBrowseTree.children(parentId)
+            log("onGetChildren parentId=$parentId count=${children?.size}")
             if (children == null) {
                 LibraryResult.ofError(SessionError.ERROR_BAD_VALUE)
             } else {
@@ -506,6 +507,7 @@ class PlayerService : MediaLibraryService() {
                 // Refreshes Android Auto's Recently Played list live, for any browser
                 // currently subscribed to it (not just on next re-entry into the folder).
                 val recentCount = mediaBrowseTree.children(RECENT_ID)?.size ?: 0
+                log("recorded play mediaId=$mediaId, notifyChildrenChanged recent count=$recentCount")
                 mediaSession.notifyChildrenChanged(RECENT_ID, recentCount, null)
             }
         }

--- a/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
+++ b/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
@@ -24,19 +24,27 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.session.CommandButton
 import androidx.media3.session.DefaultMediaNotificationProvider
+import androidx.media3.session.LibraryResult
+import androidx.media3.session.MediaConstants
+import androidx.media3.session.MediaLibraryService
+import androidx.media3.session.MediaLibraryService.LibraryParams
+import androidx.media3.session.MediaLibraryService.MediaLibrarySession
 import androidx.media3.session.MediaSession
-import androidx.media3.session.MediaSessionService
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionError
 import androidx.media3.session.SessionResult
+import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.SettableFuture
 import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_CANCEL
 import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_SET
 import com.shapeshed.aerial.data.AERIAL_USER_AGENT
+import com.shapeshed.aerial.data.MediaBrowseTree
 import com.shapeshed.aerial.data.Provider
 import com.shapeshed.aerial.data.NowPlayingInfo
 import com.shapeshed.aerial.data.NowPlayingStore
+import com.shapeshed.aerial.data.RegistryRepository
 import com.shapeshed.aerial.data.SLEEP_TIMER_DURATION_MS
 import com.shapeshed.aerial.data.SleepTimerState
 import com.shapeshed.aerial.data.SleepTimerStore
@@ -58,7 +66,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @OptIn(UnstableApi::class)
-class PlayerService : MediaSessionService() {
+class PlayerService : MediaLibraryService() {
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val favoriteCommand = SessionCommand(ACTION_TOGGLE_FAVORITE, Bundle.EMPTY)
@@ -67,8 +75,10 @@ class PlayerService : MediaSessionService() {
     private var sleepTimerJob: Job? = null
 
     private lateinit var player: ExoPlayer
-    private lateinit var mediaSession: MediaSession
+    private lateinit var mediaSession: MediaLibrarySession
     private lateinit var repository: StationRepository
+    private lateinit var registryRepository: RegistryRepository
+    private lateinit var mediaBrowseTree: MediaBrowseTree
     private var stations: List<Station> = emptyList()
     private var lastIcyTitle: String? = null
     private var lastId3Title: String? = null
@@ -91,6 +101,8 @@ class PlayerService : MediaSessionService() {
             }
         )
         repository = (application as AerialApp).repository
+        registryRepository = (application as AerialApp).registryRepository
+        mediaBrowseTree = MediaBrowseTree(this, repository, registryRepository)
         val httpDataSourceFactory = DefaultHttpDataSource.Factory()
             .setUserAgent(AERIAL_USER_AGENT)
             .setAllowCrossProtocolRedirects(true)
@@ -119,9 +131,8 @@ class PlayerService : MediaSessionService() {
             .setHandleAudioBecomingNoisy(true)
             .build()
         player.addListener(icyListener)
-        mediaSession = MediaSession.Builder(this, player)
+        mediaSession = MediaLibrarySession.Builder(this, player, librarySessionCallback)
             .setSessionActivity(pendingIntent())
-            .setCallback(sessionCallback)
             .setMediaButtonPreferences(listOf(favoriteButton(null)))
             .setBitmapLoader(CoilBitmapLoader(this))
             .build()
@@ -267,7 +278,7 @@ class PlayerService : MediaSessionService() {
         }
     }
 
-    private val sessionCallback = object : MediaSession.Callback {
+    private val librarySessionCallback = object : MediaLibrarySession.Callback {
         override fun onConnect(
             session: MediaSession,
             controller: MediaSession.ControllerInfo,
@@ -326,6 +337,107 @@ class PlayerService : MediaSessionService() {
                 else -> return super.onCustomCommand(session, controller, customCommand, args)
             }
         }
+
+        override fun onGetLibraryRoot(
+            session: MediaLibrarySession,
+            browser: MediaSession.ControllerInfo,
+            params: LibraryParams?,
+        ): ListenableFuture<LibraryResult<MediaItem>> {
+            // Folders (Favorites/Moods/Recently Played) read as a list; station logos read well
+            // as a grid, similar to most radio/podcast apps on Android Auto.
+            val rootExtras = Bundle().apply {
+                putInt(
+                    MediaConstants.EXTRAS_KEY_CONTENT_STYLE_BROWSABLE,
+                    MediaConstants.EXTRAS_VALUE_CONTENT_STYLE_CATEGORY_LIST_ITEM,
+                )
+                putInt(
+                    MediaConstants.EXTRAS_KEY_CONTENT_STYLE_PLAYABLE,
+                    MediaConstants.EXTRAS_VALUE_CONTENT_STYLE_GRID_ITEM,
+                )
+            }
+            val rootParams = LibraryParams.Builder().setExtras(rootExtras).build()
+            return Futures.immediateFuture(LibraryResult.ofItem(mediaBrowseTree.rootItem(), rootParams))
+        }
+
+        override fun onGetItem(
+            session: MediaLibrarySession,
+            browser: MediaSession.ControllerInfo,
+            mediaId: String,
+        ): ListenableFuture<LibraryResult<MediaItem>> = serviceFuture {
+            mediaBrowseTree.resolve(mediaId)?.let { LibraryResult.ofItem(it, null) }
+                ?: LibraryResult.ofError(SessionError.ERROR_BAD_VALUE)
+        }
+
+        override fun onGetChildren(
+            session: MediaLibrarySession,
+            browser: MediaSession.ControllerInfo,
+            parentId: String,
+            page: Int,
+            pageSize: Int,
+            params: LibraryParams?,
+        ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> = serviceFuture {
+            val children = mediaBrowseTree.children(parentId)
+            if (children == null) {
+                LibraryResult.ofError(SessionError.ERROR_BAD_VALUE)
+            } else {
+                LibraryResult.ofItemList(children.paginated(page, pageSize), params)
+            }
+        }
+
+        override fun onSearch(
+            session: MediaLibrarySession,
+            browser: MediaSession.ControllerInfo,
+            query: String,
+            params: LibraryParams?,
+        ): ListenableFuture<LibraryResult<Void>> = serviceFuture {
+            val resultCount = mediaBrowseTree.search(query).size
+            session.notifySearchResultChanged(browser, query, resultCount, params)
+            LibraryResult.ofVoid()
+        }
+
+        override fun onGetSearchResult(
+            session: MediaLibrarySession,
+            browser: MediaSession.ControllerInfo,
+            query: String,
+            page: Int,
+            pageSize: Int,
+            params: LibraryParams?,
+        ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> = serviceFuture {
+            LibraryResult.ofItemList(mediaBrowseTree.search(query).paginated(page, pageSize), params)
+        }
+
+        // Android Auto's legacy MediaBrowserCompat bridge plays a tapped browse item (or a voice
+        // search/resumption result) by dispatching a MediaItem carrying only a mediaId, not the
+        // fully resolved item the browse tree returned — so it must be looked up again here before
+        // ExoPlayer can play it. Falls back to the incoming item unchanged if it doesn't resolve
+        // (e.g. an ephemeral station the phone UI is already playing directly with a real URI).
+        override fun onSetMediaItems(
+            session: MediaSession,
+            controller: MediaSession.ControllerInfo,
+            mediaItems: List<MediaItem>,
+            startIndex: Int,
+            startPositionMs: Long,
+        ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> = serviceFuture {
+            val resolved = mediaItems.map { item -> mediaBrowseTree.resolve(item.mediaId) ?: item }
+            MediaSession.MediaItemsWithStartPosition(resolved, startIndex, startPositionMs)
+        }
+    }
+
+    private fun <T> serviceFuture(block: suspend () -> T): ListenableFuture<T> {
+        val future = SettableFuture.create<T>()
+        serviceScope.launch {
+            runCatching { block() }
+                .onSuccess { future.set(it) }
+                .onFailure { future.setException(it) }
+        }
+        return future
+    }
+
+    private fun List<MediaItem>.paginated(page: Int, pageSize: Int): List<MediaItem> {
+        if (pageSize <= 0) return this
+        val from = (page * pageSize).coerceIn(0, size)
+        val to = (from + pageSize).coerceIn(from, size)
+        return subList(from, to)
     }
 
     private fun updateFavoriteButton() {

--- a/app/src/main/java/com/shapeshed/aerial/StationMediaItems.kt
+++ b/app/src/main/java/com/shapeshed/aerial/StationMediaItems.kt
@@ -1,0 +1,93 @@
+package com.shapeshed.aerial
+
+import android.content.Context
+import android.os.Bundle
+import androidx.core.net.toUri
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import com.shapeshed.aerial.data.RegistryStation
+import com.shapeshed.aerial.data.Station
+import com.shapeshed.aerial.data.bauerStreamUrl
+import com.shapeshed.aerial.ui.appIconBitmap
+import com.shapeshed.aerial.ui.compressedLogoData
+import java.io.File
+
+/**
+ * A registry catalogue result not yet saved locally, mirrored as an ephemeral (id=0) [Station] so
+ * it can be played and displayed the same way as a saved one.
+ */
+fun RegistryStation.toEphemeralStation(): Station = Station(
+    name = name,
+    streamUrl = streamUrl,
+    logoPath = logoUrl,
+    provider = provider,
+    providerId = providerId,
+    tags = tags,
+    description = description,
+    country = country,
+    countryCode = countryCode,
+)
+
+/**
+ * Shared by direct phone playback and the media browse tree (Android Auto, Google TV), so both
+ * surfaces describe a station identically.
+ */
+fun stationMediaMetadata(context: Context, station: Station): MediaMetadata {
+    val artworkUri = station.logoPath
+        .takeIf { it.startsWith("http") }
+        ?.toUri()
+    val localArtworkData = station.logoPath
+        .takeIf { it.isNotEmpty() && !it.startsWith("http") }
+        ?.let { compressedLogoData(File(it)) }
+
+    return MediaMetadata.Builder().apply {
+        when {
+            localArtworkData != null -> setArtworkData(
+                localArtworkData,
+                MediaMetadata.PICTURE_TYPE_FRONT_COVER,
+            )
+            artworkUri != null -> setArtworkUri(artworkUri)
+            else -> appIconBitmap(context)?.let {
+                setArtworkData(it, MediaMetadata.PICTURE_TYPE_FRONT_COVER)
+            }
+        }
+    }
+        .setTitle(station.name)
+        .setArtist(context.getString(R.string.live_radio))
+        .setSubtitle(context.getString(R.string.live_radio))
+        .setIsBrowsable(false)
+        .setIsPlayable(true)
+        .setMediaType(MediaMetadata.MEDIA_TYPE_RADIO_STATION)
+        .setExtras(Bundle().apply {
+            putString("provider", station.provider)
+            putString("providerId", station.providerId)
+            putString("streamUrl", station.streamUrl)
+        })
+        .build()
+}
+
+/** A fully resolved, directly playable [MediaItem] — real stream URI included, no further
+ * resolution needed by whatever surface (phone controller, Android Auto, Google TV) plays it. */
+fun Station.toPlayableMediaItem(context: Context): MediaItem =
+    MediaItem.Builder()
+        .setMediaId(id.toString())
+        .setUri(bauerStreamUrl(this))
+        .setMediaMetadata(stationMediaMetadata(context, this))
+        .build()
+
+/** Prefix marking a browse-tree mediaId as a registry (not-yet-saved) station, keyed by
+ * [RegistryStation.id] rather than the shared `0` every ephemeral [Station] otherwise has —
+ * multiple registry stations appear side by side in mood/search browse results, so their
+ * mediaIds must stay distinct from each other and from real saved stations. */
+const val REGISTRY_MEDIA_ID_PREFIX = "reg:"
+
+/** A fully resolved, directly playable [MediaItem] for a browse-tree leaf sourced from the
+ * station registry (mood/search results) — see [REGISTRY_MEDIA_ID_PREFIX]. */
+fun RegistryStation.toPlayableMediaItem(context: Context): MediaItem {
+    val ephemeral = toEphemeralStation()
+    return MediaItem.Builder()
+        .setMediaId("$REGISTRY_MEDIA_ID_PREFIX$id")
+        .setUri(bauerStreamUrl(ephemeral))
+        .setMediaMetadata(stationMediaMetadata(context, ephemeral))
+        .build()
+}

--- a/app/src/main/java/com/shapeshed/aerial/StationMediaItems.kt
+++ b/app/src/main/java/com/shapeshed/aerial/StationMediaItems.kt
@@ -1,6 +1,7 @@
 package com.shapeshed.aerial
 
 import android.content.Context
+import android.net.Uri
 import android.os.Bundle
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
@@ -9,6 +10,7 @@ import com.shapeshed.aerial.data.RegistryStation
 import com.shapeshed.aerial.data.Station
 import com.shapeshed.aerial.data.bauerStreamUrl
 import com.shapeshed.aerial.ui.appIconBitmap
+import com.shapeshed.aerial.ui.cachedRemoteArtworkUri
 import com.shapeshed.aerial.ui.compressedLogoData
 import java.io.File
 
@@ -30,9 +32,16 @@ fun RegistryStation.toEphemeralStation(): Station = Station(
 
 /**
  * Shared by direct phone playback and the media browse tree (Android Auto, Google TV), so both
- * surfaces describe a station identically.
+ * surfaces describe a station identically. [artworkUriOverride] substitutes a decodable
+ * content:// URI (a registry SVG rasterized to PNG, served by [ArtworkProvider]) for surfaces
+ * that decode a MediaItem's artwork themselves and can't handle SVG, like Android Auto's
+ * browse lists.
  */
-fun stationMediaMetadata(context: Context, station: Station): MediaMetadata {
+fun stationMediaMetadata(
+    context: Context,
+    station: Station,
+    artworkUriOverride: Uri? = null,
+): MediaMetadata {
     val artworkUri = station.logoPath
         .takeIf { it.startsWith("http") }
         ?.toUri()
@@ -42,6 +51,7 @@ fun stationMediaMetadata(context: Context, station: Station): MediaMetadata {
 
     return MediaMetadata.Builder().apply {
         when {
+            artworkUriOverride != null -> setArtworkUri(artworkUriOverride)
             localArtworkData != null -> setArtworkData(
                 localArtworkData,
                 MediaMetadata.PICTURE_TYPE_FRONT_COVER,
@@ -62,18 +72,26 @@ fun stationMediaMetadata(context: Context, station: Station): MediaMetadata {
             putString("provider", station.provider)
             putString("providerId", station.providerId)
             putString("streamUrl", station.streamUrl)
+            putString("logoPath", station.logoPath)
         })
         .build()
 }
 
 /** A fully resolved, directly playable [MediaItem] — real stream URI included, no further
  * resolution needed by whatever surface (phone controller, Android Auto, Google TV) plays it. */
-fun Station.toPlayableMediaItem(context: Context): MediaItem =
+fun Station.toPlayableMediaItem(context: Context, artworkUriOverride: Uri? = null): MediaItem =
     MediaItem.Builder()
         .setMediaId(id.toString())
         .setUri(bauerStreamUrl(this))
-        .setMediaMetadata(stationMediaMetadata(context, this))
+        .setMediaMetadata(stationMediaMetadata(context, this, artworkUriOverride))
         .build()
+
+/** [toPlayableMediaItem] for the media browse tree: suspends to proxy a remote logo Android
+ * Auto can't fetch or decode itself (SVG or cleartext http) through [ArtworkProvider] — see
+ * [cachedRemoteArtworkUri]. Phone playback keeps the plain variant; its surfaces load artwork
+ * through the app's own Coil stack, which handles both. */
+suspend fun Station.toBrowseMediaItem(context: Context): MediaItem =
+    toPlayableMediaItem(context, cachedRemoteArtworkUri(context, logoPath))
 
 /** Prefix marking a browse-tree mediaId as a registry (not-yet-saved) station, keyed by
  * [RegistryStation.id] rather than the shared `0` every ephemeral [Station] otherwise has —
@@ -82,12 +100,15 @@ fun Station.toPlayableMediaItem(context: Context): MediaItem =
 const val REGISTRY_MEDIA_ID_PREFIX = "reg:"
 
 /** A fully resolved, directly playable [MediaItem] for a browse-tree leaf sourced from the
- * station registry (mood/search results) — see [REGISTRY_MEDIA_ID_PREFIX]. */
-fun RegistryStation.toPlayableMediaItem(context: Context): MediaItem {
+ * station registry (mood/search results) — see [REGISTRY_MEDIA_ID_PREFIX]. Suspends to
+ * rasterize an SVG logo to a PNG-backed content URI (cached on disk), since browse-list
+ * consumers like Android Auto can't decode SVG from a remote artworkUri themselves. */
+suspend fun RegistryStation.toPlayableMediaItem(context: Context): MediaItem {
     val ephemeral = toEphemeralStation()
+    val artworkUriOverride = cachedRemoteArtworkUri(context, logoUrl)
     return MediaItem.Builder()
         .setMediaId("$REGISTRY_MEDIA_ID_PREFIX$id")
         .setUri(bauerStreamUrl(ephemeral))
-        .setMediaMetadata(stationMediaMetadata(context, ephemeral))
+        .setMediaMetadata(stationMediaMetadata(context, ephemeral, artworkUriOverride))
         .build()
 }

--- a/app/src/main/java/com/shapeshed/aerial/data/MediaBrowseTree.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/MediaBrowseTree.kt
@@ -5,15 +5,25 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import com.shapeshed.aerial.R
 import com.shapeshed.aerial.REGISTRY_MEDIA_ID_PREFIX
+import com.shapeshed.aerial.toBrowseMediaItem
 import com.shapeshed.aerial.toPlayableMediaItem
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
+
+/** Runs [transform] for all items concurrently — browse lists resolve per-station artwork that
+ * may each hit the network (see cachedRemoteArtworkUri), and doing that sequentially would
+ * stack timeouts into a folder-level stall Android Auto gives up on. */
+private suspend fun <T, R> List<T>.mapConcurrently(transform: suspend (T) -> R): List<R> =
+    coroutineScope { map { async { transform(it) } }.awaitAll() }
 
 const val MEDIA_BROWSE_ROOT_ID = "root"
 private const val FAVORITES_ID = "favorites"
 private const val MOODS_ID = "moods"
-private const val RECENT_ID = "recent"
+const val RECENT_ID = "recent"
 private const val MOOD_ID_PREFIX = "mood:"
-private const val RECENT_LIMIT = 20
+private const val RECENT_LIMIT = 10
 
 private val MOOD_TITLES = listOf(
     "relax" to R.string.mood_relax,
@@ -42,7 +52,7 @@ class MediaBrowseTree(
     fun rootChildren(): List<MediaItem> = listOf(
         browsableFolder(FAVORITES_ID, context.getString(R.string.tab_favorites)),
         browsableFolder(MOODS_ID, context.getString(R.string.car_moods)),
-        browsableFolder(RECENT_ID, context.getString(R.string.car_recently_played)),
+        browsableFolder(RECENT_ID, context.getString(R.string.recently_played)),
     )
 
     /** Dispatches a parentId to the right children list, or null if it's not a known folder. */
@@ -56,7 +66,7 @@ class MediaBrowseTree(
     }
 
     suspend fun favoriteChildren(): List<MediaItem> =
-        stationRepository.getAll().first().map { it.toPlayableMediaItem(context) }
+        stationRepository.getAll().first().mapConcurrently { it.toBrowseMediaItem(context) }
 
     fun moodChildren(): List<MediaItem> = MOOD_TITLES.map { (id, titleRes) ->
         browsableFolder("$MOOD_ID_PREFIX$id", context.getString(titleRes))
@@ -64,20 +74,23 @@ class MediaBrowseTree(
 
     suspend fun moodStationChildren(moodId: String): List<MediaItem> =
         registryRepository.curatedMoodStations()[moodId]
-            ?.map { it.toPlayableMediaItem(context) }
+            ?.mapConcurrently { it.toPlayableMediaItem(context) }
             ?: emptyList()
 
+    // Sourced from play_history (any station played, favorited or not) rather than favorited
+    // stations' lastPlayedAt, so browsing a mood/search result shows up here even if it's never
+    // been saved. Entries only resolve for registry-backed stations (provider+providerId); a
+    // history row whose station has since vanished from the registry — or a curated mood
+    // station without a real providerId — is silently skipped rather than shown broken.
     suspend fun recentChildren(): List<MediaItem> =
-        stationRepository.getAll().first()
-            .filter { it.lastPlayedAt > 0 }
-            .sortedByDescending { it.lastPlayedAt }
-            .take(RECENT_LIMIT)
-            .map { it.toPlayableMediaItem(context) }
+        stationRepository.recentlyPlayed(RECENT_LIMIT)
+            .mapNotNull { entry -> registryRepository.getByProviderId(entry.provider, entry.providerId) }
+            .mapConcurrently { it.toPlayableMediaItem(context) }
 
     /** Broad catalogue search (not just favorites) so voice search can find and play any station
      * in the registry, matching what "Hey Google, play X on Aerial" needs. */
     suspend fun search(query: String): List<MediaItem> =
-        registryRepository.search(query).map { it.toPlayableMediaItem(context) }
+        registryRepository.search(query).mapConcurrently { it.toPlayableMediaItem(context) }
 
     /**
      * Resolves a bare mediaId — from a browse-item tap, voice search, or playback resumption —
@@ -92,6 +105,9 @@ class MediaBrowseTree(
             return registryRepository.getById(registryId)?.toPlayableMediaItem(context)
         }
         val id = mediaId.toLongOrNull() ?: return null
+        // toPlayableMediaItem, not toBrowseMediaItem: this sits on the playback-start path
+        // (onSetMediaItems), and the session's own artwork loads through CoilBitmapLoader —
+        // proxying the logo here would block "tap play" on an uncached network fetch.
         return stationRepository.getById(id)?.toPlayableMediaItem(context)
     }
 

--- a/app/src/main/java/com/shapeshed/aerial/data/MediaBrowseTree.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/MediaBrowseTree.kt
@@ -1,0 +1,110 @@
+package com.shapeshed.aerial.data
+
+import android.content.Context
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import com.shapeshed.aerial.R
+import com.shapeshed.aerial.REGISTRY_MEDIA_ID_PREFIX
+import com.shapeshed.aerial.toPlayableMediaItem
+import kotlinx.coroutines.flow.first
+
+const val MEDIA_BROWSE_ROOT_ID = "root"
+private const val FAVORITES_ID = "favorites"
+private const val MOODS_ID = "moods"
+private const val RECENT_ID = "recent"
+private const val MOOD_ID_PREFIX = "mood:"
+private const val RECENT_LIMIT = 20
+
+private val MOOD_TITLES = listOf(
+    "relax" to R.string.mood_relax,
+    "focus" to R.string.mood_focus,
+    "morning" to R.string.mood_morning,
+    "driving" to R.string.mood_driving,
+    "late_night" to R.string.mood_late_night,
+    "workout" to R.string.mood_workout,
+)
+
+/**
+ * Builds the media browse tree shared by any surface that browses Aerial's content through a
+ * MediaLibraryService (Android Auto today, Google TV planned) — plain suspend functions, no
+ * session/callback types, so it's unit-testable the same way the rest of the data layer is.
+ *
+ * Tree shape: root -> Favorites | Moods | Recently Played, Moods -> one folder per curated mood.
+ * Search is a separate root capability, not a tab (see [search]).
+ */
+class MediaBrowseTree(
+    private val context: Context,
+    private val stationRepository: StationRepository,
+    private val registryRepository: RegistryRepository,
+) {
+    fun rootItem(): MediaItem = browsableFolder(MEDIA_BROWSE_ROOT_ID, context.getString(R.string.app_name))
+
+    fun rootChildren(): List<MediaItem> = listOf(
+        browsableFolder(FAVORITES_ID, context.getString(R.string.tab_favorites)),
+        browsableFolder(MOODS_ID, context.getString(R.string.car_moods)),
+        browsableFolder(RECENT_ID, context.getString(R.string.car_recently_played)),
+    )
+
+    /** Dispatches a parentId to the right children list, or null if it's not a known folder. */
+    suspend fun children(parentId: String): List<MediaItem>? = when {
+        parentId == MEDIA_BROWSE_ROOT_ID -> rootChildren()
+        parentId == FAVORITES_ID -> favoriteChildren()
+        parentId == MOODS_ID -> moodChildren()
+        parentId == RECENT_ID -> recentChildren()
+        parentId.startsWith(MOOD_ID_PREFIX) -> moodStationChildren(parentId.removePrefix(MOOD_ID_PREFIX))
+        else -> null
+    }
+
+    suspend fun favoriteChildren(): List<MediaItem> =
+        stationRepository.getAll().first().map { it.toPlayableMediaItem(context) }
+
+    fun moodChildren(): List<MediaItem> = MOOD_TITLES.map { (id, titleRes) ->
+        browsableFolder("$MOOD_ID_PREFIX$id", context.getString(titleRes))
+    }
+
+    suspend fun moodStationChildren(moodId: String): List<MediaItem> =
+        registryRepository.curatedMoodStations()[moodId]
+            ?.map { it.toPlayableMediaItem(context) }
+            ?: emptyList()
+
+    suspend fun recentChildren(): List<MediaItem> =
+        stationRepository.getAll().first()
+            .filter { it.lastPlayedAt > 0 }
+            .sortedByDescending { it.lastPlayedAt }
+            .take(RECENT_LIMIT)
+            .map { it.toPlayableMediaItem(context) }
+
+    /** Broad catalogue search (not just favorites) so voice search can find and play any station
+     * in the registry, matching what "Hey Google, play X on Aerial" needs. */
+    suspend fun search(query: String): List<MediaItem> =
+        registryRepository.search(query).map { it.toPlayableMediaItem(context) }
+
+    /**
+     * Resolves a bare mediaId — from a browse-item tap, voice search, or playback resumption —
+     * into a fully playable [MediaItem]. Used by `onGetItem` and `onSetMediaItems`: Android
+     * Auto's legacy MediaBrowserCompat bridge dispatches "play this" by mediaId string alone, not
+     * by replaying the exact MediaItem object the browse tree returned, so the session must be
+     * able to look any mediaId up again here.
+     */
+    suspend fun resolve(mediaId: String): MediaItem? {
+        if (mediaId.startsWith(REGISTRY_MEDIA_ID_PREFIX)) {
+            val registryId = mediaId.removePrefix(REGISTRY_MEDIA_ID_PREFIX).toLongOrNull() ?: return null
+            return registryRepository.getById(registryId)?.toPlayableMediaItem(context)
+        }
+        val id = mediaId.toLongOrNull() ?: return null
+        return stationRepository.getById(id)?.toPlayableMediaItem(context)
+    }
+
+    private fun browsableFolder(id: String, title: String): MediaItem {
+        val metadata = MediaMetadata.Builder()
+            .setTitle(title)
+            .setIsBrowsable(true)
+            .setIsPlayable(false)
+            .setMediaType(MediaMetadata.MEDIA_TYPE_FOLDER_RADIO_STATIONS)
+            .build()
+        return MediaItem.Builder()
+            .setMediaId(id)
+            .setMediaMetadata(metadata)
+            .build()
+    }
+}

--- a/app/src/main/java/com/shapeshed/aerial/data/PlayHistoryDao.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/PlayHistoryDao.kt
@@ -1,0 +1,19 @@
+package com.shapeshed.aerial.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PlayHistoryDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun recordPlay(entry: PlayHistoryEntry)
+
+    @Query("SELECT * FROM play_history ORDER BY playedAt DESC LIMIT :limit")
+    suspend fun recent(limit: Int): List<PlayHistoryEntry>
+
+    @Query("SELECT * FROM play_history ORDER BY playedAt DESC LIMIT :limit")
+    fun recentAsFlow(limit: Int): Flow<List<PlayHistoryEntry>>
+}

--- a/app/src/main/java/com/shapeshed/aerial/data/PlayHistoryEntry.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/PlayHistoryEntry.kt
@@ -1,0 +1,18 @@
+package com.shapeshed.aerial.data
+
+import androidx.room.Entity
+
+/**
+ * A station play, recorded regardless of favourite status — unlike [Station], where a row only
+ * exists once a station is favourited. Powers "Recently Played" (Android Auto today; any surface
+ * later) without duplicating station data: display info (name, logo, stream URL) is looked up
+ * from the registry by provider+providerId at render time, not stored here. Only resolves for
+ * registry-backed stations — locally-added custom stations have no provider identity and are
+ * tracked separately via [Station.lastPlayedAt].
+ */
+@Entity(tableName = "play_history", primaryKeys = ["provider", "providerId"])
+data class PlayHistoryEntry(
+    val provider: String,
+    val providerId: String,
+    val playedAt: Long,
+)

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryDao.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryDao.kt
@@ -30,6 +30,9 @@ abstract class RegistryDao {
     @Query("SELECT * FROM registry_stations WHERE providerId IN (:ids)")
     abstract suspend fun getByProviderIds(ids: List<String>): List<RegistryStation>
 
+    @Query("SELECT * FROM registry_stations WHERE provider = :provider AND providerId = :providerId LIMIT 1")
+    abstract suspend fun getByProviderId(provider: String, providerId: String): RegistryStation?
+
     @Query("SELECT * FROM registry_stations WHERE id = :id")
     abstract suspend fun getById(id: Long): RegistryStation?
 

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryDao.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryDao.kt
@@ -30,6 +30,9 @@ abstract class RegistryDao {
     @Query("SELECT * FROM registry_stations WHERE providerId IN (:ids)")
     abstract suspend fun getByProviderIds(ids: List<String>): List<RegistryStation>
 
+    @Query("SELECT * FROM registry_stations WHERE id = :id")
+    abstract suspend fun getById(id: Long): RegistryStation?
+
     @Query("SELECT * FROM registry_stations WHERE name IN (:names)")
     abstract suspend fun getByNames(names: List<String>): List<RegistryStation>
 

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
@@ -205,6 +205,8 @@ class RegistryRepository(private val dao: RegistryDao) {
 
     suspend fun randomByCategory(tag: String): RegistryStation? = dao.randomStationByTag(tag)
 
+    suspend fun getById(id: Long): RegistryStation? = dao.getById(id)
+
     suspend fun availableCountryCodes(): List<String> = dao.distinctCountryCodes()
 
     suspend fun availableTags(): List<String> {

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
@@ -207,6 +207,9 @@ class RegistryRepository(private val dao: RegistryDao) {
 
     suspend fun getById(id: Long): RegistryStation? = dao.getById(id)
 
+    suspend fun getByProviderId(provider: String, providerId: String): RegistryStation? =
+        dao.getByProviderId(provider, providerId)
+
     suspend fun availableCountryCodes(): List<String> = dao.distinctCountryCodes()
 
     suspend fun availableTags(): List<String> {

--- a/app/src/main/java/com/shapeshed/aerial/data/StationDatabase.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/StationDatabase.kt
@@ -8,12 +8,13 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
-    entities = [Station::class, StationFts::class],
-    version = 15,
+    entities = [Station::class, StationFts::class, PlayHistoryEntry::class],
+    version = 16,
     exportSchema = true,
 )
 abstract class StationDatabase : RoomDatabase() {
     abstract fun stationDao(): StationDao
+    abstract fun playHistoryDao(): PlayHistoryDao
 
     companion object {
         @Volatile private var instance: StationDatabase? = null
@@ -34,6 +35,7 @@ abstract class StationDatabase : RoomDatabase() {
                         MIGRATION_12_13,
                         MIGRATION_13_14,
                         MIGRATION_14_15,
+                        MIGRATION_15_16,
                     )
                     .fallbackToDestructiveMigration(dropAllTables = true)
                     .build()
@@ -182,6 +184,21 @@ abstract class StationDatabase : RoomDatabase() {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE `stations` ADD COLUMN `playCount` INTEGER NOT NULL DEFAULT 0")
                 db.execSQL("ALTER TABLE `stations` ADD COLUMN `lastPlayedAt` INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
+        private val MIGRATION_15_16 = object : Migration(15, 16) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `play_history` (
+                      `provider` TEXT NOT NULL,
+                      `providerId` TEXT NOT NULL,
+                      `playedAt` INTEGER NOT NULL,
+                      PRIMARY KEY(`provider`, `providerId`)
+                    )
+                    """.trimIndent(),
+                )
             }
         }
 

--- a/app/src/main/java/com/shapeshed/aerial/data/StationRepository.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/StationRepository.kt
@@ -2,7 +2,7 @@ package com.shapeshed.aerial.data
 
 import kotlinx.coroutines.flow.Flow
 
-class StationRepository(private val dao: StationDao) {
+class StationRepository(private val dao: StationDao, private val playHistoryDao: PlayHistoryDao) {
     fun getAll(): Flow<List<Station>> = dao.getAll()
     suspend fun getById(id: Long): Station? = dao.getById(id)
     suspend fun getByStreamUrl(streamUrl: String): Station? = dao.getByStreamUrl(streamUrl)
@@ -14,6 +14,10 @@ class StationRepository(private val dao: StationDao) {
     suspend fun update(station: Station) = dao.update(station)
     suspend fun delete(station: Station) = dao.delete(station)
     suspend fun recordPlay(id: Long, playedAt: Long) = dao.recordPlay(id, playedAt)
+
+    suspend fun recordHistoryPlay(entry: PlayHistoryEntry) = playHistoryDao.recordPlay(entry)
+    suspend fun recentlyPlayed(limit: Int): List<PlayHistoryEntry> = playHistoryDao.recent(limit)
+    fun recentlyPlayedAsFlow(limit: Int): Flow<List<PlayHistoryEntry>> = playHistoryDao.recentAsFlow(limit)
 
     suspend fun insertOrGetExisting(station: Station): Long {
         val existing = findExisting(station)

--- a/app/src/main/java/com/shapeshed/aerial/ui/LogoFiles.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/LogoFiles.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.net.Uri
+import com.shapeshed.aerial.ArtworkProvider
 import com.shapeshed.aerial.R
 import android.webkit.MimeTypeMap
 import androidx.core.graphics.createBitmap
@@ -12,6 +13,7 @@ import coil3.BitmapImage
 import coil3.DrawableImage
 import coil3.Image
 import coil3.ImageLoader
+import coil3.SingletonImageLoader
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.svg.SvgDecoder
@@ -19,6 +21,9 @@ import java.io.File
 import java.net.URL
 import java.util.Locale
 import java.util.UUID
+import kotlinx.coroutines.withTimeoutOrNull
+
+private const val ARTWORK_FETCH_TIMEOUT_MS = 3_000L
 
 suspend fun copyLogoFromUri(context: Context, uri: Uri, directory: File): File? {
     val contentResolver = context.contentResolver
@@ -71,6 +76,61 @@ suspend fun ensureMediaArtworkForLogo(context: Context, file: File): File {
         pngFile
     } catch (_: Exception) {
         file
+    }
+}
+
+/**
+ * Renders a remote logo Android Auto can't fetch or decode itself to a PNG cached on disk,
+ * keyed by URL, and returns a stable content:// URI served by
+ * [com.shapeshed.aerial.ArtworkProvider]. Returns null for logos Auto handles fine directly.
+ *
+ * Two classes need this proxying. SVGs: surfaces that render a MediaItem's artworkUri
+ * themselves — Auto's browse lists and mini player — can't decode SVG (only the actively
+ * playing session's artwork goes through the app's SVG-capable
+ * [com.shapeshed.aerial.CoilBitmapLoader]). Cleartext http URLs: Auto fetches artworkUri in
+ * its own process, which blocks cleartext, while this app permits it (see
+ * network_security_config.xml — many station streams and logos are http-only). Handing Auto a
+ * content URI keeps its normal decode-once-and-cache-by-URI behaviour, which embedded
+ * artworkData bytes would defeat (visible as icons flashing in on every list render).
+ */
+suspend fun cachedRemoteArtworkUri(context: Context, logoUrl: String): Uri? {
+    if (!logoUrl.startsWith("http")) return null
+    val isSvg = logoUrl.substringBefore('?').lowercase(Locale.US).endsWith(".svg")
+    val isCleartext = logoUrl.startsWith("http://")
+    if (!isSvg && !isCleartext) return null
+
+    val cacheDir = File(context.cacheDir, ArtworkProvider.ARTWORK_CACHE_DIR)
+    val pngFile = File(cacheDir, "${logoUrl.hashCode().toUInt()}.png")
+    if (pngFile.exists()) return ArtworkProvider.uriFor(context, pngFile.name)
+
+    return try {
+        val request = ImageRequest.Builder(context)
+            .data(logoUrl)
+            .size(512)
+            .build()
+        // The singleton loader (AerialApp) has both the SvgDecoder and the User-Agent-sending
+        // HTTP client some logo hosts require; the local svgLoader is file-only. The timeout
+        // bounds how long a browse list can stall on one slow host — on miss the icon just
+        // falls back until a later request re-tries.
+        val result = withTimeoutOrNull(ARTWORK_FETCH_TIMEOUT_MS) {
+            SingletonImageLoader.get(context).execute(request)
+        } as? SuccessResult ?: return null
+        val bitmap = result.image.toBitmap() ?: return null
+        cacheDir.mkdirs()
+        // Write-then-rename so a concurrent request (Android Auto prefetches folders in
+        // parallel) or a mid-write process kill can never expose a truncated PNG under the
+        // final name — exists() above only ever sees complete files.
+        val tmpFile = File(cacheDir, "${pngFile.name}.${UUID.randomUUID()}.tmp")
+        tmpFile.outputStream().use { output ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
+        }
+        if (!tmpFile.renameTo(pngFile)) {
+            tmpFile.delete()
+            if (!pngFile.exists()) return null
+        }
+        ArtworkProvider.uriFor(context, pngFile.name)
+    } catch (_: Exception) {
+        null
     }
 }
 

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -327,6 +327,7 @@ fun MainScreen(
     val allTags by viewModel.allTags.collectAsStateWithLifecycle()
     val featuredStations by viewModel.featuredStations.collectAsStateWithLifecycle()
     val forYouStations by viewModel.forYouStations.collectAsStateWithLifecycle()
+    val recentlyPlayedStations by viewModel.recentlyPlayedStations.collectAsStateWithLifecycle()
     val defaultStations by viewModel.defaultStations.collectAsStateWithLifecycle()
     val curatedMoodStations by viewModel.curatedMoodStations.collectAsStateWithLifecycle()
     val homeViewMode by viewModel.homeViewMode.collectAsStateWithLifecycle()
@@ -593,6 +594,7 @@ fun MainScreen(
                     HomeTabContent(
                         forYouStations = forYouStations.ifEmpty { featuredStations },
                         forYouCountry = countryName(forYouCountryCode, appLocale).takeIf { hasCountrySelection },
+                        recentlyPlayedStations = recentlyPlayedStations,
                         listState = homeListState,
                         bottomPadding = stationContentBottomPadding,
                         onMoodTap = { selectedMoodId = it.id },
@@ -1484,16 +1486,68 @@ private fun HomeTabContent(
     forYouStations: List<com.shapeshed.aerial.data.RegistryStation>,
     // Null when the selection isn't country-specific; the header drops the country.
     forYouCountry: String?,
+    recentlyPlayedStations: List<com.shapeshed.aerial.data.RegistryStation>,
     listState: LazyListState,
     bottomPadding: androidx.compose.ui.unit.Dp,
     onMoodTap: (CuratedMood) -> Unit,
     onFeaturedStationTap: (com.shapeshed.aerial.data.RegistryStation) -> Unit,
     onForYouViewAll: () -> Unit,
 ) {
+    // On launch the splash screen holds until the Recently Played row is resolved (see
+    // MainViewModel.isInitialized), so scroll restoration composes against the full list. The
+    // one remaining shift is the section's very first appearance mid-session (first play ever
+    // recorded): keyed items keep the viewport anchored, hiding the new section above it, so
+    // snap to the top when it appears — but only if the user is in the top header region and
+    // not mid-scroll.
+    val hasRecentlyPlayed = recentlyPlayedStations.isNotEmpty()
+    var hadRecentlyPlayed by rememberSaveable { mutableStateOf(hasRecentlyPlayed) }
+    LaunchedEffect(hasRecentlyPlayed) {
+        if (hasRecentlyPlayed && !hadRecentlyPlayed &&
+            !listState.isScrollInProgress && listState.firstVisibleItemIndex <= 2
+        ) {
+            listState.scrollToItem(0)
+        }
+        hadRecentlyPlayed = hasRecentlyPlayed
+    }
     LazyColumn(
         state = listState,
         contentPadding = PaddingValues(bottom = bottomPadding + 16.dp),
     ) {
+        if (recentlyPlayedStations.isNotEmpty()) {
+            item("recently-played-header") {
+                Text(
+                    text = stringResource(R.string.recently_played),
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 20.dp, bottom = 12.dp),
+                )
+            }
+            item("recently-played-row") {
+                val rowState = rememberLazyListState()
+                // Keyed items keep the viewport anchored when a just-played station is inserted
+                // at (or moved to) the front, leaving it hidden off-screen left — snap back to
+                // the start so the newest play is always visible.
+                val frontKey = recentlyPlayedStations.firstOrNull()?.let { "${it.provider}-${it.providerId}" }
+                LaunchedEffect(frontKey) { rowState.scrollToItem(0) }
+                LazyRow(
+                    state = rowState,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    contentPadding = PaddingValues(horizontal = 16.dp),
+                ) {
+                    items(
+                        items = recentlyPlayedStations,
+                        key = { "recent-${it.provider}-${it.providerId}" },
+                        contentType = { "for-you-station" },
+                    ) { station ->
+                        ForYouStationCard(
+                            station = station,
+                            onClick = { onFeaturedStationTap(station) },
+                        )
+                    }
+                }
+            }
+        }
+
         if (forYouStations.isNotEmpty()) {
             item("for-you-header") {
                 Row(

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -614,6 +614,56 @@ class MainViewModel(
     }
 
     private val playerListener = object : Player.Listener {
+        // Playback can start or change from outside this ViewModel — Android Auto, voice
+        // search, a queue skip — so the phone's current-station state must follow the
+        // session's media item, not just this ViewModel's own play() calls. When play() did
+        // initiate the change the state already matches and the guards below make this a
+        // no-op.
+        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+            val item = mediaItem ?: return
+            val extras = item.mediaMetadata.extras
+            val streamUrl = extras?.getString("streamUrl").orEmpty()
+            val provider = extras?.getString("provider").orEmpty()
+            val providerId = extras?.getString("providerId").orEmpty()
+            // Resolve to a saved row the same way PlayerService.stationForMediaItem does:
+            // numeric mediaId first, then provider identity, then stream URL.
+            val saved = item.mediaId.toLongOrNull()
+                ?.let { id -> _allStations.value.firstOrNull { it.id == id } }
+                ?: _allStations.value.firstOrNull {
+                    provider.isNotBlank() && providerId.isNotBlank() &&
+                        it.provider == provider && it.providerId == providerId
+                }
+                ?: _allStations.value.firstOrNull { streamUrl.isNotBlank() && it.streamUrl == streamUrl }
+            val current = currentStation.value
+            when {
+                saved != null -> {
+                    if (current?.id == saved.id) return
+                    _ephemeralStation.value = null
+                    _currentStationId.value = saved.id
+                }
+                streamUrl.isNotBlank() -> {
+                    if (current?.id == 0L && current.streamUrl == streamUrl) return
+                    _currentStationId.value = null
+                    _ephemeralStation.value = Station(
+                        name = item.mediaMetadata.title?.toString().orEmpty(),
+                        streamUrl = streamUrl,
+                        logoPath = extras?.getString("logoPath").orEmpty(),
+                        provider = provider,
+                        providerId = providerId,
+                    )
+                }
+                else -> return
+            }
+            // Per-track state belongs to the previous station; onMediaMetadataChanged
+            // repopulates it for the new one.
+            _currentTrackTitle.value = null
+            _currentTrackArtist.value = null
+            _currentTrackArtworkUrl.value = null
+            _currentTrackArtworkData.value = null
+            _currentBitrateKbps.value = null
+            _playbackError.value = null
+        }
+
         override fun onIsPlayingChanged(isPlaying: Boolean) {
             _isPlaying.value = isPlaying
             if (!suppressLastPlayedPersist) {

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -3,7 +3,6 @@ package com.shapeshed.aerial.ui
 import android.app.Application
 import android.content.ComponentName
 import android.content.Context
-import androidx.core.net.toUri
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
@@ -49,7 +48,8 @@ import com.shapeshed.aerial.data.SleepTimerState
 import com.shapeshed.aerial.data.SleepTimerStore
 import com.shapeshed.aerial.data.Station
 import com.shapeshed.aerial.data.StationRepository
-import com.shapeshed.aerial.data.bauerStreamUrl
+import com.shapeshed.aerial.toEphemeralStation
+import com.shapeshed.aerial.toPlayableMediaItem
 import java.io.File
 import java.net.HttpURLConnection
 import java.net.URL
@@ -197,8 +197,6 @@ class MainViewModel(
             )
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
-
-    private val appIconArtwork: ByteArray? by lazy { appIconBitmap(getApplication()) }
 
     private val _currentStationId = MutableStateFlow<Long?>(null)
     private val _ephemeralStation = MutableStateFlow<Station?>(null)
@@ -438,18 +436,7 @@ class MainViewModel(
     }
 
     fun playFromRegistry(registryStation: RegistryStation) {
-        val station = Station(
-            name = registryStation.name,
-            streamUrl = registryStation.streamUrl,
-            logoPath = registryStation.logoUrl,
-            provider = registryStation.provider,
-            providerId = registryStation.providerId,
-            tags = registryStation.tags,
-            description = registryStation.description,
-            country = registryStation.country,
-            countryCode = registryStation.countryCode,
-        )
-        play(station)
+        play(registryStation.toEphemeralStation())
     }
 
     fun addFromRegistry(registryStation: RegistryStation) {
@@ -684,11 +671,7 @@ class MainViewModel(
         _currentBitrateKbps.value = null
         _playbackError.value = null
         persistLastPlayedStation(station)
-        val mediaItem = MediaItem.Builder()
-            .setMediaId(station.id.toString())
-            .setUri(bauerStreamUrl(station))
-            .setMediaMetadata(stationMediaMetadata(station))
-            .build()
+        val mediaItem = station.toPlayableMediaItem(getApplication())
         controller?.apply {
             setMediaItem(mediaItem)
             prepare()
@@ -847,48 +830,13 @@ class MainViewModel(
     }
 
     private fun loadStationPaused(station: Station) {
-        val mediaItem = MediaItem.Builder()
-            .setMediaId(station.id.toString())
-            .setUri(bauerStreamUrl(station))
-            .setMediaMetadata(stationMediaMetadata(station))
-            .build()
+        val mediaItem = station.toPlayableMediaItem(getApplication())
 
         controller?.apply {
             setMediaItem(mediaItem)
             prepare()
             pause()
         }
-    }
-
-    private fun stationMediaMetadata(station: Station): MediaMetadata {
-        val artworkUri = station.logoPath
-            .takeIf { it.startsWith("http") }
-            ?.toUri()
-        val localArtworkData = station.logoPath
-            .takeIf { it.isNotEmpty() && !it.startsWith("http") }
-            ?.let { compressedLogoData(File(it)) }
-
-        return MediaMetadata.Builder().apply {
-            when {
-                localArtworkData != null -> setArtworkData(
-                    localArtworkData,
-                    MediaMetadata.PICTURE_TYPE_FRONT_COVER,
-                )
-                artworkUri != null -> setArtworkUri(artworkUri)
-                else -> appIconArtwork?.let {
-                    setArtworkData(it, MediaMetadata.PICTURE_TYPE_FRONT_COVER)
-                }
-            }
-        }
-            .setTitle(station.name)
-            .setArtist(liveRadio())
-            .setSubtitle(liveRadio())
-            .setExtras(Bundle().apply {
-                putString("provider", station.provider)
-                putString("providerId", station.providerId)
-                putString("streamUrl", station.streamUrl)
-            })
-            .build()
     }
 }
 

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -84,6 +84,7 @@ enum class FavoritesSort {
     MOST_PLAYED,
 }
 private const val MAX_RECENT_SEARCHES = 5
+private const val RECENTLY_PLAYED_LIMIT = 10
 
 private data class LastPlayedStationSnapshot(
     val station: Station,
@@ -128,9 +129,31 @@ class MainViewModel(
     private val _curatedMoodStations = MutableStateFlow<Map<String, List<RegistryStation>>>(emptyMap())
     val curatedMoodStations: StateFlow<Map<String, List<RegistryStation>>> = _curatedMoodStations.asStateFlow()
 
+    // Recently played stations for the home screen, same source as Android Auto's Recently
+    // Played folder: the play_history table resolved against the registry (entries whose
+    // station is no longer in the registry are skipped). Room re-emits on every recorded
+    // play, so the row reorders live. The first resolution gates isInitialized (and so the
+    // splash screen) below: the home list's scroll position is restored against the first
+    // composition, so this section must already be present in it rather than streaming in
+    // afterwards and shifting the restored position.
+    private val _recentlyPlayedStations = MutableStateFlow<List<RegistryStation>>(emptyList())
+    val recentlyPlayedStations: StateFlow<List<RegistryStation>> = _recentlyPlayedStations.asStateFlow()
+    private val recentlyPlayedFirstLoad = CompletableDeferred<Unit>()
+
     init {
         viewModelScope.launch {
+            repository.recentlyPlayedAsFlow(RECENTLY_PLAYED_LIMIT)
+                .map { entries ->
+                    entries.mapNotNull { registryRepository.getByProviderId(it.provider, it.providerId) }
+                }
+                .collect {
+                    _recentlyPlayedStations.value = it
+                    recentlyPlayedFirstLoad.complete(Unit)
+                }
+        }
+        viewModelScope.launch {
             repository.getAll().first()
+            recentlyPlayedFirstLoad.await()
             _isInitialized.value = true
         }
         viewModelScope.launch {
@@ -660,9 +683,6 @@ class MainViewModel(
         } else {
             _ephemeralStation.value = null
             _currentStationId.value = station.id
-            viewModelScope.launch {
-                repository.recordPlay(station.id, System.currentTimeMillis())
-            }
         }
         _currentTrackTitle.value = null
         _currentTrackArtist.value = null

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -112,5 +112,5 @@
     <string name="no_favorites">Noch keine Favoriten</string>
     <string name="no_favorites_desc">Füge Sender hinzu, die du liebst, um sie hier leicht wiederzufinden</string>
     <string name="car_moods">Stimmungen</string>
-    <string name="car_recently_played">Zuletzt gespielt</string>
+    <string name="recently_played">Zuletzt gespielt</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -111,4 +111,6 @@
     <string name="favorites_grid_columns_desc">Spalten in der Kartenansicht</string>
     <string name="no_favorites">Noch keine Favoriten</string>
     <string name="no_favorites_desc">Füge Sender hinzu, die du liebst, um sie hier leicht wiederzufinden</string>
+    <string name="car_moods">Stimmungen</string>
+    <string name="car_recently_played">Zuletzt gespielt</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -111,4 +111,6 @@
     <string name="favorites_grid_columns_desc">Columnas en la vista de tarjetas</string>
     <string name="no_favorites">Aún no tienes favoritos</string>
     <string name="no_favorites_desc">Añade las emisoras que te gustan para encontrarlas fácilmente aquí</string>
+    <string name="car_moods">Estados de ánimo</string>
+    <string name="car_recently_played">Reproducidos recientemente</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -112,5 +112,5 @@
     <string name="no_favorites">Aún no tienes favoritos</string>
     <string name="no_favorites_desc">Añade las emisoras que te gustan para encontrarlas fácilmente aquí</string>
     <string name="car_moods">Estados de ánimo</string>
-    <string name="car_recently_played">Reproducidos recientemente</string>
+    <string name="recently_played">Reproducidos recientemente</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -111,4 +111,6 @@
     <string name="favorites_grid_columns_desc">Colonnes dans la vue en cartes</string>
     <string name="no_favorites">Aucun favori pour l\'instant</string>
     <string name="no_favorites_desc">Ajoutez vos stations préférées pour les retrouver facilement ici</string>
+    <string name="car_moods">Humeurs</string>
+    <string name="car_recently_played">Écouté récemment</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -112,5 +112,5 @@
     <string name="no_favorites">Aucun favori pour l\'instant</string>
     <string name="no_favorites_desc">Ajoutez vos stations préférées pour les retrouver facilement ici</string>
     <string name="car_moods">Humeurs</string>
-    <string name="car_recently_played">Écouté récemment</string>
+    <string name="recently_played">Écouté récemment</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -112,5 +112,5 @@
     <string name="no_favorites">Nessun preferito</string>
     <string name="no_favorites_desc">Aggiungi le stazioni che ami per ritrovarle facilmente qui</string>
     <string name="car_moods">Umori</string>
-    <string name="car_recently_played">Ascoltati di recente</string>
+    <string name="recently_played">Ascoltati di recente</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -111,4 +111,6 @@
     <string name="favorites_grid_columns_desc">Colonne nella vista a schede</string>
     <string name="no_favorites">Nessun preferito</string>
     <string name="no_favorites_desc">Aggiungi le stazioni che ami per ritrovarle facilmente qui</string>
+    <string name="car_moods">Umori</string>
+    <string name="car_recently_played">Ascoltati di recente</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -111,4 +111,6 @@
     <string name="favorites_grid_columns_desc">カード表示の列数</string>
     <string name="no_favorites">お気に入りはまだありません</string>
     <string name="no_favorites_desc">お気に入りの放送局を追加すると、ここからすぐに見つけられます</string>
+    <string name="car_moods">気分</string>
+    <string name="car_recently_played">最近再生</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -112,5 +112,5 @@
     <string name="no_favorites">お気に入りはまだありません</string>
     <string name="no_favorites_desc">お気に入りの放送局を追加すると、ここからすぐに見つけられます</string>
     <string name="car_moods">気分</string>
-    <string name="car_recently_played">最近再生</string>
+    <string name="recently_played">最近再生</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -112,5 +112,5 @@
     <string name="no_favorites">즐겨찾기가 없습니다</string>
     <string name="no_favorites_desc">좋아하는 방송국을 추가하면 여기서 쉽게 찾을 수 있어요</string>
     <string name="car_moods">기분</string>
-    <string name="car_recently_played">최근 재생</string>
+    <string name="recently_played">최근 재생</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -111,4 +111,6 @@
     <string name="favorites_grid_columns_desc">카드 보기의 열 수</string>
     <string name="no_favorites">즐겨찾기가 없습니다</string>
     <string name="no_favorites_desc">좋아하는 방송국을 추가하면 여기서 쉽게 찾을 수 있어요</string>
+    <string name="car_moods">기분</string>
+    <string name="car_recently_played">최근 재생</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -112,5 +112,5 @@
     <string name="no_favorites">Nog geen favorieten</string>
     <string name="no_favorites_desc">Voeg zenders toe die je leuk vindt om ze hier snel terug te vinden</string>
     <string name="car_moods">Stemmingen</string>
-    <string name="car_recently_played">Laatst afgespeeld</string>
+    <string name="recently_played">Laatst afgespeeld</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -111,4 +111,6 @@
     <string name="favorites_grid_columns_desc">Kolommen in de kaartweergave</string>
     <string name="no_favorites">Nog geen favorieten</string>
     <string name="no_favorites_desc">Voeg zenders toe die je leuk vindt om ze hier snel terug te vinden</string>
+    <string name="car_moods">Stemmingen</string>
+    <string name="car_recently_played">Laatst afgespeeld</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -113,5 +113,5 @@
     <string name="no_favorites">Ainda sem favoritos</string>
     <string name="no_favorites_desc">Adicione as estações que você gosta para encontrá-las facilmente aqui</string>
     <string name="car_moods">Humores</string>
-    <string name="car_recently_played">Reproduzidos recentemente</string>
+    <string name="recently_played">Reproduzidos recentemente</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -112,4 +112,6 @@
     <string name="favorites_grid_columns_desc">Colunas na visualização de cartões</string>
     <string name="no_favorites">Ainda sem favoritos</string>
     <string name="no_favorites_desc">Adicione as estações que você gosta para encontrá-las facilmente aqui</string>
+    <string name="car_moods">Humores</string>
+    <string name="car_recently_played">Reproduzidos recentemente</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -112,5 +112,5 @@
     <string name="no_favorites">暂无收藏</string>
     <string name="no_favorites_desc">添加喜欢的电台，方便在此快速找到</string>
     <string name="car_moods">心情</string>
-    <string name="car_recently_played">最近播放</string>
+    <string name="recently_played">最近播放</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -111,4 +111,6 @@
     <string name="favorites_grid_columns_desc">卡片视图的列数</string>
     <string name="no_favorites">暂无收藏</string>
     <string name="no_favorites_desc">添加喜欢的电台，方便在此快速找到</string>
+    <string name="car_moods">心情</string>
+    <string name="car_recently_played">最近播放</string>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,4 +2,7 @@
 <resources>
     <color name="ic_launcher_background">#FFFFFFFF</color>
     <color name="splash_background">#FFFFFFFF</color>
+    <!-- Fixed brand teal for surfaces that don't participate in Material You dynamic color
+         (Android Auto, Google TV) — matches ui/theme/Color.kt's primaryDark. -->
+    <color name="car_accent">#FF82D3E0</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,4 +113,7 @@
     <string name="favorites_grid_columns_desc">Columns shown in the cards view</string>
     <string name="no_favorites">No favourites yet</string>
     <string name="no_favorites_desc">Add stations you love to easily find them here</string>
+    <!-- Media browse tree (Android Auto, Google TV) -->
+    <string name="car_moods">Moods</string>
+    <string name="car_recently_played">Recently Played</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,5 +115,5 @@
     <string name="no_favorites_desc">Add stations you love to easily find them here</string>
     <!-- Media browse tree (Android Auto, Google TV) -->
     <string name="car_moods">Moods</string>
-    <string name="car_recently_played">Recently Played</string>
+    <string name="recently_played">Recently Played</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -11,4 +11,11 @@
         <item name="windowSplashScreenIconBackgroundColor">@color/splash_background</item>
         <item name="postSplashScreenTheme">@style/Theme.Aerial</item>
     </style>
+
+    <!-- Referenced only by the com.google.android.gms.car.application.theme meta-data in the
+         manifest, for Android Auto's accent color — the app's phone theme is otherwise untouched
+         since normal UI theming goes through Compose's MaterialTheme, not this XML theme. -->
+    <style name="Theme.Aerial.Car" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="colorAccent">@color/car_accent</item>
+    </style>
 </resources>

--- a/app/src/main/res/xml/automotive_app_desc.xml
+++ b/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<automotiveApp>
+    <uses name="media"/>
+</automotiveApp>

--- a/app/src/test/java/com/shapeshed/aerial/data/MediaBrowseTreeTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/data/MediaBrowseTreeTest.kt
@@ -1,0 +1,237 @@
+package com.shapeshed.aerial.data
+
+import android.content.Context
+import com.shapeshed.aerial.R
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class MediaBrowseTreeTest {
+
+    @Test
+    fun rootChildrenAreFavoritesMoodsAndRecentFolders() {
+        val tree = tree()
+
+        val root = tree.rootChildren()
+
+        assertEquals(
+            listOf("favorites", "moods", "recent"),
+            root.map { it.mediaId },
+        )
+        root.forEach {
+            assertTrue(it.mediaMetadata.isBrowsable == true)
+            assertTrue(it.mediaMetadata.isPlayable == false)
+        }
+    }
+
+    @Test
+    fun moodChildrenAreTheSixCuratedMoodFolders() {
+        val tree = tree()
+
+        val moods = tree.moodChildren()
+
+        assertEquals(
+            listOf("mood:relax", "mood:focus", "mood:morning", "mood:driving", "mood:late_night", "mood:workout"),
+            moods.map { it.mediaId },
+        )
+        moods.forEach { assertTrue(it.mediaMetadata.isBrowsable == true) }
+    }
+
+    @Test
+    fun favoriteChildrenMapsSavedStationsToPlayableItems() = runBlocking {
+        val stationDao = FakeStationDao(station(id = 5L, name = "Kool FM"))
+        val tree = tree(stationRepository = StationRepository(stationDao))
+
+        val children = tree.favoriteChildren()
+
+        assertEquals(listOf("5"), children.map { it.mediaId })
+        assertEquals("Kool FM", children.single().mediaMetadata.title.toString())
+        assertTrue(children.single().mediaMetadata.isPlayable == true)
+    }
+
+    @Test
+    fun recentChildrenExcludesNeverPlayedAndOrdersByMostRecent() = runBlocking {
+        val stationDao = FakeStationDao(
+            station(id = 1L, name = "Never played", lastPlayedAt = 0L),
+            station(id = 2L, name = "Played earlier", lastPlayedAt = 1_000L),
+            station(id = 3L, name = "Played most recently", lastPlayedAt = 2_000L),
+        )
+        val tree = tree(stationRepository = StationRepository(stationDao))
+
+        val children = tree.recentChildren()
+
+        assertEquals(listOf("3", "2"), children.map { it.mediaId })
+    }
+
+    @Test
+    fun moodStationChildrenResolvesCuratedRegistryStations() = runBlocking {
+        val registryDao = FakeRegistryDao(
+            registryStation(
+                id = 101L,
+                name = "Café del Mar",
+                provider = "radio-browser",
+                providerId = "3fd18c3f-8157-11e9-aa30-52543be04c81",
+            ),
+        )
+        val tree = tree(registryRepository = RegistryRepository(registryDao))
+
+        val children = tree.moodStationChildren("relax")
+
+        val cafeDelMar = children.firstOrNull { it.mediaId == "reg:101" }
+        assertNotNull(cafeDelMar)
+        assertEquals("Café del Mar", cafeDelMar!!.mediaMetadata.title.toString())
+    }
+
+    @Test
+    fun searchDelegatesToRegistryCatalogueSearch() = runBlocking {
+        val registryDao = FakeRegistryDao(
+            registryStation(id = 42L, name = "Dogglounge", searchText = "dogglounge house"),
+        )
+        val tree = tree(registryRepository = RegistryRepository(registryDao))
+
+        val results = tree.search("dogglounge")
+
+        assertEquals(listOf("reg:42"), results.map { it.mediaId })
+    }
+
+    @Test
+    fun resolveLooksUpLocalStationById() = runBlocking {
+        val stationDao = FakeStationDao(station(id = 9L, name = "Rinse FM"))
+        val tree = tree(stationRepository = StationRepository(stationDao))
+
+        val resolved = tree.resolve("9")
+
+        assertEquals("9", resolved?.mediaId)
+        assertEquals("Rinse FM", resolved?.mediaMetadata?.title.toString())
+    }
+
+    @Test
+    fun resolveLooksUpRegistryStationByPrefixedId() = runBlocking {
+        val registryDao = FakeRegistryDao(registryStation(id = 55L, name = "NTS Radio"))
+        val tree = tree(registryRepository = RegistryRepository(registryDao))
+
+        val resolved = tree.resolve("reg:55")
+
+        assertEquals("reg:55", resolved?.mediaId)
+        assertEquals("NTS Radio", resolved?.mediaMetadata?.title.toString())
+    }
+
+    @Test
+    fun resolveReturnsNullForUnknownId() = runBlocking {
+        val tree = tree()
+
+        assertNull(tree.resolve("404"))
+        assertNull(tree.resolve("reg:404"))
+        assertNull(tree.resolve("not-a-number"))
+    }
+
+    @Test
+    fun childrenDispatchesToTheRightFolderAndIsNullForUnknownIds() = runBlocking {
+        val tree = tree()
+
+        assertEquals(tree.rootChildren().map { it.mediaId }, tree.children(MEDIA_BROWSE_ROOT_ID)?.map { it.mediaId })
+        assertEquals(tree.moodChildren().map { it.mediaId }, tree.children("moods")?.map { it.mediaId })
+        assertNotNull(tree.children("favorites"))
+        assertNotNull(tree.children("recent"))
+        assertNotNull(tree.children("mood:relax"))
+        assertNull(tree.children("unknown"))
+    }
+
+    private fun tree(
+        stationRepository: StationRepository = StationRepository(FakeStationDao()),
+        registryRepository: RegistryRepository = RegistryRepository(FakeRegistryDao()),
+    ): MediaBrowseTree = MediaBrowseTree(fakeContext(), stationRepository, registryRepository)
+
+    private fun fakeContext(): Context {
+        val context = mock<Context>()
+        // Folder titles and the "Live Radio" fallback text come from string resources; station
+        // names in tests below come straight from station data, not from these ids, so a stable
+        // placeholder per resource id is enough to verify the right resource was requested.
+        whenever(context.getString(any())).thenAnswer { invocation -> "string-${invocation.arguments[0]}" }
+        return context
+    }
+
+    private fun station(
+        id: Long = 0,
+        name: String = "Mango",
+        streamUrl: String = "https://stream.example.com/mango",
+        lastPlayedAt: Long = 0,
+    ) = Station(id = id, name = name, streamUrl = streamUrl, lastPlayedAt = lastPlayedAt)
+
+    private fun registryStation(
+        id: Long = 0,
+        name: String = "Mango",
+        streamUrl: String = "https://stream.example.com/mango",
+        provider: String = "",
+        providerId: String = "",
+        searchText: String = name.lowercase(),
+    ) = RegistryStation(
+        id = id,
+        name = name,
+        streamUrl = streamUrl,
+        provider = provider,
+        providerId = providerId,
+        searchText = searchText,
+    )
+
+    private class FakeStationDao(vararg initialStations: Station) : StationDao {
+        val stations = initialStations.toMutableList()
+
+        override fun getAll(): Flow<List<Station>> = flowOf(stations)
+        override suspend fun getById(id: Long): Station? = stations.firstOrNull { it.id == id }
+        override suspend fun getByStreamUrl(streamUrl: String): Station? =
+            stations.firstOrNull { it.streamUrl == streamUrl }
+        override suspend fun getByProviderId(provider: String, providerId: String): Station? =
+            stations.firstOrNull { it.provider == provider && it.providerId == providerId }
+        override suspend fun searchStationFts(match: String): List<Station> = emptyList()
+        override suspend fun updateStreamUrlByProviderId(provider: String, providerId: String, streamUrl: String) {}
+        override suspend fun recordPlay(id: Long, playedAt: Long) {}
+        override suspend fun insert(station: Station): Long = 0
+        override suspend fun update(station: Station) {}
+        override suspend fun delete(station: Station) {}
+    }
+
+    private class FakeRegistryDao(vararg initialStations: RegistryStation) : RegistryDao() {
+        val stations = initialStations.toMutableList()
+
+        override suspend fun searchFts(match: String): List<RegistryStation> {
+            val terms = match.split(" ").map { it.removeSuffix("*").lowercase() }
+            return stations
+                .filter { station ->
+                    val text = "${station.searchText} ${station.description} ${station.country}".lowercase()
+                    terms.all { text.contains(it) }
+                }
+                .sortedBy { it.name.lowercase() }
+        }
+
+        override fun countAsFlow(): Flow<Int> = flowOf(stations.size)
+        override suspend fun count(): Int = stations.size
+        override suspend fun randomStationByTag(tag: String): RegistryStation? =
+            stations.firstOrNull { it.tags.contains(tag, ignoreCase = true) }
+        override suspend fun randomByCountryWithLogo(countryCode: String, limit: Int): List<RegistryStation> =
+            stations.filter { it.countryCode.equals(countryCode, ignoreCase = true) && it.logoUrl.isNotEmpty() }
+                .take(limit)
+        override suspend fun getByProviderIds(ids: List<String>): List<RegistryStation> =
+            stations.filter { it.providerId in ids }
+        override suspend fun getById(id: Long): RegistryStation? = stations.firstOrNull { it.id == id }
+        override suspend fun getByNames(names: List<String>): List<RegistryStation> =
+            stations.filter { it.name in names }
+        override suspend fun distinctCountryCodes(): List<String> =
+            stations.map { it.countryCode }.filter { it.isNotEmpty() }.distinct().sorted()
+        override suspend fun tagRows(): List<String> = stations.map { it.tags }.filter { it.isNotEmpty() }
+        override suspend fun filterByCountryCodes(countryCodes: List<String>): List<RegistryStation> =
+            stations.filter { it.countryCode.lowercase() in countryCodes }.sortedBy { it.name }
+        override suspend fun byTagLike(tag: String): List<RegistryStation> =
+            stations.filter { it.tags.contains(tag, ignoreCase = true) }
+        override suspend fun all(): List<RegistryStation> = stations.sortedBy { it.name }
+        override suspend fun browse(limit: Int): List<RegistryStation> = stations.sortedBy { it.name }.take(limit)
+    }
+}

--- a/app/src/test/java/com/shapeshed/aerial/data/MediaBrowseTreeTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/data/MediaBrowseTreeTest.kt
@@ -48,7 +48,7 @@ class MediaBrowseTreeTest {
     @Test
     fun favoriteChildrenMapsSavedStationsToPlayableItems() = runBlocking {
         val stationDao = FakeStationDao(station(id = 5L, name = "Kool FM"))
-        val tree = tree(stationRepository = StationRepository(stationDao))
+        val tree = tree(stationRepository = StationRepository(stationDao, FakePlayHistoryDao()))
 
         val children = tree.favoriteChildren()
 
@@ -58,17 +58,35 @@ class MediaBrowseTreeTest {
     }
 
     @Test
-    fun recentChildrenExcludesNeverPlayedAndOrdersByMostRecent() = runBlocking {
-        val stationDao = FakeStationDao(
-            station(id = 1L, name = "Never played", lastPlayedAt = 0L),
-            station(id = 2L, name = "Played earlier", lastPlayedAt = 1_000L),
-            station(id = 3L, name = "Played most recently", lastPlayedAt = 2_000L),
+    fun recentChildrenOrdersByMostRecentPlayRegardlessOfFavoriteStatus() = runBlocking {
+        val playHistoryDao = FakePlayHistoryDao(
+            PlayHistoryEntry(provider = "radio-browser", providerId = "earlier", playedAt = 1_000L),
+            PlayHistoryEntry(provider = "radio-browser", providerId = "recent", playedAt = 2_000L),
         )
-        val tree = tree(stationRepository = StationRepository(stationDao))
+        val registryDao = FakeRegistryDao(
+            registryStation(id = 1L, name = "Played earlier", provider = "radio-browser", providerId = "earlier"),
+            registryStation(id = 2L, name = "Played most recently", provider = "radio-browser", providerId = "recent"),
+        )
+        val tree = tree(
+            stationRepository = StationRepository(FakeStationDao(), playHistoryDao),
+            registryRepository = RegistryRepository(registryDao),
+        )
 
         val children = tree.recentChildren()
 
-        assertEquals(listOf("3", "2"), children.map { it.mediaId })
+        assertEquals(listOf("reg:2", "reg:1"), children.map { it.mediaId })
+    }
+
+    @Test
+    fun recentChildrenSkipsEntriesNoLongerInTheRegistry() = runBlocking {
+        val playHistoryDao = FakePlayHistoryDao(
+            PlayHistoryEntry(provider = "radio-browser", providerId = "vanished", playedAt = 1_000L),
+        )
+        val tree = tree(stationRepository = StationRepository(FakeStationDao(), playHistoryDao))
+
+        val children = tree.recentChildren()
+
+        assertEquals(emptyList<String>(), children.map { it.mediaId })
     }
 
     @Test
@@ -105,7 +123,7 @@ class MediaBrowseTreeTest {
     @Test
     fun resolveLooksUpLocalStationById() = runBlocking {
         val stationDao = FakeStationDao(station(id = 9L, name = "Rinse FM"))
-        val tree = tree(stationRepository = StationRepository(stationDao))
+        val tree = tree(stationRepository = StationRepository(stationDao, FakePlayHistoryDao()))
 
         val resolved = tree.resolve("9")
 
@@ -146,7 +164,7 @@ class MediaBrowseTreeTest {
     }
 
     private fun tree(
-        stationRepository: StationRepository = StationRepository(FakeStationDao()),
+        stationRepository: StationRepository = StationRepository(FakeStationDao(), FakePlayHistoryDao()),
         registryRepository: RegistryRepository = RegistryRepository(FakeRegistryDao()),
     ): MediaBrowseTree = MediaBrowseTree(fakeContext(), stationRepository, registryRepository)
 
@@ -221,6 +239,8 @@ class MediaBrowseTreeTest {
                 .take(limit)
         override suspend fun getByProviderIds(ids: List<String>): List<RegistryStation> =
             stations.filter { it.providerId in ids }
+        override suspend fun getByProviderId(provider: String, providerId: String): RegistryStation? =
+            stations.firstOrNull { it.provider == provider && it.providerId == providerId }
         override suspend fun getById(id: Long): RegistryStation? = stations.firstOrNull { it.id == id }
         override suspend fun getByNames(names: List<String>): List<RegistryStation> =
             stations.filter { it.name in names }
@@ -233,5 +253,20 @@ class MediaBrowseTreeTest {
             stations.filter { it.tags.contains(tag, ignoreCase = true) }
         override suspend fun all(): List<RegistryStation> = stations.sortedBy { it.name }
         override suspend fun browse(limit: Int): List<RegistryStation> = stations.sortedBy { it.name }.take(limit)
+    }
+
+    private class FakePlayHistoryDao(vararg initialEntries: PlayHistoryEntry) : PlayHistoryDao {
+        val entries = initialEntries.toMutableList()
+
+        override suspend fun recordPlay(entry: PlayHistoryEntry) {
+            entries.removeAll { it.provider == entry.provider && it.providerId == entry.providerId }
+            entries += entry
+        }
+
+        override suspend fun recent(limit: Int): List<PlayHistoryEntry> =
+            entries.sortedByDescending { it.playedAt }.take(limit)
+
+        override fun recentAsFlow(limit: Int): Flow<List<PlayHistoryEntry>> =
+            flowOf(entries.sortedByDescending { it.playedAt }.take(limit))
     }
 }

--- a/app/src/test/java/com/shapeshed/aerial/data/StationRepositoryTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/data/StationRepositoryTest.kt
@@ -11,7 +11,7 @@ class StationRepositoryTest {
     @Test
     fun insertOrGetExistingInsertsNewStation() = runBlocking {
         val dao = FakeStationDao()
-        val repository = StationRepository(dao)
+        val repository = StationRepository(dao, FakePlayHistoryDao())
 
         val id = repository.insertOrGetExisting(station())
 
@@ -24,7 +24,7 @@ class StationRepositoryTest {
     fun insertOrGetExistingReturnsExistingStreamUrlStation() = runBlocking {
         val existing = station(id = 7L, logoPath = "/logos/existing.png")
         val dao = FakeStationDao(existing)
-        val repository = StationRepository(dao)
+        val repository = StationRepository(dao, FakePlayHistoryDao())
 
         val id = repository.insertOrGetExisting(
             station(
@@ -42,7 +42,7 @@ class StationRepositoryTest {
     fun insertOrGetExistingMatchesByStreamUrl() = runBlocking {
         val existing = station(id = 4L)
         val dao = FakeStationDao(existing)
-        val repository = StationRepository(dao)
+        val repository = StationRepository(dao, FakePlayHistoryDao())
 
         val id = repository.insertOrGetExisting(station())
 
@@ -60,7 +60,7 @@ class StationRepositoryTest {
             providerId = "mango",
         )
         val dao = FakeStationDao(existing)
-        val repository = StationRepository(dao)
+        val repository = StationRepository(dao, FakePlayHistoryDao())
 
         val id = repository.insertOrGetExisting(
             station(
@@ -79,7 +79,7 @@ class StationRepositoryTest {
     fun insertOrGetExistingKeepsExistingLogoWhenPresent() = runBlocking {
         val existing = station(id = 3L, logoPath = "/logos/existing.png")
         val dao = FakeStationDao(existing)
-        val repository = StationRepository(dao)
+        val repository = StationRepository(dao, FakePlayHistoryDao())
 
         repository.insertOrGetExisting(station(logoPath = "/logos/new.png"))
 
@@ -90,7 +90,7 @@ class StationRepositoryTest {
     fun insertOrGetExistingMarksExistingStationAsFavorite() = runBlocking {
         val existing = station(id = 9L, isFavorite = false)
         val dao = FakeStationDao(existing)
-        val repository = StationRepository(dao)
+        val repository = StationRepository(dao, FakePlayHistoryDao())
 
         repository.insertOrGetExisting(station(isFavorite = true))
 
@@ -107,7 +107,7 @@ class StationRepositoryTest {
         )
         val streamMatch = station(id = 11L, streamUrl = "https://stream.example.com/registry")
         val dao = FakeStationDao(providerMatch, streamMatch)
-        val repository = StationRepository(dao)
+        val repository = StationRepository(dao, FakePlayHistoryDao())
 
         val result = repository.findMatching(
             RegistryStation(
@@ -125,7 +125,7 @@ class StationRepositoryTest {
     fun findMatchingFallsBackToStreamUrl() = runBlocking {
         val existing = station(id = 12L, streamUrl = "https://stream.example.com/registry")
         val dao = FakeStationDao(existing)
-        val repository = StationRepository(dao)
+        val repository = StationRepository(dao, FakePlayHistoryDao())
 
         val result = repository.findMatching(
             RegistryStation(
@@ -151,7 +151,7 @@ class StationRepositoryTest {
             providerId = "mango",
         )
         val dao = FakeStationDao(existing)
-        val repository = StationRepository(dao)
+        val repository = StationRepository(dao, FakePlayHistoryDao())
 
         val id = repository.saveAsFavorite(
             station(
@@ -171,7 +171,7 @@ class StationRepositoryTest {
     fun upsertImportedKeepsNewerLocalPlayStats() = runBlocking {
         val existing = station(id = 6L, playCount = 12, lastPlayedAt = 2_000L)
         val dao = FakeStationDao(existing)
-        val repository = StationRepository(dao)
+        val repository = StationRepository(dao, FakePlayHistoryDao())
 
         repository.upsertImported(station(playCount = 3, lastPlayedAt = 1_000L))
 
@@ -182,7 +182,7 @@ class StationRepositoryTest {
     @Test
     fun upsertImportedRestoresPlayStatsOntoFreshInstall() = runBlocking {
         val dao = FakeStationDao()
-        val repository = StationRepository(dao)
+        val repository = StationRepository(dao, FakePlayHistoryDao())
 
         repository.upsertImported(station(playCount = 7, lastPlayedAt = 3_000L))
 
@@ -195,7 +195,7 @@ class StationRepositoryTest {
         val dao = FakeStationDao(
             station(id = 2L, name = "dublab", isFavorite = false),
         )
-        val repository = StationRepository(dao)
+        val repository = StationRepository(dao, FakePlayHistoryDao())
 
         val results = repository.searchFavorites("dublab")
 
@@ -213,7 +213,7 @@ class StationRepositoryTest {
                 country = "United Kingdom",
             ),
         )
-        val repository = StationRepository(dao)
+        val repository = StationRepository(dao, FakePlayHistoryDao())
 
         assertEquals(listOf(dao.stations.single()), repository.searchFavorites("jungle"))
         assertEquals(listOf(dao.stations.single()), repository.searchFavorites("underground"))
@@ -315,5 +315,20 @@ class StationRepositoryTest {
         override suspend fun delete(station: Station) {
             stations.removeAll { it.id == station.id }
         }
+    }
+
+    private class FakePlayHistoryDao(vararg initialEntries: PlayHistoryEntry) : PlayHistoryDao {
+        val entries = initialEntries.toMutableList()
+
+        override suspend fun recordPlay(entry: PlayHistoryEntry) {
+            entries.removeAll { it.provider == entry.provider && it.providerId == entry.providerId }
+            entries += entry
+        }
+
+        override suspend fun recent(limit: Int): List<PlayHistoryEntry> =
+            entries.sortedByDescending { it.playedAt }.take(limit)
+
+        override fun recentAsFlow(limit: Int): Flow<List<PlayHistoryEntry>> =
+            flowOf(entries.sortedByDescending { it.playedAt }.take(limit))
     }
 }


### PR DESCRIPTION
Adds Android Auto support: browse tree (Favorites / Moods / Recently Played), voice and typed search, queueing with wraparound skip, and station logos on the car screen.

Also adds a play-history table (any station played, favourited or not) that backs Recently Played in Auto and a new live row on the phone home screen, plus an `ArtworkProvider` that serves SVG and cleartext-http logos as cached PNG content URIs.

Tested against the Desktop Head Unit and the phone app; DHU workflow notes added to DEVELOPERS.md.