### PR TITLE
fix(artwork): composite artwork onto an opaque background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
+- Station logos with a transparent background — notably SVGs whose fill color depends on a `prefers-color-scheme` our decoder doesn't evaluate — no longer render invisible on the media notification, lock screen, quick settings player, or Android Auto.
 - Hardware and Bluetooth media buttons (car stereo, headphones) now skip to the next/previous station, matching the order of whatever list you played from — favourites, a mood, or For You. (#112)
 - Favouriting a station played from search now downloads its logo to local storage immediately, instead of only saving the remote URL — so the image is included in backups and survives a restore. (#100)
 

--- a/app/src/main/java/com/shapeshed/aerial/CoilBitmapLoader.kt
+++ b/app/src/main/java/com/shapeshed/aerial/CoilBitmapLoader.kt
@@ -3,18 +3,16 @@ package com.shapeshed.aerial
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.graphics.Canvas
 import android.net.Uri
 import androidx.concurrent.futures.SuspendToFutureAdapter
-import androidx.core.graphics.createBitmap
 import androidx.media3.common.util.BitmapLoader
 import androidx.media3.common.util.UnstableApi
-import coil3.BitmapImage
 import coil3.SingletonImageLoader
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.size.Size
 import com.google.common.util.concurrent.ListenableFuture
+import com.shapeshed.aerial.ui.toOpaqueBitmap
 import kotlinx.coroutines.Dispatchers
 
 // Media3's default BitmapLoader fetches artwork with its own bare HTTP stack and decodes it
@@ -43,22 +41,10 @@ class CoilBitmapLoader(private val context: Context) : BitmapLoader {
                 .build()
             val result = imageLoader.execute(request) as? SuccessResult
                 ?: error("Could not load artwork from $uri")
-            when (val image = result.image) {
-                // The common case: a decoded raster logo. Coil may hand back a hardware
-                // bitmap for performance; system notifications need a software one, and
-                // Bitmap.copy() does that GPU-to-software readback correctly — unlike
-                // Canvas, which throws "Software rendering doesn't support hardware
-                // bitmaps" if you try to draw a hardware bitmap into a software canvas.
-                is BitmapImage -> if (image.bitmap.config == Bitmap.Config.HARDWARE) {
-                    image.bitmap.copy(Bitmap.Config.ARGB_8888, false)
-                } else {
-                    image.bitmap
-                }
-                // Any other Image implementation (e.g. a vector drawable) isn't backed by a
-                // hardware bitmap, so drawing it into a fresh software canvas is safe.
-                else -> createBitmap(image.width, image.height).apply {
-                    image.draw(Canvas(this))
-                }
-            }
+            // Composited onto an opaque background — see toOpaqueBitmap's doc for why: a
+            // transparent-background logo (e.g. an SVG whose fill depends on a
+            // prefers-color-scheme our decoder doesn't evaluate) would otherwise render
+            // invisible against the system's own dark quick-controls/notification backdrop.
+            result.image.toOpaqueBitmap()
         }
 }

--- a/app/src/main/java/com/shapeshed/aerial/ui/LogoFiles.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/LogoFiles.kt
@@ -10,7 +10,6 @@ import com.shapeshed.aerial.R
 import android.webkit.MimeTypeMap
 import androidx.core.graphics.createBitmap
 import coil3.BitmapImage
-import coil3.DrawableImage
 import coil3.Image
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
@@ -69,7 +68,7 @@ suspend fun ensureMediaArtworkForLogo(context: Context, file: File): File {
             .size(512)
             .build()
         val result = svgLoader(context).execute(request) as? SuccessResult ?: return file
-        val bitmap = result.image.toBitmap() ?: return file
+        val bitmap = result.image.toOpaqueBitmap()
         pngFile.outputStream().use { output ->
             bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
         }
@@ -115,7 +114,7 @@ suspend fun cachedRemoteArtworkUri(context: Context, logoUrl: String): Uri? {
         val result = withTimeoutOrNull(ARTWORK_FETCH_TIMEOUT_MS) {
             SingletonImageLoader.get(context).execute(request)
         } as? SuccessResult ?: return null
-        val bitmap = result.image.toBitmap() ?: return null
+        val bitmap = result.image.toOpaqueBitmap()
         cacheDir.mkdirs()
         // Write-then-rename so a concurrent request (Android Auto prefetches folders in
         // parallel) or a mid-write process kill can never expose a truncated PNG under the
@@ -189,18 +188,28 @@ private fun String.extensionOrNull(): String? {
         .takeIf { it.isNotBlank() && it.length <= 5 }
 }
 
-private fun Image.toBitmap(): Bitmap? {
-    return when (this) {
-        is BitmapImage -> bitmap
-        is DrawableImage -> {
-            val width = width.takeIf { it > 0 } ?: 512
-            val height = height.takeIf { it > 0 } ?: 512
-            createBitmap(width, height).also { bitmap ->
-                val canvas = Canvas(bitmap)
-                drawable.setBounds(0, 0, canvas.width, canvas.height)
-                drawable.draw(canvas)
-            }
-        }
-        else -> null
+/**
+ * Rasterizes a Coil [Image] onto an opaque background. System media surfaces (quick controls,
+ * lock screen, Bluetooth AVRCP, Android Auto) draw an artwork bitmap with no guaranteed
+ * background behind it, so a source image with transparent areas can end up invisible against
+ * a dark system theme — notably an SVG logo that uses `prefers-color-scheme` to pick between a
+ * black and white fill, which our SVG decoder doesn't evaluate, so it always renders the
+ * non-media-query default (typically a black path on a transparent canvas). Compositing onto
+ * solid white keeps the logo visible regardless of what surrounds it.
+ */
+fun Image.toOpaqueBitmap(backgroundColor: Int = android.graphics.Color.WHITE): Bitmap {
+    val width = width.takeIf { it > 0 } ?: 512
+    val height = height.takeIf { it > 0 } ?: 512
+    val bitmap = createBitmap(width, height)
+    val canvas = Canvas(bitmap)
+    canvas.drawColor(backgroundColor)
+    when {
+        // A hardware bitmap can't be drawn into a software Canvas ("Software rendering doesn't
+        // support hardware bitmaps") — copy() does the GPU-to-software readback instead.
+        this is BitmapImage && this.bitmap.config == Bitmap.Config.HARDWARE ->
+            canvas.drawBitmap(this.bitmap.copy(Bitmap.Config.ARGB_8888, false), 0f, 0f, null)
+        this is BitmapImage -> canvas.drawBitmap(this.bitmap, 0f, 0f, null)
+        else -> draw(canvas)
     }
+    return bitmap
 }


### PR DESCRIPTION
## Summary
- Some station logos (notably SVGs using a `prefers-color-scheme` CSS media query our decoder doesn't evaluate) were rasterized onto a transparent canvas, using the light-mode fill color — invisible against the dark media notification, lock screen, quick settings player, and Android Auto. Reproduced live with Radio Raheem's SVG favicon.
- Fixed by compositing onto an opaque white background in `CoilBitmapLoader` (the live session artwork path) and the shared local-file/browse-tree rasterization helper in `LogoFiles.kt`, so favourited stations' cached logos and Android Auto/Google TV browse art get the same treatment.

## Test plan
- [x] Verified on a physical Pixel 9 Pro XL: played Radio Raheem (SVG logo) from a queued list, confirmed the quick settings media player now shows the logo instead of a near-invisible black shape.
- [x] `./gradlew test` passes.