### PR TITLE
feat(settings): allow favorites-only navigation

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/AerialApp.kt
+++ b/app/src/main/java/com/shapeshed/aerial/AerialApp.kt
@@ -31,6 +31,7 @@ import okhttp3.OkHttpClient
 val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
 val ENRICH_METADATA_KEY = booleanPreferencesKey("enrich_metadata")
 val SHOW_STREAM_BITRATE_KEY = booleanPreferencesKey("show_stream_bitrate")
+val SHOW_HOME_KEY = booleanPreferencesKey("show_home")
 val FAVORITES_GRID_COLUMNS_KEY = intPreferencesKey("favorites_grid_columns")
 const val FAVORITES_GRID_COLUMNS_DEFAULT = 3
 val FAVORITES_GRID_COLUMNS_RANGE = 2..8

--- a/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
+++ b/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
@@ -57,6 +57,7 @@ import com.shapeshed.aerial.data.Station
 import com.shapeshed.aerial.data.StationRepository
 import com.shapeshed.aerial.data.parseIcyTitle
 import com.shapeshed.aerial.ENRICH_METADATA_KEY
+import com.shapeshed.aerial.SHOW_HOME_KEY
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -172,6 +173,12 @@ class PlayerService : MediaLibraryService() {
                 stations = updatedStations
                 updateFavoriteButton()
             }
