### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,19 @@ All notable changes to Aerial will be documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and version numbers should follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once public releases begin.
 
-## [Unreleased]
+## [0.5.0] - 2026-07-21
 
 ### Added
 
-- Android Auto support: browse Favorites, Moods, and Recently Played, voice/typed search, and playback queues — tapping a station queues its list with skip next/previous wrapping around.
-- A favourite toggle on the Android Auto now-playing screen adds or removes the current station, including stations played straight from mood folders or search.
-- Recently Played now tracks any station played, favourited or not, in a new play-history table resolved against the station registry, and updates live on the car screen.
-- The home screen shows a Recently Played row above the For You section once at least one station has been played, updating live as stations play.
-- Station logos render in Android Auto browse lists even when the source is an SVG or a cleartext http URL, served as cached PNGs through a read-only content provider.
-- The phone's mini player and Now Playing screen follow playback started elsewhere — Android Auto, voice search, or a queue skip — instead of only playback started in-app.
+- Android Auto support, with voice search.
+- Recently Played, showing any station you play, not just favourites, with a new home screen row.
+- The mini player and Now Playing screen now follow playback started elsewhere, such as Android Auto or voice search.
 
 ### Fixed
 
-- Station logos with a transparent background — notably SVGs whose fill color depends on a `prefers-color-scheme` our decoder doesn't evaluate — no longer render invisible on the media notification, lock screen, quick settings player, or Android Auto.
-- Hardware and Bluetooth media buttons (car stereo, headphones) now skip to the next/previous station, matching the order of whatever list you played from — favourites, a mood, or For You. (#112)
-- Favouriting a station played from search now downloads its logo to local storage immediately, instead of only saving the remote URL — so the image is included in backups and survives a restore. (#100)
+- Station logos with transparent backgrounds, such as some SVGs, no longer disappear on the media notification, lock screen, and Android Auto.
+- Hardware and Bluetooth media buttons now skip to the next/previous station in the list you played from. (#112)
+- Favouriting a station from search now saves its logo locally right away, so it's included in backups. (#100)
 
 ## [0.4.3] - 2026-07-12
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -295,7 +295,10 @@ The release build must not require local signing environment variables.
 ## Android Auto
 
 `PlayerService` is a `media3` `MediaLibraryService` exposing a browse tree:
-root -> Favorites | Moods | Recently Played, plus voice/typed search. The
+root -> Favorites | Moods | Recently Played, plus search (verified via voice —
+the underlying `onSearch`/`onGetSearchResult` callbacks accept any query
+string, so a typed keyboard search should work too, but that path hasn't
+actually been tested). The
 tree-building logic lives in `data/MediaBrowseTree.kt` (plain suspend
 functions over `StationRepository`/`RegistryRepository`, no session types) so
 it's unit-testable without Robolectric — see

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,8 +32,8 @@ android {
         applicationId "com.shapeshed.aerial"
         minSdk 26
         targetSdk 37
-        versionCode 8
-        versionName "0.4.3"
+        versionCode 9
+        versionName "0.5.0"
     }
 
     signingConfigs {

--- a/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -1,0 +1,6 @@
+- Android Auto support, with voice search.
+- Recently Played, showing any station you play, not just favourites, with a new home screen row.
+- The mini player and Now Playing screen now follow playback started elsewhere, such as Android Auto or voice search.
+- Fixed station logos with transparent backgrounds, such as some SVGs, disappearing on the media notification, lock screen, and Android Auto.
+- Fixed hardware and Bluetooth media buttons not skipping to the next/previous station in the list you played from.
+- Fixed a station favourited from search not saving its logo locally right away.


### PR DESCRIPTION
## Summary
- Bumps versionCode 8→9, versionName 0.4.3→0.5.0.
- Renames the CHANGELOG's `[Unreleased]` section to `[0.5.0] - 2026-07-21`.
- Adds the Fastlane changelog for versionCode 9.
- Corrects `DEVELOPERS.md`'s Android Auto search claim to only assert what's actually been verified (voice search).

## Verified
- `scripts/prepare-release.sh` (Gradle test/lint/assembleRelease/bundleRelease + F-Droid metadata rewrite/lint) passes clean.
- Upgrade path from a real v0.4.3 install (Room schema 15) to this build (schema 16) tested on a physical device: favourites, settings, and the new `play_history` table all survive via the registered migration, no destructive fallback triggered.

## Test plan
- [x] `scripts/prepare-release.sh`
- [x] Manual 0.4.3 → 0.5.0 upgrade test on a physical device (favourites, settings, no crash)

Does not tag, push a tag, or upload to Google Play — that's a manual follow-up once this merges.