### PR TITLE
fix(artwork): adaptive logo plate contrast and Recently Played logos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - Playing from favourites over Bluetooth no longer crashes the car's Bluetooth connection when skipping stations. (#123)
 - The Bluetooth previous control now moves to the previous station instead of replaying the current one. (#120)
+- White-on-transparent SVG logos are no longer unreadable, and station logo plates now use the device's dynamic-color palette instead of a fixed white background. (#121, #122)
+- Recently Played now shows a user's own locally-saved logo (including custom-uploaded SVGs) instead of falling back to a blank avatar when the registry has none. (#119)
+- Search results show a station-initial letter, matching Recently Played, when there's no logo or it fails to load.
 
 ## [0.5.0] - 2026-07-21
 

--- a/app/src/main/java/com/shapeshed/aerial/CoilBitmapLoader.kt
+++ b/app/src/main/java/com/shapeshed/aerial/CoilBitmapLoader.kt
@@ -45,6 +45,6 @@ class CoilBitmapLoader(private val context: Context) : BitmapLoader {
             // transparent-background logo (e.g. an SVG whose fill depends on a
             // prefers-color-scheme our decoder doesn't evaluate) would otherwise render
             // invisible against the system's own dark quick-controls/notification backdrop.
-            result.image.toOpaqueBitmap()
+            result.image.toOpaqueBitmap(context)
         }
 }

--- a/app/src/main/java/com/shapeshed/aerial/ui/LogoFiles.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/LogoFiles.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.net.Uri
+import android.os.Build
 import com.shapeshed.aerial.ArtworkProvider
 import com.shapeshed.aerial.R
 import android.webkit.MimeTypeMap
