### PR TITLE
chore(release): prepare v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,21 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-31
+
 ### Added
 
 - Stations whose stream URL is a `.pls`, `.m3u`, or `.asx` playlist now play — the underlying stream URL is resolved at play time. (#129)
+- A setting to start on Favourites and hide Home when it is the only available destination. This also applies to Android Auto. (#133)
+
+### Changed
+
+- The Now Playing screen now uses a single, simpler Material 3 layout with a secondary-toned background, consistent typography and spacing, left-aligned metadata, and stable layout space when stream metadata is unavailable.
+- The station artwork is no longer duplicated in a secondary Now Playing overlay; copying track information remains available.
+
+### Removed
+
+- Provider-based Now Playing enrichers and the setting to enhance What’s Playing. ICY and ID3 stream metadata remain supported. (#117)
 
 ## [0.5.1] - 2026-07-24
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,8 +32,8 @@ android {
         applicationId "com.shapeshed.aerial"
         minSdk 26
         targetSdk 37
-        versionCode 14
-        versionName "0.5.1"
+        versionCode 15
+        versionName "0.6.0"
     }
 
     signingConfigs {

--- a/fastlane/metadata/android/en-US/changelogs/15.txt
+++ b/fastlane/metadata/android/en-US/changelogs/15.txt
@@ -1,0 +1,4 @@
+- Start on Favourites and hide Home when it is the only available destination, including in Android Auto.
+- Support playback from `.pls`, `.m3u`, and `.asx` playlist URLs.
+- Simplify Now Playing with a clearer Material 3 layout, stable metadata spacing, and a secondary-toned background.
+- Remove provider-based metadata enrichers while retaining ICY and ID3 stream metadata.


### PR DESCRIPTION
## Release 0.6.0

- bump version name to `0.6.0` and version code to `15`
- move the unreleased playlist support into the 0.6.0 changelog
- document the Favourites startup setting, simplified Now Playing experience, and enricher removal
- add Fastlane release notes for version code 15

The full release-preparation gate has passed locally, including tests, lint, release APK/bundle, and F-Droid metadata validation.