### PR TITLE
fix(playback): hardware/Bluetooth media buttons skip stations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
+- Hardware and Bluetooth media buttons (car stereo, headphones) now skip to the next/previous station, matching the order of whatever list you played from — favourites, a mood, or For You. (#112)
 - Favouriting a station played from search now downloads its logo to local storage immediately, instead of only saving the remote URL — so the image is included in backups and survives a restore. (#100)
 
 ## [0.4.3] - 2026-07-12

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -338,3 +338,25 @@ The Recently Played folder reorders on re-entry but not while it stays on
 screen: `notifyChildrenChanged("recent")` fires after each recorded play
 (visible in logcat), but the Auto host decides whether to re-query a folder
 it is currently displaying, and the DHU does not. Not fixable app-side.
+
+## Hardware / Bluetooth media buttons
+
+`media3`'s default `MediaSession.Callback` handles `onSkipToNext`/`onSkipToPrevious`
+(from headphones, a car stereo's AVRCP controls, or the media notification) by
+seeking within the player's timeline — it needs a timeline with neighbouring items to
+do anything. `MainViewModel.play()`/`playFromRegistry()`/`loadStationPaused()` take an
+optional `queue` parameter: whichever list the phone UI is already showing (favourites
+in the user's sort order, an active mood, For You) is queued as real `MediaItem`s via
+`setMediaItems`, the same list `NowPlayingScreen`'s swipe pager steps through. A
+station played outside any visible list (an ephemeral search result) still falls back
+to a single-item queue, same as before.
+
+This can be verified without real Bluetooth hardware:
+
+```sh
+adb shell input keyevent 87  # KEYCODE_MEDIA_NEXT
+adb shell input keyevent 88  # KEYCODE_MEDIA_PREVIOUS
+```
+
+Play a favourite, confirm skip moves through the same list/order the Now Playing
+pager swipes through, and check `logcat -s AerialPlayerService` for errors.

--- a/app/src/main/java/com/shapeshed/aerial/data/Station.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/Station.kt
@@ -18,4 +18,19 @@ data class Station(
     val countryCode: String = "",
     val playCount: Int = 0,
     val lastPlayedAt: Long = 0,
-)
+) {
+    /** Same station by identity, not by value: a saved row and an ephemeral/registry copy of
+     * it (id 0, no db row) should still match by provider+providerId or stream URL. */
+    fun matches(other: Station): Boolean =
+        (id != 0L && id == other.id) ||
+            streamUrl == other.streamUrl ||
+            (provider.isNotBlank() &&
+                providerId.isNotBlank() &&
+                provider == other.provider &&
+                providerId == other.providerId)
+}
+
+/** Resolves where [target] sits in [queue] for queueing playback — null if it isn't a member,
+ * or the queue is a single station (nothing to skip to). */
+fun resolveQueueStart(queue: List<Station>, target: Station): Int? =
+    queue.indexOfFirst { it.matches(target) }.takeIf { it >= 0 && queue.size > 1 }

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -279,13 +279,6 @@ private fun RegistryStation.toPlaybackStation(): Station = Station(
     countryCode = countryCode,
 )
 
-private fun Station.matchesStation(other: Station): Boolean =
-    streamUrl == other.streamUrl ||
-        (provider.isNotBlank() &&
-            providerId.isNotBlank() &&
-            provider == other.provider &&
-            providerId == other.providerId)
-
 enum class HomeViewMode {
     Cards,
     List,
@@ -576,12 +569,15 @@ fun MainScreen(
                         savedRegistryKeys = savedRegistryKeys,
                         bottomPadding = stationContentBottomPadding,
                         onBack = { selectedMoodId = null },
-                        onPlay = { selectedMoodStations.firstOrNull()?.let(viewModel::playFromRegistry) },
+                        onPlay = {
+                            selectedMoodStations.firstOrNull()
+                                ?.let { viewModel.playFromRegistry(it, selectedMoodStations) }
+                        },
                         onSave = { selectedMoodStations.forEach(viewModel::addFromRegistry) },
                         onTogglePlayback = { viewModel.togglePlayback() },
                         onAddStation = { viewModel.addFromRegistry(it) },
                         onRemoveStation = { viewModel.removeFromRegistry(it) },
-                        onPlayStation = { viewModel.playFromRegistry(it) },
+                        onPlayStation = { viewModel.playFromRegistry(it, selectedMoodStations) },
                     )
                 } else if (selectedTab == TAB_HOME) {
                     // The For You row is the locale country's selection (curated or a random
@@ -591,14 +587,15 @@ fun MainScreen(
                     val forYouCountryCode = appLocale.country.takeIf { it.isNotBlank() } ?: "GB"
                     LaunchedEffect(forYouCountryCode) { viewModel.setForYouCountry(forYouCountryCode) }
                     val hasCountrySelection = forYouStations.isNotEmpty()
+                    val forYouOrFeatured = forYouStations.ifEmpty { featuredStations }
                     HomeTabContent(
-                        forYouStations = forYouStations.ifEmpty { featuredStations },
+                        forYouStations = forYouOrFeatured,
                         forYouCountry = countryName(forYouCountryCode, appLocale).takeIf { hasCountrySelection },
                         recentlyPlayedStations = recentlyPlayedStations,
                         listState = homeListState,
                         bottomPadding = stationContentBottomPadding,
                         onMoodTap = { selectedMoodId = it.id },
-                        onFeaturedStationTap = { viewModel.playFromRegistry(it) },
+                        onFeaturedStationTap = { viewModel.playFromRegistry(it, forYouOrFeatured) },
                         onForYouViewAll = {
                             if (hasCountrySelection) openCountrySearch(forYouCountryCode) else openRegistrySearch()
                         },
@@ -614,7 +611,7 @@ fun MainScreen(
                         gridColumns = favoritesGridColumns,
                         listState = favoritesListState,
                         bottomPadding = stationContentBottomPadding,
-                        onPlay = { viewModel.play(it) },
+                        onPlay = { viewModel.play(it, stations) },
                         onTogglePlayback = { viewModel.togglePlayback() },
                         onToggleFavorite = { viewModel.toggleFavorite(it) },
                         onHomeViewModeChange = { viewModel.setHomeViewMode(it) },
@@ -813,7 +810,7 @@ fun MainScreen(
                 val favoriteSwipeStations = remember { viewModel.stations.value }
                 val useMoodSwipeStations = selectedMood != null &&
                     moodSwipeStations.size > 1 &&
-                    moodSwipeStations.any { moodStation -> station.matchesStation(moodStation) }
+                    moodSwipeStations.any { moodStation -> station.matches(moodStation) }
                 val swipeStations = if (useMoodSwipeStations) moodSwipeStations else favoriteSwipeStations
                 NowPlayingScreen(
                     station = station,
@@ -828,7 +825,7 @@ fun MainScreen(
                     showStreamBitrate = showStreamBitrate,
                     sleepTimer = sleepTimer,
                     swipeStations = swipeStations,
-                    onPlayStation = { viewModel.play(it) },
+                    onPlayStation = { viewModel.play(it, swipeStations) },
                     onToggle = { viewModel.togglePlayback() },
                     onToggleFavorite = { viewModel.toggleFavorite(station) },
                     onSetSleepTimer = { viewModel.setSleepTimer(it) },

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -48,6 +48,7 @@ import com.shapeshed.aerial.data.SleepTimerState
 import com.shapeshed.aerial.data.SleepTimerStore
 import com.shapeshed.aerial.data.Station
 import com.shapeshed.aerial.data.StationRepository
+import com.shapeshed.aerial.data.resolveQueueStart
 import com.shapeshed.aerial.toEphemeralStation
 import com.shapeshed.aerial.toPlayableMediaItem
 import java.io.File
@@ -458,8 +459,8 @@ class MainViewModel(
         }
     }
 
-    fun playFromRegistry(registryStation: RegistryStation) {
-        play(registryStation.toEphemeralStation())
+    fun playFromRegistry(registryStation: RegistryStation, queue: List<RegistryStation> = emptyList()) {
+        play(registryStation.toEphemeralStation(), queue.map { it.toEphemeralStation() })
     }
 
     fun addFromRegistry(registryStation: RegistryStation) {
@@ -726,7 +727,13 @@ class MainViewModel(
             ?.let { bitrate -> (bitrate / 1_000).coerceAtLeast(1) }
     }
 
-    fun play(station: Station) {
+    // queue is the ordered list station is part of in whatever screen triggered playback
+    // (favourites in the user's sort order, or an active mood's stations) — the same list the
+    // Now Playing pager swipes through. Feeding it to the session as a real multi-item queue
+    // (rather than a single MediaItem) is what makes hardware/Bluetooth media-button
+    // next/previous work: Media3's default session callback already handles those by seeking
+    // within the player's timeline, it just needs a timeline with neighbours to seek to.
+    fun play(station: Station, queue: List<Station> = emptyList()) {
         if (station.id == 0L) {
             _ephemeralStation.value = station
             _currentStationId.value = null
@@ -741,9 +748,14 @@ class MainViewModel(
         _currentBitrateKbps.value = null
         _playbackError.value = null
         persistLastPlayedStation(station)
-        val mediaItem = station.toPlayableMediaItem(getApplication())
+        val startIndex = resolveQueueStart(queue, station)
         controller?.apply {
-            setMediaItem(mediaItem)
+            if (startIndex != null) {
+                val mediaItems = queue.map { it.toPlayableMediaItem(getApplication()) }
+                setMediaItems(mediaItems, startIndex, C.TIME_UNSET)
+            } else {
+                setMediaItem(station.toPlayableMediaItem(getApplication()))
+            }
             prepare()
             play()
         }
@@ -900,10 +912,15 @@ class MainViewModel(
     }
 
     private fun loadStationPaused(station: Station) {
-        val mediaItem = station.toPlayableMediaItem(getApplication())
+        val startIndex = resolveQueueStart(stations.value, station)
 
         controller?.apply {
-            setMediaItem(mediaItem)
+            if (startIndex != null) {
+                val mediaItems = stations.value.map { it.toPlayableMediaItem(getApplication()) }
+                setMediaItems(mediaItems, startIndex, C.TIME_UNSET)
+            } else {
+                setMediaItem(station.toPlayableMediaItem(getApplication()))
+            }
             prepare()
             pause()
         }

--- a/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
@@ -94,14 +94,6 @@ import com.shapeshed.aerial.data.Station
 import java.io.File
 import kotlin.math.abs
 
-private fun Station.matchesStation(other: Station): Boolean =
-    (id != 0L && id == other.id) ||
-        streamUrl == other.streamUrl ||
-        (provider.isNotBlank() &&
-            providerId.isNotBlank() &&
-            provider == other.provider &&
-            providerId == other.providerId)
-
 private fun circularPageIndex(page: Int, size: Int): Int = ((page % size) + size) % size
 
 // A station's own saved logo, resolved the same way StationAvatar does. Used as full-bleed
@@ -145,7 +137,7 @@ fun NowPlayingScreen(
     // Horizontal paging steps through swipeStations (the favourites in their selected sort
     // order). A non-favourite station isn't in the list, so the artwork stays static for it.
     val swipeIndex = remember(swipeStations, station) {
-        swipeStations.indexOfFirst { it.matchesStation(station) }
+        swipeStations.indexOfFirst { it.matches(station) }
     }
     var showTrackDetail by remember { mutableStateOf(false) }
     var showSleepTimer by remember { mutableStateOf(false) }
@@ -317,7 +309,7 @@ fun NowPlayingScreen(
                         val pagerState = rememberPagerState(initialPage = initialPage) { virtualPageCount }
                         LaunchedEffect(pagerState.settledPage) {
                             val target = swipeStations[circularPageIndex(pagerState.settledPage, swipeStations.size)]
-                            if (!target.matchesStation(station)) onPlayStation(target)
+                            if (!target.matches(station)) onPlayStation(target)
                         }
                         // Keep the pager in step when the station changes some other way (e.g. the
                         // media notification or a tap on the favourites grid behind the pane).
@@ -335,7 +327,7 @@ fun NowPlayingScreen(
                             pageSpacing = 24.dp,
                         ) { page ->
                             val pageStation = swipeStations[circularPageIndex(page, swipeStations.size)]
-                            if (pageStation.matchesStation(station)) {
+                            if (pageStation.matches(station)) {
                                 StationArtworkSurface(
                                     station = pageStation,
                                     shape = artworkShape,

--- a/app/src/test/java/com/shapeshed/aerial/data/StationTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/data/StationTest.kt
@@ -1,0 +1,77 @@
+package com.shapeshed.aerial.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StationTest {
+
+    @Test
+    fun matchesById() {
+        val a = station(id = 1L, streamUrl = "https://a")
+        val b = station(id = 1L, streamUrl = "https://b")
+
+        assertTrue(a.matches(b))
+    }
+
+    @Test
+    fun matchesByStreamUrlWhenEitherIdIsEphemeral() {
+        val saved = station(id = 5L, streamUrl = "https://same")
+        val ephemeral = station(id = 0L, streamUrl = "https://same")
+
+        assertTrue(saved.matches(ephemeral))
+        assertTrue(ephemeral.matches(saved))
+    }
+
+    @Test
+    fun matchesByProviderAndProviderIdForEphemeralStations() {
+        val a = station(id = 0L, streamUrl = "https://a", provider = "bauer", providerId = "42")
+        val b = station(id = 0L, streamUrl = "https://b", provider = "bauer", providerId = "42")
+
+        assertTrue(a.matches(b))
+    }
+
+    @Test
+    fun doesNotMatchDifferentStations() {
+        val a = station(id = 0L, streamUrl = "https://a")
+        val b = station(id = 0L, streamUrl = "https://b")
+
+        assertFalse(a.matches(b))
+    }
+
+    @Test
+    fun resolveQueueStartFindsIndexInMultiStationQueue() {
+        val queue = listOf(station(id = 1L), station(id = 2L), station(id = 3L))
+
+        assertEquals(1, resolveQueueStart(queue, station(id = 2L)))
+    }
+
+    @Test
+    fun resolveQueueStartReturnsNullForSingleStationQueue() {
+        val queue = listOf(station(id = 1L))
+
+        assertNull(resolveQueueStart(queue, station(id = 1L)))
+    }
+
+    @Test
+    fun resolveQueueStartReturnsNullWhenTargetNotInQueue() {
+        val queue = listOf(station(id = 1L), station(id = 2L))
+
+        assertNull(resolveQueueStart(queue, station(id = 99L)))
+    }
+
+    private fun station(
+        id: Long = 0L,
+        streamUrl: String = "https://stream.example/$id",
+        provider: String = "",
+        providerId: String = "",
+    ) = Station(
+        id = id,
+        name = "Station $id",
+        streamUrl = streamUrl,
+        provider = provider,
+        providerId = providerId,
+    )
+}


### PR DESCRIPTION
## Summary
- Queues the list a station is played from (favourites, mood, For You) as a real multi-item Media3 queue instead of a single `MediaItem`, so hardware/Bluetooth media buttons (car stereo, headphones) can skip next/previous between stations, matching the swipe gesture's order.
- Dedupes the station-identity check that existed separately in `MainScreen.kt` and `NowPlayingScreen.kt` into one `Station.matches()`.
- No changes to `PlayerService.kt`/`MediaBrowseTree.kt` — Android Auto is unaffected.

Fixes #112

## Test plan
- [x] `./gradlew testDebugUnitTest`
- [x] Verified on an emulator: seeded two favourites, confirmed `KEYCODE_MEDIA_NEXT`/`PREVIOUS` skip and wrap between them (matching swipe order)
- [x] Confirmed swiping in Now Playing still works, no regression