+        }
+        serviceScope.launch {
+            dataStore.data
+                .map { it[SHOW_HOME_KEY] ?: true }
+                .distinctUntilChanged()
+                .collectLatest(mediaBrowseTree::setShowHome)
         }
         serviceScope.launch {
             NowPlayingStore.state.collectLatest { info ->

--- a/app/src/main/java/com/shapeshed/aerial/data/MediaBrowseTree.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/MediaBrowseTree.kt
@@ -47,21 +47,30 @@ class MediaBrowseTree(
     private val stationRepository: StationRepository,
     private val registryRepository: RegistryRepository,
 ) {
+    @Volatile
+    private var showHome = true
+
+    fun setShowHome(show: Boolean) {
+        showHome = show
+    }
+
     fun rootItem(): MediaItem = browsableFolder(MEDIA_BROWSE_ROOT_ID, context.getString(R.string.app_name))
 
-    fun rootChildren(): List<MediaItem> = listOf(
-        browsableFolder(FAVORITES_ID, context.getString(R.string.tab_favorites)),
-        browsableFolder(MOODS_ID, context.getString(R.string.car_moods)),
-        browsableFolder(RECENT_ID, context.getString(R.string.recently_played)),
-    )
+    fun rootChildren(): List<MediaItem> = buildList {
+        add(browsableFolder(FAVORITES_ID, context.getString(R.string.tab_favorites)))
+        if (showHome) {
+            add(browsableFolder(MOODS_ID, context.getString(R.string.car_moods)))
+            add(browsableFolder(RECENT_ID, context.getString(R.string.recently_played)))
+        }
+    }
 
     /** Dispatches a parentId to the right children list, or null if it's not a known folder. */
     suspend fun children(parentId: String): List<MediaItem>? = when {
         parentId == MEDIA_BROWSE_ROOT_ID -> rootChildren()
         parentId == FAVORITES_ID -> favoriteChildren()
-        parentId == MOODS_ID -> moodChildren()
-        parentId == RECENT_ID -> recentChildren()
-        parentId.startsWith(MOOD_ID_PREFIX) -> moodStationChildren(parentId.removePrefix(MOOD_ID_PREFIX))
+        showHome && parentId == MOODS_ID -> moodChildren()
+        showHome && parentId == RECENT_ID -> recentChildren()
+        showHome && parentId.startsWith(MOOD_ID_PREFIX) -> moodStationChildren(parentId.removePrefix(MOOD_ID_PREFIX))
         else -> null
     }
 

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -327,6 +327,7 @@ fun MainScreen(
     val favoritesSort by viewModel.favoritesSort.collectAsStateWithLifecycle()
     val favoritesGridColumns by viewModel.favoritesGridColumns.collectAsStateWithLifecycle()
     val showStreamBitrate by viewModel.showStreamBitrate.collectAsStateWithLifecycle()
+    val showHome by viewModel.showHome.collectAsStateWithLifecycle()
     val selectedCountries: Set<String> by viewModel.selectedCountries.collectAsStateWithLifecycle()
     val selectedTags: Set<String> by viewModel.selectedTags.collectAsStateWithLifecycle()
     val availableCountries: List<String> by viewModel.availableCountries.collectAsStateWithLifecycle()
@@ -359,6 +360,7 @@ fun MainScreen(
     val savedRegistryKeys = remember(stations) { stations.mapNotNull { it.savedKey() }.toSet() }
 
     val selectedTab by viewModel.selectedHomeTab.collectAsStateWithLifecycle()
+    val effectiveSelectedTab = if (showHome) selectedTab else TAB_FAVORITES
     // Hoisted so each tab keeps its scroll position across tab switches.
     val homeListState = rememberLazyListState()
     val favoritesListState = rememberLazyListState()
@@ -456,28 +458,30 @@ fun MainScreen(
         val useNavigationRail = maxWidth > maxHeight && maxWidth >= 600.dp
 
         Row(modifier = Modifier.fillMaxSize()) {
-            if (useNavigationRail) {
+            if (useNavigationRail && showHome) {
                 WideNavigationRail(
                     colors = WideNavigationRailDefaults.colors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
                 ) {
                     Spacer(Modifier.height(8.dp))
+                    if (showHome) {
+                        WideNavigationRailItem(
+                            selected = effectiveSelectedTab == TAB_HOME,
+                            onClick = {
+                                selectedMoodId = null
+                                viewModel.setSelectedHomeTab(TAB_HOME)
+                            },
+                            icon = {
+                                Icon(
+                                    imageVector = if (selectedTab == TAB_HOME) Icons.Rounded.Home else Icons.Outlined.Home,
+                                    contentDescription = null,
+                                )
+                            },
+                            label = { Text(stringResource(R.string.tab_home)) },
+                            railExpanded = false,
+                        )
+                    }
                     WideNavigationRailItem(
-                        selected = selectedTab == TAB_HOME,
-                        onClick = {
-                            selectedMoodId = null
-                            viewModel.setSelectedHomeTab(TAB_HOME)
-                        },
-                        icon = {
-                            Icon(
-                                imageVector = if (selectedTab == TAB_HOME) Icons.Rounded.Home else Icons.Outlined.Home,
-                                contentDescription = null,
-                            )
-                        },
-                        label = { Text(stringResource(R.string.tab_home)) },
-                        railExpanded = false,
-                    )
-                    WideNavigationRailItem(
-                        selected = selectedTab == TAB_FAVORITES,
+                        selected = effectiveSelectedTab == TAB_FAVORITES,
                         onClick = {
                             selectedMoodId = null
                             viewModel.setSelectedHomeTab(TAB_FAVORITES)
@@ -499,12 +503,12 @@ fun MainScreen(
                     .semantics { traversalIndex = 0f },
                 contentWindowInsets = WindowInsets.navigationBars,
                 bottomBar = {
-                    if (!useNavigationRail) {
+                    if (!useNavigationRail && showHome) {
                         // surfaceContainerLow matches the reference bar (Google Drive) rather
                         // than the component's default surfaceContainer.
                         ShortNavigationBar(containerColor = MaterialTheme.colorScheme.surfaceContainerLow) {
-                            ShortNavigationBarItem(
-                                selected = selectedTab == TAB_HOME,
+                            if (showHome) ShortNavigationBarItem(
+                                selected = effectiveSelectedTab == TAB_HOME,
                                 onClick = {
                                     selectedMoodId = null
                                     viewModel.setSelectedHomeTab(TAB_HOME)
@@ -518,7 +522,7 @@ fun MainScreen(
                                 label = { Text(stringResource(R.string.tab_home)) },
                             )
                             ShortNavigationBarItem(
-                                selected = selectedTab == TAB_FAVORITES,
+                                selected = effectiveSelectedTab == TAB_FAVORITES,
                                 onClick = {
                                     selectedMoodId = null
                                     viewModel.setSelectedHomeTab(TAB_FAVORITES)
@@ -579,7 +583,7 @@ fun MainScreen(
                         onRemoveStation = { viewModel.removeFromRegistry(it) },
                         onPlayStation = { viewModel.playFromRegistry(it, selectedMoodStations) },
                     )
-                } else if (selectedTab == TAB_HOME) {
+                } else if (effectiveSelectedTab == TAB_HOME) {
                     // The For You row is the locale country's selection (curated or a random
                     // sample with artwork), headed by the country name; if the registry has
                     // nothing for that country it falls back to the featured stations under

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -37,6 +37,7 @@ import com.shapeshed.aerial.FAVORITES_GRID_COLUMNS_DEFAULT
 import com.shapeshed.aerial.FAVORITES_GRID_COLUMNS_KEY
 import com.shapeshed.aerial.FAVORITES_GRID_COLUMNS_RANGE
 import com.shapeshed.aerial.SHOW_STREAM_BITRATE_KEY
+import com.shapeshed.aerial.SHOW_HOME_KEY
 import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_CANCEL
 import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_SET
 import com.shapeshed.aerial.data.NowPlayingInfo
@@ -354,6 +355,10 @@ class MainViewModel(
     val showStreamBitrate: StateFlow<Boolean> = dataStore.data
         .map { prefs -> prefs[SHOW_STREAM_BITRATE_KEY] ?: false }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    val showHome: StateFlow<Boolean> = dataStore.data
+        .map { prefs -> prefs[SHOW_HOME_KEY] ?: true }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
 
     val favoritesGridColumns: StateFlow<Int> = dataStore.data
         .map { prefs ->

--- a/app/src/main/java/com/shapeshed/aerial/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/SettingsScreen.kt
@@ -60,6 +60,7 @@ fun SettingsScreen(
     val context = LocalContext.current
     val enrichMetadata by viewModel.enrichMetadata.collectAsStateWithLifecycle()
     val showStreamBitrate by viewModel.showStreamBitrate.collectAsStateWithLifecycle()
+    val showHome by viewModel.showHome.collectAsStateWithLifecycle()
     val favoritesGridColumns by viewModel.favoritesGridColumns.collectAsStateWithLifecycle()
     val versionName = BuildConfig.VERSION_NAME
     val snackbarHostState = remember { SnackbarHostState() }
@@ -99,6 +100,21 @@ fun SettingsScreen(
                 .fillMaxSize()
                 .padding(padding),
         ) {
+            item(contentType = "setting") {
+                ListItem(
+                    modifier = Modifier.clickable { viewModel.setShowHome(!showHome) },
+                    supportingContent = { Text(stringResource(R.string.show_home_desc)) },
+                    trailingContent = {
+                        Switch(
+                            checked = showHome,
+                            onCheckedChange = { viewModel.setShowHome(it) },
+                        )
+                    },
+                ) {
+                    Text(stringResource(R.string.show_home))
+                }
+                HorizontalDivider()
+            }
             item(contentType = "setting") {
                 ListItem(
                     modifier = Modifier.clickable { viewModel.setEnrichMetadata(!enrichMetadata) },

--- a/app/src/main/java/com/shapeshed/aerial/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/SettingsViewModel.kt
@@ -15,6 +15,7 @@ import com.shapeshed.aerial.FAVORITES_GRID_COLUMNS_DEFAULT
 import com.shapeshed.aerial.FAVORITES_GRID_COLUMNS_KEY
 import com.shapeshed.aerial.FAVORITES_GRID_COLUMNS_RANGE
 import com.shapeshed.aerial.SHOW_STREAM_BITRATE_KEY
+import com.shapeshed.aerial.SHOW_HOME_KEY
 import com.shapeshed.aerial.data.Station
 import com.shapeshed.aerial.data.StationRepository
 import java.io.ByteArrayOutputStream
@@ -51,6 +52,10 @@ class SettingsViewModel(
         .map { it[SHOW_STREAM_BITRATE_KEY] ?: false }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
+    val showHome = dataStore.data
+        .map { it[SHOW_HOME_KEY] ?: true }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
+
     val favoritesGridColumns = dataStore.data
         .map { (it[FAVORITES_GRID_COLUMNS_KEY] ?: FAVORITES_GRID_COLUMNS_DEFAULT).coerceIn(FAVORITES_GRID_COLUMNS_RANGE) }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FAVORITES_GRID_COLUMNS_DEFAULT)
@@ -73,6 +78,12 @@ class SettingsViewModel(
     fun setShowStreamBitrate(enabled: Boolean) {
         viewModelScope.launch {
             dataStore.edit { it[SHOW_STREAM_BITRATE_KEY] = enabled }
+        }
+    }
+
+    fun setShowHome(enabled: Boolean) {
+        viewModelScope.launch {
+            dataStore.edit { it[SHOW_HOME_KEY] = enabled }
         }
     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -102,6 +102,8 @@
     <string name="tag_electronic">Elektronisch</string>
     <string name="tab_home">Start</string>
     <string name="tab_favorites">Favoriten</string>
+    <string name="show_home">Startseite anzeigen</string>
+    <string name="show_home_desc">Startseite und Entdeckungsordner neben Favoriten anzeigen</string>
     <string name="sort_by">Sortieren nach</string>
     <string name="sort_az">A bis Z</string>
     <string name="sort_last_played">Zuletzt gespielt</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -11,6 +11,8 @@
     <string name="search_stations_header">Stations</string>
     <string name="tab_home">Home</string>
     <string name="tab_favorites">Favourites</string>
+    <string name="show_home">Show Home</string>
+    <string name="show_home_desc">Show the Home tab and discovery folders alongside Favourites</string>
     <string name="sort_by">Sort by</string>
     <string name="sort_az">A to Z</string>
     <string name="sort_last_played">Last played</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -102,6 +102,8 @@
     <string name="tag_electronic">Electrónica</string>
     <string name="tab_home">Inicio</string>
     <string name="tab_favorites">Favoritos</string>
+    <string name="show_home">Mostrar inicio</string>
+    <string name="show_home_desc">Mostrar la pestaña Inicio y las carpetas de descubrimiento junto a Favoritos</string>
     <string name="sort_by">Ordenar por</string>
     <string name="sort_az">De la A a la Z</string>
     <string name="sort_last_played">Reproducida recientemente</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -102,6 +102,8 @@
     <string name="tag_electronic">Électronique</string>
     <string name="tab_home">Accueil</string>
     <string name="tab_favorites">Favoris</string>
+    <string name="show_home">Afficher l’accueil</string>
+    <string name="show_home_desc">Afficher l’onglet Accueil et les dossiers de découverte avec les Favoris</string>
     <string name="sort_by">Trier par</string>
     <string name="sort_az">De A à Z</string>
     <string name="sort_last_played">Écoutée récemment</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -102,6 +102,8 @@
     <string name="tag_electronic">Elettronica</string>
     <string name="tab_home">Home</string>
     <string name="tab_favorites">Preferiti</string>
+    <string name="show_home">Mostra Home</string>
+    <string name="show_home_desc">Mostra la scheda Home e le cartelle di scoperta insieme ai Preferiti</string>
     <string name="sort_by">Ordina per</string>
     <string name="sort_az">Dalla A alla Z</string>
     <string name="sort_last_played">Riprodotta di recente</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -102,6 +102,8 @@
     <string name="tag_electronic">エレクトロニック</string>
     <string name="tab_home">ホーム</string>
     <string name="tab_favorites">お気に入り</string>
+    <string name="show_home">ホームを表示</string>
+    <string name="show_home_desc">お気に入りと一緒にホームタブと探索フォルダを表示します</string>
     <string name="sort_by">並べ替え</string>
     <string name="sort_az">A〜Z順</string>
     <string name="sort_last_played">最近再生した順</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -102,6 +102,8 @@
     <string name="tag_electronic">일렉트로닉</string>
     <string name="tab_home">홈</string>
     <string name="tab_favorites">즐겨찾기</string>
+    <string name="show_home">홈 표시</string>
+    <string name="show_home_desc">즐겨찾기와 함께 홈 탭 및 탐색 폴더 표시</string>
     <string name="sort_by">정렬 기준</string>
     <string name="sort_az">가나다순</string>
     <string name="sort_last_played">최근 재생순</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -102,6 +102,8 @@
     <string name="tag_electronic">Elektronisch</string>
     <string name="tab_home">Home</string>
     <string name="tab_favorites">Favorieten</string>
+    <string name="show_home">Home tonen</string>
+    <string name="show_home_desc">Het tabblad Home en ontdekkingsmappen naast Favorieten tonen</string>
     <string name="sort_by">Sorteren op</string>
     <string name="sort_az">A tot Z</string>
     <string name="sort_last_played">Laatst afgespeeld</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -102,6 +102,8 @@
     <string name="tag_electronic">Eletrônica</string>
     <string name="tab_home">Início</string>
     <string name="tab_favorites">Favoritos</string>
+    <string name="show_home">Mostrar início</string>
+    <string name="show_home_desc">Mostrar o separador Início e as pastas de descoberta juntamente com os Favoritos</string>
     <string name="sort_by">Ordenar por</string>
     <!-- "a" here is the preposition "to" ("From A to Z"), not a doubled word. -->
     <string name="sort_az" tools:ignore="Typos">De A a Z</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -102,6 +102,8 @@
     <string name="tag_electronic">电子</string>
     <string name="tab_home">首页</string>
     <string name="tab_favorites">收藏</string>
+    <string name="show_home">显示首页</string>
+    <string name="show_home_desc">在收藏旁显示首页标签和探索文件夹</string>
     <string name="sort_by">排序方式</string>
     <string name="sort_az">按字母顺序</string>
     <string name="sort_last_played">最近播放</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,6 +104,8 @@
     <string name="sleep_preset_hours_minutes">%1$dh %2$dm</string>
     <string name="tab_home">Home</string>
     <string name="tab_favorites">Favorites</string>
+    <string name="show_home">Show Home</string>
+    <string name="show_home_desc">Show the Home tab and discovery folders alongside Favorites</string>
     <string name="sort_by">Sort by</string>
     <string name="sort_az">A to Z</string>
     <string name="sort_last_played">Last played</string>

--- a/app/src/test/java/com/shapeshed/aerial/data/MediaBrowseTreeTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/data/MediaBrowseTreeTest.kt
@@ -33,6 +33,18 @@ class MediaBrowseTreeTest {
     }
 
     @Test
+    fun hidingHomeLeavesFavoritesAsTheOnlyBrowseFolder() = runBlocking {
+        val tree = tree()
+        tree.setShowHome(false)
+
+        assertEquals(listOf("favorites"), tree.rootChildren().map { it.mediaId })
+        assertNull(tree.children("moods"))
+        assertNull(tree.children(RECENT_ID))
+        assertNull(tree.children("mood:relax"))
+        assertNotNull(tree.children("favorites"))
+    }
+
+    @Test
     fun moodChildrenAreTheSixCuratedMoodFolders() {
         val tree = tree()
 


### PR DESCRIPTION
## Summary

- Add a Settings switch to hide the Home destination and use Favorites as the only phone destination.
- Remove the bottom navigation bar and wide navigation rail when Favorites is the only destination.
- Apply the same preference to Android Auto so only Favorites is browsable.
- Add localized strings for all supported locales and browse-tree coverage.

## Validation

- `./gradlew compileDebugKotlin testDebugUnitTest`
- `./gradlew installDebug`

Fixes #133