### PR TITLE
fix(playback): make Bluetooth previous move back a station, not restart it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 ### Fixed
 
 - Playing from favourites over Bluetooth no longer crashes the car's Bluetooth connection when skipping stations. (#123)
+- The Bluetooth previous control now moves to the previous station instead of replaying the current one. (#120)
 
 ## [0.5.0] - 2026-07-21
 

--- a/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
+++ b/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
@@ -133,6 +133,13 @@ class PlayerService : MediaLibraryService() {
                 true,
             )
             .setHandleAudioBecomingNoisy(true)
+            // Player's default seekToPrevious() (what hardware/Bluetooth "previous" calls)
+            // restarts the current item instead of moving back unless playback position is
+            // under this threshold — meant for "restart the song" on a track you're a few
+            // seconds into. There's no such position to rewind to on a live station, so with
+            // the 3s default, "previous" almost always just replays the current station
+            // instead of moving to the one before it. Zero makes it always move back.
+            .setMaxSeekToPreviousPositionMs(0)
             .build()
         // Wraps skip next/previous around a browsed list's queue (e.g. Android Auto's mood
         // folders), matching the phone UI's circular swipe-through-favourites pager.


### PR DESCRIPTION
## Summary
- Player's default `seekToPrevious()` (what the hardware/Bluetooth previous button calls) restarts the current item unless playback position is under `maxSeekToPreviousPositionMs` (3s default) — meant for restarting a track you're a few seconds into.
- Live radio has no position to rewind to, so previous almost always just replayed the current station instead of moving back.
- Set `maxSeekToPreviousPositionMs` to 0 so previous always moves back.

Fixes #120

## Test plan
- [x] `./gradlew test lint` passes
- [x] Installed debug build on device
- [ ] Confirm Bluetooth previous moves to the prior station, not a replay (device owner to verify)