### PR TITLE
fix(playback): preserve recent station queue

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -595,6 +595,7 @@ fun MainScreen(
                         listState = homeListState,
                         bottomPadding = stationContentBottomPadding,
                         onMoodTap = { selectedMoodId = it.id },
+                        onRecentlyPlayedStationTap = { viewModel.playFromRegistry(it, recentlyPlayedStations) },
                         onFeaturedStationTap = { viewModel.playFromRegistry(it, forYouOrFeatured) },
                         onForYouViewAll = {
                             if (hasCountrySelection) openCountrySearch(forYouCountryCode) else openRegistrySearch()
@@ -1461,6 +1462,7 @@ private fun HomeTabContent(
     listState: LazyListState,
     bottomPadding: androidx.compose.ui.unit.Dp,
     onMoodTap: (CuratedMood) -> Unit,
+    onRecentlyPlayedStationTap: (com.shapeshed.aerial.data.RegistryStation) -> Unit,
     onFeaturedStationTap: (com.shapeshed.aerial.data.RegistryStation) -> Unit,
     onForYouViewAll: () -> Unit,
 ) {
@@ -1512,7 +1514,7 @@ private fun HomeTabContent(
                     ) { station ->
                         ForYouStationCard(
                             station = station,
-                            onClick = { onFeaturedStationTap(station) },
+                            onClick = { onRecentlyPlayedStationTap(station) },
                         )
                     }
                 }


### PR DESCRIPTION
## Summary

- give Recently Played its own playback callback
- use the recent stations list as the media queue
- keep the existing For You queue unchanged

This makes previous/next controls in the notification and lock-screen player move through Recently Played stations as expected.

Fixes #149
