### PR TITLE
feat(playback): resolve .pls/.m3u/.asx playlist stream URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Aerial will be documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and version numbers should follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once public releases begin.
 
+## [Unreleased]
+
+### Added
+
+- Stations whose stream URL is a `.pls`, `.m3u`, or `.asx` playlist now play — the underlying stream URL is resolved at play time. (#129)
+
 ## [0.5.1] - 2026-07-24
 
 ### Fixed

--- a/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
+++ b/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
@@ -16,6 +16,7 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.extractor.metadata.icy.IcyInfo
 import androidx.media3.extractor.metadata.id3.ApicFrame
 import androidx.media3.extractor.metadata.id3.TextInformationFrame
@@ -46,6 +47,8 @@ import com.shapeshed.aerial.data.NowPlayingInfo
 import com.shapeshed.aerial.data.NowPlayingStore
 import com.shapeshed.aerial.data.PlayHistoryEntry
 import com.shapeshed.aerial.data.RECENT_ID
+import com.shapeshed.aerial.data.httpGetText
+import com.shapeshed.aerial.data.resolveStreamUrl
 import com.shapeshed.aerial.data.RegistryRepository
 import com.shapeshed.aerial.data.SLEEP_TIMER_DURATION_MS
 import com.shapeshed.aerial.data.SleepTimerState
@@ -112,8 +115,21 @@ class PlayerService : MediaLibraryService() {
             .setAllowCrossProtocolRedirects(true)
             .setConnectTimeoutMs(HTTP_TIMEOUT_MS)
             .setReadTimeoutMs(HTTP_TIMEOUT_MS)
+        // Some stations' stream URLs point at a .pls/.m3u/.asx playlist file rather than the
+        // audio itself. ExoPlayer can't play those containers, so unwrap them to the real
+        // stream URL here — on the loader thread, right before the connection opens, so the
+        // fetch is lazy (per item, including queue neighbours) and never touches the UI thread.
+        // A non-playlist URL (the vast majority) passes through untouched with no network cost;
+        // a playlist that can't be fetched or parsed also passes through, surfacing the normal
+        // playback error. Note: a playlist resolving to HLS (.m3u8) won't switch ExoPlayer to
+        // its HLS source type, since resolution happens below source selection — rare in practice.
+        val playlistResolvingFactory = ResolvingDataSource.Factory(httpDataSourceFactory) { dataSpec ->
+            val original = dataSpec.uri.toString()
+            val resolved = resolveStreamUrl(original) { httpGetText(it) }
+            if (resolved == original) dataSpec else dataSpec.withUri(Uri.parse(resolved))
+        }
         val mediaSourceFactory = DefaultMediaSourceFactory(this)
-            .setDataSourceFactory(httpDataSourceFactory)
+            .setDataSourceFactory(playlistResolvingFactory)
         val loadControl = DefaultLoadControl.Builder()
             .setBufferDurationsMs(
                 MIN_BUFFER_MS,

--- a/app/src/main/java/com/shapeshed/aerial/data/HttpUtils.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/HttpUtils.kt
@@ -11,7 +11,7 @@ internal val AERIAL_USER_AGENT = "Aerial/${BuildConfig.VERSION_NAME} (Android)"
  * GET [url] and return the response body as a string, or null on any error or non-2xx status.
  * Caller is responsible for running this on a background thread (e.g. Dispatchers.IO).
  */
-internal fun httpGetJson(url: String, extraHeaders: Map<String, String> = emptyMap()): String? {
+internal fun httpGetText(url: String, extraHeaders: Map<String, String> = emptyMap()): String? {
     return try {
         val conn = URL(url).openConnection() as HttpURLConnection
         conn.connectTimeout = 10_000
@@ -28,6 +28,10 @@ internal fun httpGetJson(url: String, extraHeaders: Map<String, String> = emptyM
         null
     }
 }
+
+/** [httpGetText] under its original name, kept for the metadata/JSON callers. */
+internal fun httpGetJson(url: String, extraHeaders: Map<String, String> = emptyMap()): String? =
+    httpGetText(url, extraHeaders)
 
 /**
  * POST [body] (JSON) to [url] and return the response body, or null on any error or non-2xx status.

--- a/app/src/main/java/com/shapeshed/aerial/data/PlaylistResolver.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/PlaylistResolver.kt
@@ -1,0 +1,120 @@
+package com.shapeshed.aerial.data
+
+import java.net.URI
+
+/**
+ * Playlist container formats Aerial unwraps to a direct stream URL at play time. A station's
+ * stream URL is sometimes a link to one of these small text files rather than the audio itself
+ * (common for SHOUTcast/Icecast and older Windows Media stations), and ExoPlayer can't play the
+ * container — it has to be fetched and the real stream URL extracted first.
+ */
+private enum class PlaylistFormat { PLS, M3U, ASX }
+
+/**
+ * True if [url]'s path ends in a playlist container extension we can unwrap (.pls, .m3u, .asx).
+ *
+ * `.m3u8` is deliberately NOT a playlist here — that's an HLS manifest ExoPlayer streams
+ * natively, so it must pass straight through untouched. Detection is by extension only (no
+ * network, no Content-Type): the check runs before every stream open, so the direct-audio
+ * majority must stay free, and radio servers routinely mislabel playlist Content-Types anyway.
+ */
+internal fun isPlaylistUrl(url: String): Boolean = playlistFormatFromExtension(url) != null
+
+private fun playlistFormatFromExtension(url: String): PlaylistFormat? {
+    val path = url.substringBefore('?').substringBefore('#').lowercase()
+    return when {
+        path.endsWith(".pls") -> PlaylistFormat.PLS
+        path.endsWith(".m3u8") -> null
+        path.endsWith(".m3u") -> PlaylistFormat.M3U
+        path.endsWith(".asx") -> PlaylistFormat.ASX
+        else -> null
+    }
+}
+
+/**
+ * Resolve [url] to a direct stream URL by fetching and unwrapping playlist containers, following
+ * nested playlists up to [maxHops] deep. [fetch] returns a URL's body or null on any failure.
+ *
+ * Returns the original [url] unchanged when it isn't a playlist, can't be fetched, or can't be
+ * parsed — callers hand that straight to ExoPlayer, which surfaces the normal playback error.
+ * [fetch] is injected so this stays a pure function (unit-testable without a network).
+ */
+internal fun resolveStreamUrl(url: String, maxHops: Int = 3, fetch: (String) -> String?): String {
+    var current = url
+    repeat(maxHops) {
+        if (!isPlaylistUrl(current)) return current
+        val body = fetch(current) ?: return current
+        val next = parsePlaylist(body, current) ?: return current
+        if (next == current) return current
+        current = next
+    }
+    return current
+}
+
+/**
+ * Parse a fetched playlist [body] and return the first stream URL, or null if none is found.
+ * [sourceUrl] is the playlist's own URL — its extension picks the format, and it resolves any
+ * relative entry to an absolute URL.
+ *
+ * The extension chooses the parser, but a differing body sniff is tried as a fallback so a
+ * mislabelled file (e.g. a `.pls` URL whose body is actually m3u) still resolves.
+ */
+internal fun parsePlaylist(body: String, sourceUrl: String): String? {
+    val clean = body.trimStart('\uFEFF')
+    val candidates = listOfNotNull(playlistFormatFromExtension(sourceUrl), sniffFormat(clean)).distinct()
+    for (format in candidates) {
+        val entry = when (format) {
+            PlaylistFormat.PLS -> parsePls(clean)
+            PlaylistFormat.M3U -> parseM3u(clean)
+            PlaylistFormat.ASX -> parseAsx(clean)
+        }
+        if (entry != null) return absolutize(entry, sourceUrl)
+    }
+    return null
+}
+
+private fun sniffFormat(body: String): PlaylistFormat? {
+    val head = body.trimStart().take(256).lowercase()
+    return when {
+        head.startsWith("[playlist]") -> PlaylistFormat.PLS
+        head.startsWith("<asx") -> PlaylistFormat.ASX
+        head.startsWith("#extm3u") -> PlaylistFormat.M3U
+        else -> null
+    }
+}
+
+// FileN=<url>: capture N so the lowest-numbered entry (the primary stream) wins.
+private val PLS_FILE_REGEX = Regex("(?i)File(\\d+)\\s*=\\s*(.+)")
+
+private fun parsePls(body: String): String? =
+    body.lineSequence()
+        .mapNotNull { line ->
+            val match = PLS_FILE_REGEX.matchEntire(line.trim()) ?: return@mapNotNull null
+            val index = match.groupValues[1].toIntOrNull() ?: return@mapNotNull null
+            val url = match.groupValues[2].trim()
+            if (url.isEmpty()) null else index to url
+        }
+        .minByOrNull { it.first }
+        ?.second
+
+private fun parseM3u(body: String): String? =
+    body.lineSequence()
+        .map { it.trim() }
+        .firstOrNull { it.isNotEmpty() && !it.startsWith("#") }
+
+// ASX is frequently not well-formed XML (uppercase tags, unquoted or unclosed elements), so a
+// tolerant match for the first <ref href="..."> beats a strict XML parser — and keeps this file
+// free of Android framework XML APIs so it stays unit-testable on the plain JVM.
+private val ASX_REF_REGEX = Regex("(?i)<ref\\b[^>]*\\bhref\\s*=\\s*[\"']([^\"']+)[\"']")
+
+private fun parseAsx(body: String): String? =
+    ASX_REF_REGEX.find(body)?.groupValues?.get(1)?.trim()?.takeIf { it.isNotEmpty() }
+
+private fun absolutize(entry: String, baseUrl: String): String {
+    return try {
+        if (URI(entry).isAbsolute) entry else URI(baseUrl).resolve(entry).toString()
+    } catch (_: Exception) {
+        // Not parseable as a URI (unusual entry) — hand it back as-is and let ExoPlayer judge it.
+        entry
+    }
+}

--- a/app/src/test/java/com/shapeshed/aerial/data/PlaylistResolverTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/data/PlaylistResolverTest.kt
@@ -1,0 +1,150 @@
+package com.shapeshed.aerial.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaylistResolverTest {
+
+    @Test
+    fun isPlaylistUrlDetectsSupportedExtensions() {
+        assertTrue(isPlaylistUrl("https://example.com/stream.pls"))
+        assertTrue(isPlaylistUrl("https://example.com/stream.m3u"))
+        assertTrue(isPlaylistUrl("https://example.com/stream.asx"))
+        assertTrue(isPlaylistUrl("https://example.com/STREAM.PLS"))
+        assertTrue(isPlaylistUrl("https://example.com/stream.pls?token=abc#frag"))
+    }
+
+    @Test
+    fun isPlaylistUrlExcludesHlsAndDirectStreams() {
+        assertFalse(isPlaylistUrl("https://example.com/master.m3u8"))
+        assertFalse(isPlaylistUrl("https://example.com/live.mp3"))
+        assertFalse(isPlaylistUrl("https://example.com/live/aac"))
+        assertFalse(isPlaylistUrl("https://example.com/stream?type=.pls"))
+    }
+
+    @Test
+    fun parsesPlsLowestNumberedEntry() {
+        val body = """
+            [playlist]
+            NumberOfEntries=2
+            File2=https://example.com/backup.mp3
+            File1=https://example.com/primary.mp3
+            Title1=Primary
+            Version=2
+        """.trimIndent()
+        assertEquals("https://example.com/primary.mp3", parsePlaylist(body, "https://host/x.pls"))
+    }
+
+    @Test
+    fun parsesPlsWithWhitespaceAndCrlf() {
+        val body = "[playlist]\r\nFile1 = https://example.com/stream.aac \r\nNumberOfEntries=1\r\n"
+        assertEquals("https://example.com/stream.aac", parsePlaylist(body, "https://host/x.pls"))
+    }
+
+    @Test
+    fun parsesM3uSkippingComments() {
+        val body = """
+            #EXTM3U
+            #EXTINF:-1,Some Station
+            https://example.com/stream.aac
+            https://example.com/second.aac
+        """.trimIndent()
+        assertEquals("https://example.com/stream.aac", parsePlaylist(body, "https://host/x.m3u"))
+    }
+
+    @Test
+    fun parsesM3uWithBomAndBlankLines() {
+        val body = "﻿\n\n  https://example.com/stream.mp3  \n"
+        assertEquals("https://example.com/stream.mp3", parsePlaylist(body, "https://host/x.m3u"))
+    }
+
+    @Test
+    fun resolvesRelativeM3uEntryAgainstPlaylistUrl() {
+        val body = "#EXTM3U\nmount.mp3\n"
+        assertEquals(
+            "https://example.com/radio/mount.mp3",
+            parsePlaylist(body, "https://example.com/radio/listen.m3u"),
+        )
+    }
+
+    @Test
+    fun parsesAsxFirstRefHref() {
+        val body = """
+            <ASX version="3.0">
+              <Entry>
+                <Ref HREF="https://example.com/stream.asf" />
+                <Ref HREF="https://example.com/backup.asf" />
+              </Entry>
+            </ASX>
+        """.trimIndent()
+        assertEquals("https://example.com/stream.asf", parsePlaylist(body, "https://host/x.asx"))
+    }
+
+    @Test
+    fun parsesAsxWithSingleQuotesAndExtraAttributes() {
+        val body = "<asx><entry><ref foo='bar' href='http://example.com/a.mp3' /></entry></asx>"
+        assertEquals("http://example.com/a.mp3", parsePlaylist(body, "https://host/x.asx"))
+    }
+
+    @Test
+    fun fallsBackToBodySniffWhenExtensionMismatchesContent() {
+        // A .pls URL whose body is actually an m3u still resolves via the sniff fallback.
+        val body = "#EXTM3U\nhttps://example.com/stream.aac\n"
+        assertEquals("https://example.com/stream.aac", parsePlaylist(body, "https://host/x.pls"))
+    }
+
+    @Test
+    fun returnsNullForEmptyOrGarbageBody() {
+        assertNull(parsePlaylist("", "https://host/x.pls"))
+        assertNull(parsePlaylist("not a playlist at all", "https://host/x.pls"))
+        assertNull(parsePlaylist("[playlist]\nNumberOfEntries=0\n", "https://host/x.pls"))
+    }
+
+    @Test
+    fun resolveStreamUrlPassesThroughNonPlaylist() {
+        val direct = "https://example.com/live.mp3"
+        assertEquals(direct, resolveStreamUrl(direct) { fail("should not fetch a direct stream") })
+    }
+
+    @Test
+    fun resolveStreamUrlUnwrapsSinglePlaylist() {
+        val resolved = resolveStreamUrl("https://host/x.pls") {
+            "[playlist]\nFile1=https://example.com/stream.aac\n"
+        }
+        assertEquals("https://example.com/stream.aac", resolved)
+    }
+
+    @Test
+    fun resolveStreamUrlFollowsNestedPlaylistWithinHopLimit() {
+        val resolved = resolveStreamUrl("https://host/outer.pls") { url ->
+            when (url) {
+                "https://host/outer.pls" -> "[playlist]\nFile1=https://host/inner.m3u\n"
+                "https://host/inner.m3u" -> "https://example.com/final.aac\n"
+                else -> null
+            }
+        }
+        assertEquals("https://example.com/final.aac", resolved)
+    }
+
+    @Test
+    fun resolveStreamUrlStopsAtHopLimit() {
+        // A playlist that only ever points at another playlist bottoms out at the last URL,
+        // never looping forever.
+        val resolved = resolveStreamUrl("https://host/0.pls", maxHops = 2) { url ->
+            val n = url.substringAfterLast('/').substringBefore('.').toInt()
+            "[playlist]\nFile1=https://host/${n + 1}.pls\n"
+        }
+        assertEquals("https://host/2.pls", resolved)
+    }
+
+    @Test
+    fun resolveStreamUrlReturnsOriginalWhenFetchFails() {
+        val url = "https://host/dead.pls"
+        assertEquals(url, resolveStreamUrl(url) { null })
+    }
+
+    private fun fail(message: String): Nothing = throw AssertionError(message)
+}


### PR DESCRIPTION
Resolves stations whose stream URL points at a `.pls`, `.m3u`, or `.asx` playlist container to the underlying stream URL at play time.

A `ResolvingDataSource` on the ExoPlayer fetches the playlist on the loader thread and rewrites the URI to the first stream entry. Covers phone, Android Auto, and Google TV in one place; queue neighbours resolve lazily on skip.

- `.m3u8` (HLS) is untouched — Media3 streams it natively.
- Non-playlist URLs pass through with no network cost.
- Unreachable or unparseable playlists fall through to the raw URL, surfacing the normal playback error.

Detection is by extension (`.pls`/`.m3u`/`.asx`), with a body-content sniff fallback; Content-Type is not used. Parser is pure and covered by 16 unit tests.

Verified on-device: a laut.fm `.pls` station resolves to its stream and plays.

Closes #129