### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Aerial will be documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and version numbers should follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once public releases begin.
 
-## [Unreleased]
+## [0.5.1] - 2026-07-24
 
 ### Fixed
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,8 +32,8 @@ android {
         applicationId "com.shapeshed.aerial"
         minSdk 26
         targetSdk 37
-        versionCode 13
-        versionName "0.5.0"
+        versionCode 14
+        versionName "0.5.1"
     }
 
     signingConfigs {

--- a/fastlane/metadata/android/en-US/changelogs/14.txt
+++ b/fastlane/metadata/android/en-US/changelogs/14.txt
@@ -1,0 +1,1 @@
+Fixed a Bluetooth crash when skipping favourite stations in the car. Bluetooth previous now moves to the prior station instead of replaying the current one. Fixed unreadable white station logos and jarring light backgrounds in dark mode. Recently Played now shows your own saved logo instead of a blank avatar. Search results show a station initial when there's no logo.


### PR DESCRIPTION
## Summary
Bump to v0.5.1 (versionCode 14).

### Fixed
- Playing from favourites over Bluetooth no longer crashes the car's Bluetooth connection when skipping stations. (#123)
- The Bluetooth previous control now moves to the previous station instead of replaying the current one. (#120)
- White-on-transparent SVG logos are no longer unreadable, and station logo plates now use the device's dynamic-color palette instead of a fixed white background. (#121, #122)
- Recently Played now shows a user's own locally-saved logo (including custom-uploaded SVGs) instead of falling back to a blank avatar when the registry has none. (#119)
- Search results show a station-initial letter, matching Recently Played, when there's no logo or it fails to load.

## Test plan
- [x] `scripts/prepare-release.sh --skip-fdroid` passed (test, lint, assembleRelease, bundleRelease)
- [ ] F-Droid metadata sync skipped (no local fdroiddata checkout) — not required for this PR
- [ ] Tag `v0.5.1` and push after this merges, to trigger Play production publish