@@ -68,7 +69,7 @@ suspend fun ensureMediaArtworkForLogo(context: Context, file: File): File {
             .size(512)
             .build()
         val result = svgLoader(context).execute(request) as? SuccessResult ?: return file
-        val bitmap = result.image.toOpaqueBitmap()
+        val bitmap = result.image.toOpaqueBitmap(context)
         pngFile.outputStream().use { output ->
             bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
         }
@@ -114,7 +115,7 @@ suspend fun cachedRemoteArtworkUri(context: Context, logoUrl: String): Uri? {
         val result = withTimeoutOrNull(ARTWORK_FETCH_TIMEOUT_MS) {
             SingletonImageLoader.get(context).execute(request)
         } as? SuccessResult ?: return null
-        val bitmap = result.image.toOpaqueBitmap()
+        val bitmap = result.image.toOpaqueBitmap(context)
         cacheDir.mkdirs()
         // Write-then-rename so a concurrent request (Android Auto prefetches folders in
         // parallel) or a mid-write process kill can never expose a truncated PNG under the
@@ -184,20 +185,14 @@ private fun String.extensionOrNull(): String? {
 }
 
 /**
- * Rasterizes a Coil [Image] onto an opaque background. System media surfaces (quick controls,
- * lock screen, Bluetooth AVRCP, Android Auto) draw an artwork bitmap with no guaranteed
- * background behind it, so a source image with transparent areas can end up invisible against
- * a dark system theme — notably an SVG logo that uses `prefers-color-scheme` to pick between a
- * black and white fill, which our SVG decoder doesn't evaluate, so it always renders the
- * non-media-query default (typically a black path on a transparent canvas). Compositing onto
- * solid white keeps the logo visible regardless of what surrounds it.
+ * Renders a Coil [Image] to a same-size ARGB bitmap, preserving its own transparency —
+ * shared decode step behind [toOpaqueBitmap] and [isPredominantlyLight].
  */
-fun Image.toOpaqueBitmap(backgroundColor: Int = android.graphics.Color.WHITE): Bitmap {
+private fun Image.toTransparentBitmap(): Bitmap {
     val width = width.takeIf { it > 0 } ?: 512
     val height = height.takeIf { it > 0 } ?: 512
     val bitmap = createBitmap(width, height)
     val canvas = Canvas(bitmap)
-    canvas.drawColor(backgroundColor)
     when {
         // A hardware bitmap can't be drawn into a software Canvas ("Software rendering doesn't
         // support hardware bitmaps") — copy() does the GPU-to-software readback instead.
@@ -208,3 +203,90 @@ fun Image.toOpaqueBitmap(backgroundColor: Int = android.graphics.Color.WHITE): B
     }
     return bitmap
 }
+
+/**
+ * Rasterizes a Coil [Image] onto an opaque background. System media surfaces (quick controls,
+ * lock screen, Bluetooth AVRCP, Android Auto) draw an artwork bitmap with no guaranteed
+ * background behind it, so a source image with transparent areas can end up invisible against
+ * a dark system theme — notably an SVG logo that uses `prefers-color-scheme` to pick between a
+ * black and white fill, which our SVG decoder doesn't evaluate, so it always renders the
+ * non-media-query default. A single fixed background makes one or the other invisible (#121),
+ * so the backdrop contrasts with the logo's own [isPredominantlyLightBitmap] rather than
+ * always being white — using the device's own dynamic-color neutral tones ([adaptiveNeutral])
+ * rather than a fixed hardcoded color, matching the Compose UI's use of dynamic color, since
+ * these surfaces have no MaterialTheme to draw from.
+ */
+fun Image.toOpaqueBitmap(context: Context): Bitmap {
+    val content = toTransparentBitmap()
+    val backgroundColor = context.adaptiveNeutral(dark = content.isPredominantlyLightBitmap())
+    val bitmap = createBitmap(content.width, content.height)
+    val canvas = Canvas(bitmap)
+    canvas.drawColor(backgroundColor)
+    canvas.drawBitmap(content, 0f, 0f, null)
+    return bitmap
+}
+
+/**
+ * A neutral tone from the device's Material You wallpaper-derived dynamic color palette
+ * (Android 12+), falling back to a fixed near-black/white on older devices where dynamic
+ * color doesn't exist.
+ */
+private fun Context.adaptiveNeutral(dark: Boolean): Int {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        val resId = if (dark) android.R.color.system_neutral1_900 else android.R.color.system_neutral1_50
+        return getColor(resId)
+    }
+    return if (dark) SYSTEM_SURFACE_DARK_PLATE_FALLBACK else android.graphics.Color.WHITE
+}
+
+/**
+ * Whether an image's own rendered content reads as light-colored overall. Used to pick a
+ * plate/backdrop that contrasts with the logo itself (light logo -> dark plate, dark logo ->
+ * light plate) rather than a single fixed background that makes one of the two invisible
+ * (#121).
+ */
+fun Image.isPredominantlyLight(): Boolean = toTransparentBitmap().isPredominantlyLightBitmap()
+
+private fun Bitmap.isPredominantlyLightBitmap(): Boolean {
+    val pixels = IntArray(width * height)
+    getPixels(pixels, 0, width, 0, 0, width, height)
+    var luminanceSum = 0.0
+    var opaquePixelCount = 0
+    for (pixel in pixels) {
+        // Ignoring near-transparent pixels means a mostly-transparent SVG canvas doesn't
+        // dilute the average toward "dark" regardless of its actual foreground color.
+        if (android.graphics.Color.alpha(pixel) < MIN_OPAQUE_ALPHA) continue
+        luminanceSum += 0.299 * android.graphics.Color.red(pixel) +
+            0.587 * android.graphics.Color.green(pixel) +
+            0.114 * android.graphics.Color.blue(pixel)
+        opaquePixelCount++
+    }
+    return opaquePixelCount > 0 && (luminanceSum / opaquePixelCount) > MID_LUMINANCE
+}
+
+private const val MIN_OPAQUE_ALPHA = 32
+private const val MID_LUMINANCE = 127.5
+
+/**
+ * Whether this image has any transparent margin of its own to justify an inset+plate
+ * treatment. A full-bleed square "brand tile" logo (opaque corner to corner, common for
+ * uploaded station artwork) is already complete artwork — insetting it just to reveal an
+ * unwanted plate-colored border looks wrong; that treatment is only for icon-style artwork
+ * drawn with its own transparent margin.
+ */
+fun Image.hasTransparentMargin(): Boolean {
+    val bitmap = toTransparentBitmap()
+    val right = bitmap.width - 1
+    val bottom = bitmap.height - 1
+    if (right < 0 || bottom < 0) return false
+    return listOf(
+        bitmap.getPixel(0, 0),
+        bitmap.getPixel(right, 0),
+        bitmap.getPixel(0, bottom),
+        bitmap.getPixel(right, bottom),
+    ).any { android.graphics.Color.alpha(it) < MIN_OPAQUE_ALPHA }
+}
+
+// MD3 baseline Neutral-10 (on-surface dark tone) — pre-API-31 fallback for adaptiveNeutral(),
+// on devices with no dynamic color palette to draw from.
+private const val SYSTEM_SURFACE_DARK_PLATE_FALLBACK = 0xFF1D1B20.toInt()

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -161,7 +161,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
@@ -708,8 +708,10 @@ fun MainScreen(
                                 label = "miniPlayerArtwork",
                             ) { model ->
                                 if (model != null) {
+                                    var miniArtworkIsLight by remember(model) { mutableStateOf(false) }
                                     Surface(
                                         shape = MaterialTheme.shapes.small,
+                                        color = stationLogoPlateColor(miniArtworkIsLight),
                                         modifier = Modifier.size(52.dp),
                                     ) {
                                         AsyncImage(
@@ -717,6 +719,9 @@ fun MainScreen(
                                             contentDescription = null,
                                             contentScale = ContentScale.Crop,
                                             onError = { miniArtworkFailed = true },
+                                            onSuccess = { state ->
+                                                miniArtworkIsLight = state.result.image.isPredominantlyLight()
+                                            },
                                             modifier = Modifier.fillMaxSize(),
                                         )
                                     }
@@ -1245,7 +1250,18 @@ private fun FavoriteResultItem(
     ListItem(
         modifier = Modifier.fillMaxWidth().clickable(onClick = onTap),
         leadingContent = {
-            StationAvatar(station = station, isActive = false, size = 50.dp)
+            val context = LocalContext.current
+            val logoModel = logoModelFor(station.logoPath)
+            val imageRequest = logoModel?.let {
+                remember(context, it) { ImageRequest.Builder(context).data(it).build() }
+            }
+            StationLogoCircle(logoModel = imageRequest, size = 50.dp) {
+                Text(
+                    text = station.name.avatarInitial(),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         },
         supportingContent = if (countryLabel.isNotBlank()) {
             {
@@ -1326,14 +1342,13 @@ private fun RegistryResultItem(
         modifier = Modifier.fillMaxWidth().clickable(onClick = onTap),
         leadingContent = {
             StationLogoCircle(
-                logoModel = station.logoUrl.takeIf { it.isNotBlank() },
+                logoModel = logoModelFor(station.logoUrl),
                 size = 50.dp,
             ) {
-                Icon(
-                    imageVector = Icons.Rounded.Radio,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(26.dp),
+                Text(
+                    text = station.name.avatarInitial(),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         },
@@ -1844,7 +1859,7 @@ private fun MoodStationRow(
         leadingContent = {
             // Circle rather than a rounded square, matching the search and favourites rows.
             StationLogoCircle(
-                logoModel = station.logoUrl.takeIf { it.isNotBlank() },
+                logoModel = logoModelFor(station.logoUrl),
                 size = 56.dp,
             ) {
                 Icon(
@@ -2279,6 +2294,8 @@ private fun StationListRow(
     }
 }
 
+private const val GRID_LOGO_INSET_FRACTION = 0.85f
+
 @Composable
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 private fun StationTile(
@@ -2298,18 +2315,16 @@ private fun StationTile(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier,
     ) {
-        val logoModel = when {
-            station.logoPath.startsWith("http") -> station.logoPath
-            station.logoPath.isNotEmpty() -> File(station.logoPath)
-            else -> null
-        }
+        val logoModel = logoModelFor(station.logoPath)
         var logoFailed by remember(logoModel) { mutableStateOf(false) }
+        var logoIsLight by remember(logoModel) { mutableStateOf(false) }
+        var logoHasMargin by remember(logoModel) { mutableStateOf(false) }
         val showLogo = logoModel != null && !logoFailed
 
         Surface(
-            // Same plate treatment as the other artwork surfaces: the light adaptive plate
-            // behind rendered logos (visible only through transparency), tonal otherwise.
-            color = if (showLogo) stationLogoPlateColor() else tileColor,
+            // Same plate treatment as the other artwork surfaces: an adaptive plate behind
+            // rendered logos (visible only through transparency), tonal otherwise.
+            color = if (showLogo) stationLogoPlateColor(logoIsLight) else tileColor,
             // Medium card radius like the other cards: a fixed 28dp reads far rounder on
             // the small tiles of a 4-5 column grid, so keep the modest spec radius at
             // every grid width.
@@ -2340,7 +2355,19 @@ private fun StationTile(
                         contentDescription = null,
                         contentScale = ContentScale.Fit,
                         onError = { logoFailed = true },
-                        modifier = Modifier.fillMaxSize(),
+                        onSuccess = { state ->
+                            val image = state.result.image
+                            logoIsLight = image.isPredominantlyLight()
+                            logoHasMargin = image.hasTransparentMargin()
+                        },
+                        // Breathing room per the MD3 spacing scale so a logo doesn't read
+                        // cramped against the card's rounded corners — but only when the logo
+                        // actually has a transparent margin of its own: a full-bleed square
+                        // "brand tile" logo has no margin to reveal, so insetting it would
+                        // just add an unwanted plate-colored border around complete artwork.
+                        // A fraction, not a fixed dp, so it scales with the tile size across
+                        // the user's chosen grid column count instead of ballooning at 8 columns.
+                        modifier = Modifier.fillMaxSize(if (logoHasMargin) GRID_LOGO_INSET_FRACTION else 1f),
                     )
                     if (isActive) {
                         Box(
@@ -2553,6 +2580,28 @@ private fun FilterPickerSheetContent(
     }
 }
 
+// Grapheme-safe "first letter" for a station-name fallback avatar. take(1) slices by UTF-16
+// code unit, not code point — a name starting with a supplementary-plane character (some
+// emoji, rare CJK extensions) would cut a lone surrogate half and render as a broken glyph.
+// codePointAt/charCount takes the full code point regardless of whether it's one or two chars.
+private fun String.avatarInitial(): String {
+    val trimmed = trim()
+    if (trimmed.isEmpty()) return ""
+    val charCount = Character.charCount(trimmed.codePointAt(0))
+    return trimmed.substring(0, charCount).uppercase()
+}
+
+// A logo path is either a remote URL or a local file path — the latter needs wrapping in a
+// File so Coil resolves it, rather than trying (and failing) to treat it as a bare URI string.
+// Recently-played entries in particular can carry a local path here: they're backed by
+// RegistryStation, but MainViewModel substitutes a locally-saved station's own logoPath when
+// the registry's copy has none.
+private fun logoModelFor(path: String): Any? = when {
+    path.startsWith("http") -> path
+    path.isNotEmpty() -> File(path)
+    else -> null
+}
+
 @Composable
 private fun ForYouStationCard(
     station: com.shapeshed.aerial.data.RegistryStation,
@@ -2570,11 +2619,11 @@ private fun ForYouStationCard(
             modifier = Modifier.padding(12.dp).fillMaxSize(),
         ) {
             StationLogoCircle(
-                logoModel = station.logoUrl.takeIf { it.isNotBlank() },
+                logoModel = logoModelFor(station.logoUrl),
                 size = 60.dp,
             ) {
                 Text(
-                    text = station.name.take(1).uppercase(),
+                    text = station.name.avatarInitial(),
                     style = MaterialTheme.typography.headlineMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -2590,20 +2639,30 @@ private fun ForYouStationCard(
     }
 }
 
-// Plate behind station artwork: near-white for legibility of arbitrary third-party logos
-// (a dark tonal plate would swallow dark transparent marks), tinted toward the dynamic
-// palette so it follows the system theme like the rest of the app.
+// Plate behind station artwork, shown through transparent regions of third-party logos.
+// Device-palette tokens, not a fixed color, so it follows the system/dynamic theme: the
+// default (dark-on-transparent logos, the common case) is the theme-following container tone;
+// a light-on-transparent logo (e.g. white marks meant for a dark backdrop) would go invisible
+// on that same tone, so it gets the theme-inverse pairing instead, which is always guaranteed
+// to contrast (#121, #122).
+//
+// inverseSurface inverts relative to the *current theme*, not relative to the logo: in dark
+// theme inverseSurface is a light tone, so naively picking it whenever the logo is light
+// produces light-on-light in dark theme (the theme-following default, surfaceContainerHighest,
+// is already dark there and already contrasts fine with a light logo). The default only needs
+// overriding when the logo's own polarity matches the theme's natural one — light logo in
+// light theme, or dark logo in dark theme — which is what the XOR below checks for.
 @Composable
-fun stationLogoPlateColor(): androidx.compose.ui.graphics.Color = lerp(
-    androidx.compose.ui.graphics.Color.White,
-    MaterialTheme.colorScheme.primaryContainer,
-    0.22f,
-)
+fun stationLogoPlateColor(isLogoLight: Boolean): androidx.compose.ui.graphics.Color {
+    val isDarkTheme = MaterialTheme.colorScheme.surface.luminance() < 0.5f
+    val needsInverse = isDarkTheme != isLogoLight
+    return if (needsInverse) MaterialTheme.colorScheme.inverseSurface else MaterialTheme.colorScheme.surfaceContainerHighest
+}
 
-// Circular station logo on a light plate. The plate shows through transparent regions of
-// third-party artwork so every logo sits on a consistent background, and it is never a
-// visible ring because the artwork fills the circle. Stations without a usable logo keep a
-// tonal circle behind the fallback content instead of the plate.
+// Circular station logo on a plate. The plate shows through transparent regions of third-party
+// artwork so every logo sits on a consistent background, and it is never a visible ring because
+// the artwork fills the circle. Stations without a usable logo keep a tonal circle behind the
+// fallback content instead of the plate.
 @Composable
 fun StationLogoCircle(
     logoModel: Any?,
@@ -2613,13 +2672,14 @@ fun StationLogoCircle(
     fallback: @Composable () -> Unit,
 ) {
     var logoFailed by remember(logoModel) { mutableStateOf(false) }
+    var logoIsLight by remember(logoModel) { mutableStateOf(false) }
     val showLogo = logoModel != null && !logoFailed
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
             .size(size)
             .clip(CircleShape)
-            .background(if (showLogo) stationLogoPlateColor() else fallbackBackground),
+            .background(if (showLogo) stationLogoPlateColor(logoIsLight) else fallbackBackground),
     ) {
         if (showLogo) {
             AsyncImage(
@@ -2627,6 +2687,7 @@ fun StationLogoCircle(
                 contentDescription = null,
                 contentScale = ContentScale.Fit,
                 onError = { logoFailed = true },
+                onSuccess = { state -> logoIsLight = state.result.image.isPredominantlyLight() },
                 modifier = Modifier.fillMaxSize(),
             )
         } else {
@@ -2643,12 +2704,7 @@ fun StationAvatar(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    val logoPath = station.logoPath
-    val logoModel = when {
-        logoPath.startsWith("http") -> logoPath
-        logoPath.isNotEmpty() -> File(logoPath)
-        else -> null
-    }
+    val logoModel = logoModelFor(station.logoPath)
     val imageRequest = logoModel?.let {
         remember(context, it) { ImageRequest.Builder(context).data(it).build() }
     }

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -145,7 +145,20 @@ class MainViewModel(
         viewModelScope.launch {
             repository.recentlyPlayedAsFlow(RECENTLY_PLAYED_LIMIT)
                 .map { entries ->
-                    entries.mapNotNull { registryRepository.getByProviderId(it.provider, it.providerId) }
+                    entries.mapNotNull { entry ->
+                        val registryStation = registryRepository.getByProviderId(entry.provider, entry.providerId)
+                            ?: return@mapNotNull null
+                        // The registry's own copy may have no logo, or one the user has
+                        // replaced locally (e.g. a custom-uploaded SVG) — prefer the user's
+                        // saved station's artwork when this station is saved locally.
+                        val localLogoPath = repository.findMatching(registryStation)
+                            ?.logoPath?.takeIf { it.isNotBlank() }
+                        if (localLogoPath != null) {
+                            registryStation.copy(logoUrl = localLogoPath)
+                        } else {
+                            registryStation
+                        }
+                    }
                 }
                 .collect {
                     _recentlyPlayedStations.value = it

--- a/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
@@ -195,6 +195,7 @@ fun NowPlayingScreen(
     }
     var mainArtworkFailed by remember(activeArtworkModel) { mutableStateOf(false) }
     var trackArtworkFailed by remember(trackArtworkModel) { mutableStateOf(false) }
+    var trackArtworkIsLight by remember(trackArtworkModel) { mutableStateOf(false) }
     // The track flows reset asynchronously when the station changes, so for a frame or two
     // the previous station's song can pair with the new station. Hide the track card from
     // the moment the station changes until that reset has been observed, so stale track
@@ -540,17 +541,20 @@ fun NowPlayingScreen(
                                 modifier = Modifier.size(52.dp),
                             ) {
                                 if (trackArtworkModel != null && !trackArtworkFailed) {
-                                    // Same light adaptive plate as the other artwork surfaces,
+                                    // Same adaptive plate as the other artwork surfaces,
                                     // visible only through transparent artwork.
                                     AsyncImage(
                                         model = trackArtworkModel,
                                         contentDescription = null,
                                         contentScale = ContentScale.Crop,
                                         onError = { trackArtworkFailed = true },
+                                        onSuccess = { state ->
+                                            trackArtworkIsLight = state.result.image.isPredominantlyLight()
+                                        },
                                         modifier = Modifier
                                             .fillMaxSize()
                                             .clip(MaterialTheme.shapes.small)
-                                            .background(stationLogoPlateColor()),
+                                            .background(stationLogoPlateColor(trackArtworkIsLight)),
                                     )
                                 } else {
                                     Surface(
@@ -665,7 +669,7 @@ fun NowPlayingScreen(
                     shape = MaterialTheme.shapes.extraLarge,
                     // Plate behind rendered artwork, matching the main artwork surface.
                     color = if (trackArtworkModel != null && !trackArtworkFailed) {
-                        stationLogoPlateColor()
+                        stationLogoPlateColor(trackArtworkIsLight)
                     } else {
                         MaterialTheme.colorScheme.primaryContainer
                     },
@@ -685,6 +689,9 @@ fun NowPlayingScreen(
                             contentDescription = null,
                             contentScale = ContentScale.Crop,
                             onError = { trackArtworkFailed = true },
+                            onSuccess = { state ->
+                                trackArtworkIsLight = state.result.image.isPredominantlyLight()
+                            },
                             modifier = Modifier.fillMaxSize(),
                         )
                     } else {
@@ -762,13 +769,14 @@ private fun StationArtworkSurface(
     onArtworkError: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var artworkIsLight by remember(artworkModel) { mutableStateOf(false) }
     Surface(
         shape = shape,
-        // Light palette-tinted plate behind rendered artwork so transparent station logos
-        // (and letterboxed images) sit on a consistent background; the tonal container
-        // shows only for the avatar fallback.
+        // Adaptive plate behind rendered artwork so transparent station logos (and
+        // letterboxed images) sit on a consistent, contrasting background; the tonal
+        // container shows only for the avatar fallback.
         color = if (artworkModel != null) {
-            stationLogoPlateColor()
+            stationLogoPlateColor(artworkIsLight)
         } else {
             MaterialTheme.colorScheme.primaryContainer
         },
@@ -796,6 +804,7 @@ private fun StationArtworkSurface(
                     // surface colour fills the letterbox space.
                     contentScale = ContentScale.Fit,
                     onError = { onArtworkError() },
+                    onSuccess = { state -> artworkIsLight = state.result.image.isPredominantlyLight() },
                     modifier = Modifier.fillMaxSize(),
                 )
             } else {


### PR DESCRIPTION
## Summary
- Logo "plate" background is now content-adaptive (contrasts with the logo's own luminance) and theme-following, using device dynamic-color tokens instead of a fixed white — fixes unreadable white-on-transparent logos and the jarring light plate in dark theme. Fixes #121, #122
- Grid tiles get proportional inset+plate only when the logo has a real transparent margin, so full-bleed opaque logos aren't given an unwanted border.
- Recently Played now prefers a locally-saved station's own logo (e.g. a custom-uploaded SVG) instead of always deferring to the registry's copy, which may have none. Fixes #119
- Consolidated five duplicated copies of the http-check/File-wrap logo model resolution into one `logoModelFor()` helper.
- Search results show a station-initial letter (matching Recently Played) instead of a generic icon on missing/failed logos, using a code-point-safe initial for non-Latin/emoji names.

## Test plan
- [x] `./gradlew test lint` passes
- [x] Verified on device: Recently Played, favourites grid, Home rows, and search results all show correct contrast in dark theme (RTE 2FM, Heart 80s/UK, BBC Radio 4)
- [x] Verified grid padding is proportional and skipped for opaque logos (Radio alHara, Refuge Worldwide)