### PR TITLE
fix(playback): serve favourite logos as a content uri to avoid Bluetooth crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Aerial will be documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and version numbers should follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once public releases begin.
 
+## [Unreleased]
+
+### Fixed
+
+- Playing from favourites over Bluetooth no longer crashes the car's Bluetooth connection when skipping stations. (#123)
+
 ## [0.5.0] - 2026-07-21
 
 ### Added

--- a/app/src/main/java/com/shapeshed/aerial/ArtworkProvider.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ArtworkProvider.kt
@@ -5,17 +5,20 @@ import android.content.ContentValues
 import android.database.Cursor
 import android.net.Uri
 import android.os.ParcelFileDescriptor
+import android.webkit.MimeTypeMap
 import java.io.File
 import java.io.FileNotFoundException
 
 /**
- * Read-only provider serving rasterized registry logos (SVG -> PNG, see
- * [com.shapeshed.aerial.ui.cachedRegistryArtworkUri]) to external artwork consumers — Android
- * Auto's browse lists, Bluetooth AVRCP, System UI. A stable content:// artworkUri lets those
- * consumers decode once and cache by URI (embedded artworkData bytes can't be cached that way,
- * which shows up as icons flashing in on every list render). Exported because media artwork
- * URIs offer no permission-grant handshake; it can only ever open files inside the
- * registry_artwork cache directory.
+ * Read-only provider serving station artwork — rasterized registry logos (SVG -> PNG, see
+ * [com.shapeshed.aerial.ui.cachedRemoteArtworkUri]) and locally-cached favourite logos (see
+ * [com.shapeshed.aerial.ui.localLogoArtworkUri]) — to external artwork consumers: Android Auto's
+ * browse lists, Bluetooth AVRCP, System UI. A stable content:// artworkUri lets those consumers
+ * decode once and cache by URI, and — critically for AVRCP — lets Media3 skip decoding a Bitmap
+ * for the item at all (embedded artworkData bytes force a decode-and-embed per queue item, which
+ * is what overloads the Bluetooth queue-diffing and crashes it; see #123). Exported because media
+ * artwork URIs offer no permission-grant handshake; it can only ever open files inside one of its
+ * two known cache directories.
  */
 class ArtworkProvider : ContentProvider() {
 
@@ -23,8 +26,14 @@ class ArtworkProvider : ContentProvider() {
 
     override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor {
         val context = context ?: throw FileNotFoundException(uri.toString())
-        val fileName = uri.lastPathSegment ?: throw FileNotFoundException(uri.toString())
-        val dir = File(context.cacheDir, ARTWORK_CACHE_DIR)
+        val segments = uri.pathSegments
+        val dirName = segments.getOrNull(0) ?: throw FileNotFoundException(uri.toString())
+        val fileName = segments.getOrNull(1) ?: throw FileNotFoundException(uri.toString())
+        val dir = when (dirName) {
+            REGISTRY_ARTWORK_DIR -> File(context.cacheDir, REGISTRY_ARTWORK_DIR)
+            LOCAL_LOGO_DIR -> File(context.filesDir, LOCAL_LOGO_DIR)
+            else -> throw FileNotFoundException(uri.toString())
+        }
         val file = File(dir, fileName)
         if (file.canonicalFile.parentFile != dir.canonicalFile || !file.exists()) {
             throw FileNotFoundException(uri.toString())
@@ -32,7 +41,10 @@ class ArtworkProvider : ContentProvider() {
         return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
     }
 
-    override fun getType(uri: Uri): String = "image/png"
+    override fun getType(uri: Uri): String {
+        val extension = uri.lastPathSegment?.substringAfterLast('.', "").orEmpty()
+        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension) ?: "image/*"
+    }
 
     override fun query(
         uri: Uri,
@@ -49,9 +61,12 @@ class ArtworkProvider : ContentProvider() {
     override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
 
     companion object {
-        const val ARTWORK_CACHE_DIR = "registry_artwork"
+        const val REGISTRY_ARTWORK_DIR = "registry_artwork"
 
-        fun uriFor(context: android.content.Context, fileName: String): Uri =
-            Uri.parse("content://${context.packageName}.artwork/$fileName")
+        // Matches the download directory MainViewModel.downloadLogo caches favourited logos in.
+        const val LOCAL_LOGO_DIR = "logos"
+
+        fun uriFor(context: android.content.Context, dir: String, fileName: String): Uri =
+            Uri.parse("content://${context.packageName}.artwork/$dir/$fileName")
     }
 }

--- a/app/src/main/java/com/shapeshed/aerial/StationMediaItems.kt
+++ b/app/src/main/java/com/shapeshed/aerial/StationMediaItems.kt
@@ -11,7 +11,7 @@ import com.shapeshed.aerial.data.Station
 import com.shapeshed.aerial.data.bauerStreamUrl
 import com.shapeshed.aerial.ui.appIconBitmap
 import com.shapeshed.aerial.ui.cachedRemoteArtworkUri
-import com.shapeshed.aerial.ui.compressedLogoData
+import com.shapeshed.aerial.ui.localLogoArtworkUri
 import java.io.File
 
 /**
@@ -45,17 +45,14 @@ fun stationMediaMetadata(
     val artworkUri = station.logoPath
         .takeIf { it.startsWith("http") }
         ?.toUri()
-    val localArtworkData = station.logoPath
+    val localArtworkUri = station.logoPath
         .takeIf { it.isNotEmpty() && !it.startsWith("http") }
-        ?.let { compressedLogoData(File(it)) }
+        ?.let { localLogoArtworkUri(context, File(it)) }
 
     return MediaMetadata.Builder().apply {
         when {
             artworkUriOverride != null -> setArtworkUri(artworkUriOverride)
-            localArtworkData != null -> setArtworkData(
-                localArtworkData,
-                MediaMetadata.PICTURE_TYPE_FRONT_COVER,
-            )
+            localArtworkUri != null -> setArtworkUri(localArtworkUri)
             artworkUri != null -> setArtworkUri(artworkUri)
             else -> appIconBitmap(context)?.let {
                 setArtworkData(it, MediaMetadata.PICTURE_TYPE_FRONT_COVER)

--- a/app/src/main/java/com/shapeshed/aerial/ui/LogoFiles.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/LogoFiles.kt
@@ -98,9 +98,9 @@ suspend fun cachedRemoteArtworkUri(context: Context, logoUrl: String): Uri? {
     val isCleartext = logoUrl.startsWith("http://")
     if (!isSvg && !isCleartext) return null
 
-    val cacheDir = File(context.cacheDir, ArtworkProvider.ARTWORK_CACHE_DIR)
+    val cacheDir = File(context.cacheDir, ArtworkProvider.REGISTRY_ARTWORK_DIR)
     val pngFile = File(cacheDir, "${logoUrl.hashCode().toUInt()}.png")
-    if (pngFile.exists()) return ArtworkProvider.uriFor(context, pngFile.name)
+    if (pngFile.exists()) return ArtworkProvider.uriFor(context, ArtworkProvider.REGISTRY_ARTWORK_DIR, pngFile.name)
 
     return try {
         val request = ImageRequest.Builder(context)
@@ -127,10 +127,25 @@ suspend fun cachedRemoteArtworkUri(context: Context, logoUrl: String): Uri? {
             tmpFile.delete()
             if (!pngFile.exists()) return null
         }
-        ArtworkProvider.uriFor(context, pngFile.name)
+        ArtworkProvider.uriFor(context, ArtworkProvider.REGISTRY_ARTWORK_DIR, pngFile.name)
     } catch (_: Exception) {
         null
     }
+}
+
+/**
+ * A stable content:// URI for a favourited station's locally-cached logo file (already on disk
+ * under filesDir/logos — see MainViewModel.downloadLogo), for the same reason
+ * [cachedRemoteArtworkUri] proxies remote logos: Media3's legacy queue bridge only decodes and
+ * embeds a Bitmap in a queue item when its MediaMetadata carries embedded artworkData bytes — an
+ * artworkUri-only item is skipped entirely. Handing the phone/Bluetooth playback queue a URI
+ * instead of bytes means Bluetooth's AVRCP queue-diffing never receives a Bitmap to crash on
+ * (#123). SVGs resolve to their pre-rasterized PNG sibling.
+ */
+fun localLogoArtworkUri(context: Context, file: File): Uri? {
+    val artworkFile = mediaArtworkFile(file)
+    if (!artworkFile.exists()) return null
+    return ArtworkProvider.uriFor(context, ArtworkProvider.LOCAL_LOGO_DIR, artworkFile.name)
 }
 
 fun appIconBitmap(context: Context): ByteArray? {
@@ -143,26 +158,6 @@ fun appIconBitmap(context: Context): ByteArray? {
         output.toByteArray()
     } catch (_: Exception) {
         null
-    }
-}
-
-fun compressedLogoData(file: File): ByteArray? {
-    val artworkFile = if (file.extension.lowercase(Locale.US) == "svg") {
-        mediaArtworkFile(file).takeIf { it.exists() } ?: return null
-    } else {
-        file
-    }
-    if (!artworkFile.exists()) return null
-    return when (artworkFile.extension.lowercase(Locale.US)) {
-        "png", "jpg", "jpeg", "webp" -> artworkFile.readBytes()
-        else -> {
-            // Unknown extension (e.g. .img) — try BitmapFactory and re-encode as JPEG
-            val bitmap = BitmapFactory.decodeFile(artworkFile.absolutePath) ?: return null
-            val out = java.io.ByteArrayOutputStream()
-            bitmap.compress(Bitmap.CompressFormat.JPEG, 90, out)
-            bitmap.recycle()
-            out.toByteArray()
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Favourited station artwork was embedded as raw bytes in queue metadata, forcing Media3 to decode and embed a Bitmap per item for the AVRCP queue — skipping through a full favourites list sent enough of these to crash `com.google.android.bluetooth` (`Image.sameAs`: recycled bitmap), looping the crash.
- Local logos now go through a stable `content://` URI instead, same as mood/for-you playlists already do, so Media3 never decodes a Bitmap for them at all.
- Drops `compressedLogoData`, now dead code.

Fixes #123

## Test plan
- [x] `./gradlew test lint` passes
- [x] Installed debug build on device, confirmed builds/queues correctly
- [ ] Confirm no Bluetooth crash when playing from favourites and skipping in-car (device owner to verify)