### PR TITLE
fix(player): preserve station queues for notification navigation

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
+++ b/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Metadata
@@ -77,6 +78,7 @@ class PlayerService : MediaLibraryService() {
     private var sleepTimerJob: Job? = null
 
     private lateinit var player: ExoPlayer
+    private lateinit var sessionPlayer: Player
     private lateinit var mediaSession: MediaLibrarySession
     private lateinit var repository: StationRepository
     private lateinit var registryRepository: RegistryRepository
@@ -143,19 +145,25 @@ class PlayerService : MediaLibraryService() {
                 true,
             )
             .setHandleAudioBecomingNoisy(true)
-            // Player's default seekToPrevious() (what hardware/Bluetooth "previous" calls)
-            // restarts the current item instead of moving back unless playback position is
-            // under this threshold — meant for "restart the song" on a track you're a few
-            // seconds into. There's no such position to rewind to on a live station, so with
-            // the 3s default, "previous" almost always just replays the current station
-            // instead of moving to the one before it. Zero makes it always move back.
-            .setMaxSeekToPreviousPositionMs(0)
+            // Player's default seekToPrevious() (what notification and hardware/Bluetooth
+            // "previous" calls use) restarts the current item when playback is beyond this
+            // threshold. Live stations have no meaningful rewind position, so use an unlimited
+            // threshold to make Back always move to the previous station in the queue.
+            .setMaxSeekToPreviousPositionMs(Long.MAX_VALUE)
             .build()
         // Wraps skip next/previous around a browsed list's queue (e.g. Android Auto's mood
         // folders), matching the phone UI's circular swipe-through-favourites pager.
         player.repeatMode = Player.REPEAT_MODE_ALL
         player.addListener(icyListener)
-        mediaSession = MediaLibrarySession.Builder(this, player, librarySessionCallback)
+        // Notifications and lock-screen controls call seekToNext()/seekToPrevious(). For live
+        // radio those generic methods can restart the current item instead of moving through the
+        // playlist. Expose a forwarding player to the session so those calls always navigate by
+        // media item; the service continues to use the ExoPlayer instance directly.
+        sessionPlayer = object : ForwardingPlayer(player) {
+            override fun seekToPrevious() = seekToPreviousMediaItem()
+            override fun seekToNext() = seekToNextMediaItem()
+        }
+        mediaSession = MediaLibrarySession.Builder(this, sessionPlayer, librarySessionCallback)
             .setSessionActivity(pendingIntent())
             .setMediaButtonPreferences(listOf(favoriteButton(null)))
             .setBitmapLoader(CoilBitmapLoader(this))

--- a/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
+++ b/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
@@ -42,15 +42,21 @@ import com.google.common.util.concurrent.SettableFuture
 import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_CANCEL
 import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_SET
 import com.shapeshed.aerial.data.AERIAL_USER_AGENT
+import com.shapeshed.aerial.data.FAVORITES_SORT_KEY
+import com.shapeshed.aerial.data.FavoritesSort
+import com.shapeshed.aerial.data.LAST_PLAYED_STATION_KEY
 import com.shapeshed.aerial.data.MediaBrowseTree
 import com.shapeshed.aerial.data.PlayHistoryEntry
 import com.shapeshed.aerial.data.RECENT_ID
 import com.shapeshed.aerial.data.httpGetText
+import com.shapeshed.aerial.data.lastPlayedStationSnapshot
+import com.shapeshed.aerial.data.resolveQueueStart
 import com.shapeshed.aerial.data.resolveStreamUrl
 import com.shapeshed.aerial.data.RegistryRepository
 import com.shapeshed.aerial.data.SLEEP_TIMER_DURATION_MS
 import com.shapeshed.aerial.data.SleepTimerState
 import com.shapeshed.aerial.data.SleepTimerStore
+import com.shapeshed.aerial.data.sortStations
 import com.shapeshed.aerial.data.Station
 import com.shapeshed.aerial.data.StationRepository
 import com.shapeshed.aerial.data.parseIcyTitle
@@ -63,6 +69,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -445,6 +452,43 @@ class PlayerService : MediaLibraryService() {
             } else {
                 val resolved = mediaItems.map { item -> mediaBrowseTree.resolve(item.mediaId) ?: item }
                 MediaSession.MediaItemsWithStartPosition(resolved, startIndex, startPositionMs)
+            }
+        }
+
+        // Called when a controller (lock-screen/notification, Bluetooth, Assistant) reconnects
+        // to a session whose player has no media item — e.g. the whole process was killed while
+        // the screen was off and the system is now restarting the service to handle a media
+        // button press. Without this, that reconnection carries only whatever single item the
+        // system cached, so Previous/Next on the lock screen have nothing to navigate — the same
+        // "queue collapses to one station" bug loadStationPaused fixes for the app-driven restore
+        // path, but for the case where the app itself never reopens.
+        override fun onPlaybackResumption(
+            mediaSession: MediaSession,
+            controller: MediaSession.ControllerInfo,
+            isForPlayback: Boolean,
+        ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> = serviceFuture {
+            val snapshot = dataStore.data.first()[LAST_PLAYED_STATION_KEY]?.let(::lastPlayedStationSnapshot)
+                ?: throw UnsupportedOperationException("No last-played station to resume")
+            val savedStation = snapshot.station.id.takeIf { it > 0 }?.let { repository.getById(it) }
+                ?: repository.getByStreamUrl(snapshot.station.streamUrl)
+            val sort = dataStore.data.first()[FAVORITES_SORT_KEY]
+                ?.let { saved -> FavoritesSort.entries.firstOrNull { it.name == saved } }
+                ?: FavoritesSort.AZ
+            val queue = sortStations(repository.getAll().first(), sort)
+            val startIndex = savedStation?.let { resolveQueueStart(queue, it) }
+            if (startIndex != null) {
+                MediaSession.MediaItemsWithStartPosition(
+                    queue.map { it.toPlayableMediaItem(this@PlayerService) },
+                    startIndex,
+                    C.TIME_UNSET,
+                )
+            } else {
+                val resumed = savedStation ?: snapshot.station.copy(id = 0)
+                MediaSession.MediaItemsWithStartPosition(
+                    listOf(resumed.toPlayableMediaItem(this@PlayerService)),
+                    0,
+                    C.TIME_UNSET,
+                )
             }
         }
     }

--- a/app/src/main/java/com/shapeshed/aerial/data/StationQueue.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/StationQueue.kt
@@ -1,0 +1,78 @@
+package com.shapeshed.aerial.data
+
+import androidx.datastore.preferences.core.stringPreferencesKey
+import org.json.JSONObject
+
+// Shared between MainViewModel (UI-driven restore) and PlayerService (system-driven
+// onPlaybackResumption) so both rebuild the same favourites queue from the same persisted state.
+
+val LAST_PLAYED_STATION_KEY = stringPreferencesKey("last_played_station")
+val FAVORITES_SORT_KEY = stringPreferencesKey("favorites_sort")
+
+enum class FavoritesSort {
+    AZ,
+    LAST_PLAYED,
+    MOST_PLAYED,
+}
+
+data class LastPlayedStationSnapshot(
+    val station: Station,
+)
+
+fun Station.toLastPlayedJson(): JSONObject =
+    JSONObject()
+        .put("id", id)
+        .put("name", name)
+        .put("streamUrl", streamUrl)
+        .put("logoPath", logoPath)
+        .put("isFavorite", isFavorite)
+        .put("provider", provider)
+        .put("providerId", providerId)
+        .put("tags", tags)
+        .put("description", description)
+        .put("country", country)
+        .put("countryCode", countryCode)
+
+fun lastPlayedStationSnapshot(json: String): LastPlayedStationSnapshot {
+    val obj = JSONObject(json)
+    return LastPlayedStationSnapshot(
+        station = Station(
+            id = obj.optLong("id"),
+            name = obj.optString("name"),
+            streamUrl = obj.optString("streamUrl"),
+            logoPath = obj.optString("logoPath"),
+            isFavorite = obj.optBoolean("isFavorite"),
+            provider = obj.optString("provider"),
+            providerId = obj.optString("providerId"),
+            tags = obj.optString("tags"),
+            description = obj.optString("description"),
+            country = obj.optString("country"),
+            countryCode = obj.optString("countryCode"),
+        ),
+    )
+}
+
+fun sortStations(stations: List<Station>, sort: FavoritesSort): List<Station> = when (sort) {
+    FavoritesSort.AZ -> stations.sortedWith(compareBy { stationSortKey(it.name) })
+    FavoritesSort.LAST_PLAYED -> stations.sortedWith(
+        compareByDescending<Station> { it.lastPlayedAt }.thenBy { stationSortKey(it.name) },
+    )
+    FavoritesSort.MOST_PLAYED -> stations.sortedWith(
+        compareByDescending<Station> { it.playCount }.thenBy { stationSortKey(it.name) },
+    )
+}
+
+// Maps English number words and digit strings to zero-padded numbers so that
+// "BBC Radio One", "BBC Radio Two" … sort in numeric order rather than alphabetically.
+private val NUMBER_WORDS = mapOf(
+    "zero" to 0, "one" to 1, "two" to 2, "three" to 3, "four" to 4,
+    "five" to 5, "six" to 6, "seven" to 7, "eight" to 8, "nine" to 9,
+    "ten" to 10, "eleven" to 11, "twelve" to 12,
+)
+
+private fun stationSortKey(name: String): String =
+    name.split(Regex("\\s+")).joinToString(" ") { token ->
+        NUMBER_WORDS[token.lowercase()]?.let { "%03d".format(it) }
+            ?: token.toIntOrNull()?.let { "%03d".format(it) }
+            ?: token.lowercase()
+    }

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -597,6 +597,9 @@ fun MainScreen(
                         onMoodTap = { selectedMoodId = it.id },
                         onRecentlyPlayedStationTap = { viewModel.playFromRegistry(it, recentlyPlayedStations) },
                         onFeaturedStationTap = { viewModel.playFromRegistry(it, forYouOrFeatured) },
+                        onRecentlyPlayedStationTap = {
+                            viewModel.playFromRegistry(it, recentlyPlayedStations)
+                        },
                         onForYouViewAll = {
                             if (hasCountrySelection) openCountrySearch(forYouCountryCode) else openRegistrySearch()
                         },
@@ -1464,6 +1467,7 @@ private fun HomeTabContent(
     onMoodTap: (CuratedMood) -> Unit,
     onRecentlyPlayedStationTap: (com.shapeshed.aerial.data.RegistryStation) -> Unit,
     onFeaturedStationTap: (com.shapeshed.aerial.data.RegistryStation) -> Unit,
+    onRecentlyPlayedStationTap: (com.shapeshed.aerial.data.RegistryStation) -> Unit,
     onForYouViewAll: () -> Unit,
 ) {
     // On launch the splash screen holds until the Recently Played row is resolved (see

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -168,6 +168,7 @@ import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import androidx.compose.ui.res.stringResource
 import com.shapeshed.aerial.R
+import com.shapeshed.aerial.data.FavoritesSort
 import com.shapeshed.aerial.data.RegistryStation
 import com.shapeshed.aerial.data.Station
 import java.io.File

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -598,9 +598,6 @@ fun MainScreen(
                         onMoodTap = { selectedMoodId = it.id },
                         onRecentlyPlayedStationTap = { viewModel.playFromRegistry(it, recentlyPlayedStations) },
                         onFeaturedStationTap = { viewModel.playFromRegistry(it, forYouOrFeatured) },
-                        onRecentlyPlayedStationTap = {
-                            viewModel.playFromRegistry(it, recentlyPlayedStations)
-                        },
                         onForYouViewAll = {
                             if (hasCountrySelection) openCountrySearch(forYouCountryCode) else openRegistrySearch()
                         },
@@ -1468,7 +1465,6 @@ private fun HomeTabContent(
     onMoodTap: (CuratedMood) -> Unit,
     onRecentlyPlayedStationTap: (com.shapeshed.aerial.data.RegistryStation) -> Unit,
     onFeaturedStationTap: (com.shapeshed.aerial.data.RegistryStation) -> Unit,
-    onRecentlyPlayedStationTap: (com.shapeshed.aerial.data.RegistryStation) -> Unit,
     onForYouViewAll: () -> Unit,
 ) {
     // On launch the splash screen holds until the Recently Played row is resolved (see

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -11,7 +11,6 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import android.os.Bundle
 import org.json.JSONArray
-import org.json.JSONObject
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelProvider
@@ -40,6 +39,9 @@ import com.shapeshed.aerial.SHOW_STREAM_BITRATE_KEY
 import com.shapeshed.aerial.SHOW_HOME_KEY
 import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_CANCEL
 import com.shapeshed.aerial.data.ACTION_SLEEP_TIMER_SET
+import com.shapeshed.aerial.data.FAVORITES_SORT_KEY
+import com.shapeshed.aerial.data.FavoritesSort
+import com.shapeshed.aerial.data.LAST_PLAYED_STATION_KEY
 import com.shapeshed.aerial.data.RegistryRepository
 import com.shapeshed.aerial.data.RegistryStation
 import com.shapeshed.aerial.data.SLEEP_TIMER_DURATION_MS
@@ -48,6 +50,9 @@ import com.shapeshed.aerial.data.SleepTimerStore
 import com.shapeshed.aerial.data.Station
 import com.shapeshed.aerial.data.StationRepository
 import com.shapeshed.aerial.data.resolveQueueStart
+import com.shapeshed.aerial.data.sortStations
+import com.shapeshed.aerial.data.lastPlayedStationSnapshot
+import com.shapeshed.aerial.data.toLastPlayedJson
 import com.shapeshed.aerial.toEphemeralStation
 import com.shapeshed.aerial.toPlayableMediaItem
 import java.io.File
@@ -73,22 +78,10 @@ import kotlinx.coroutines.withContext
 private val RECENT_SEARCHES_KEY = stringPreferencesKey("recent_searches")
 private val SEARCH_COUNTRIES_KEY = stringPreferencesKey("search_countries")
 private val SEARCH_TAGS_KEY = stringPreferencesKey("search_tags")
-private val LAST_PLAYED_STATION_KEY = stringPreferencesKey("last_played_station")
 private val HOME_CARDS_VIEW_KEY = booleanPreferencesKey("home_cards_view")
 private val LAST_HOME_TAB_KEY = intPreferencesKey("last_home_tab")
-private val FAVORITES_SORT_KEY = stringPreferencesKey("favorites_sort")
-
-enum class FavoritesSort {
-    AZ,
-    LAST_PLAYED,
-    MOST_PLAYED,
-}
 private const val MAX_RECENT_SEARCHES = 5
 private const val RECENTLY_PLAYED_LIMIT = 10
-
-private data class LastPlayedStationSnapshot(
-    val station: Station,
-)
 
 class MainViewModel(
     application: Application,
@@ -223,15 +216,7 @@ class MainViewModel(
     }
 
     val stations: StateFlow<List<Station>> = combine(_allStations, _favoritesSort) { list, sort ->
-        when (sort) {
-            FavoritesSort.AZ -> list.sortedWith(compareBy { stationSortKey(it.name) })
-            FavoritesSort.LAST_PLAYED -> list.sortedWith(
-                compareByDescending<Station> { it.lastPlayedAt }.thenBy { stationSortKey(it.name) },
-            )
-            FavoritesSort.MOST_PLAYED -> list.sortedWith(
-                compareByDescending<Station> { it.playCount }.thenBy { stationSortKey(it.name) },
-            )
-        }
+        sortStations(list, sort)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     private val _currentStationId = MutableStateFlow<Long?>(null)
@@ -907,17 +892,7 @@ class MainViewModel(
         // screen sleep there may be no collector, leaving its initial empty value in place. Using
         // that value here restores only the current station, so the lock-screen Next action has
         // no favourite to advance to. Read the database directly for service/resumption work.
-        val queue = repository.getAll().first().let { savedStations ->
-            when (_favoritesSort.value) {
-                FavoritesSort.AZ -> savedStations.sortedWith(compareBy { stationSortKey(it.name) })
-                FavoritesSort.LAST_PLAYED -> savedStations.sortedWith(
-                    compareByDescending<Station> { it.lastPlayedAt }.thenBy { stationSortKey(it.name) },
-                )
-                FavoritesSort.MOST_PLAYED -> savedStations.sortedWith(
-                    compareByDescending<Station> { it.playCount }.thenBy { stationSortKey(it.name) },
-                )
-            }
-        }
+        val queue = sortStations(repository.getAll().first(), _favoritesSort.value)
         val startIndex = resolveQueueStart(queue, station)
 
         controller?.apply {
@@ -971,60 +946,12 @@ private fun artistTitleDisplay(rawArtist: String, rawTitle: String, stationName:
 
 private fun Station.toEphemeral(): Station = copy(id = 0)
 
-private fun Station.toLastPlayedJson(): JSONObject =
-    JSONObject()
-        .put("id", id)
-        .put("name", name)
-        .put("streamUrl", streamUrl)
-        .put("logoPath", logoPath)
-        .put("isFavorite", isFavorite)
-        .put("provider", provider)
-        .put("providerId", providerId)
-        .put("tags", tags)
-        .put("description", description)
-        .put("country", country)
-        .put("countryCode", countryCode)
-
-private fun lastPlayedStationSnapshot(json: String): LastPlayedStationSnapshot {
-    val obj = JSONObject(json)
-    return LastPlayedStationSnapshot(
-        station = Station(
-            id = obj.optLong("id"),
-            name = obj.optString("name"),
-            streamUrl = obj.optString("streamUrl"),
-            logoPath = obj.optString("logoPath"),
-            isFavorite = obj.optBoolean("isFavorite"),
-            provider = obj.optString("provider"),
-            providerId = obj.optString("providerId"),
-            tags = obj.optString("tags"),
-            description = obj.optString("description"),
-            country = obj.optString("country"),
-            countryCode = obj.optString("countryCode"),
-        ),
-    )
-}
-
 private fun deleteLogoFiles(logoPath: String) {
     if (logoPath.isBlank() || logoPath.startsWith("http")) return
     val file = java.io.File(logoPath)
     file.delete()
     java.io.File(file.parentFile, "${file.nameWithoutExtension}_media.png").delete()
 }
-
-// Maps English number words and digit strings to zero-padded numbers so that
-// "BBC Radio One", "BBC Radio Two" … sort in numeric order rather than alphabetically.
-private val NUMBER_WORDS = mapOf(
-    "zero" to 0, "one" to 1, "two" to 2, "three" to 3, "four" to 4,
-    "five" to 5, "six" to 6, "seven" to 7, "eight" to 8, "nine" to 9,
-    "ten" to 10, "eleven" to 11, "twelve" to 12,
-)
-
-private fun stationSortKey(name: String): String =
-    name.split(Regex("\\s+")).joinToString(" ") { token ->
-        NUMBER_WORDS[token.lowercase()]?.let { "%03d".format(it) }
-            ?: token.toIntOrNull()?.let { "%03d".format(it) }
-            ?: token.lowercase()
-    }
 
 private fun PlaybackException.userMessage(): String {
     return when (errorCode) {

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -902,12 +902,27 @@ class MainViewModel(
         }
     }
 
-    private fun loadStationPaused(station: Station) {
-        val startIndex = resolveQueueStart(stations.value, station)
+    private suspend fun loadStationPaused(station: Station) {
+        // `stations` is a WhileSubscribed StateFlow because it is primarily a UI stream. During
+        // screen sleep there may be no collector, leaving its initial empty value in place. Using
+        // that value here restores only the current station, so the lock-screen Next action has
+        // no favourite to advance to. Read the database directly for service/resumption work.
+        val queue = repository.getAll().first().let { savedStations ->
+            when (_favoritesSort.value) {
+                FavoritesSort.AZ -> savedStations.sortedWith(compareBy { stationSortKey(it.name) })
+                FavoritesSort.LAST_PLAYED -> savedStations.sortedWith(
+                    compareByDescending<Station> { it.lastPlayedAt }.thenBy { stationSortKey(it.name) },
+                )
+                FavoritesSort.MOST_PLAYED -> savedStations.sortedWith(
+                    compareByDescending<Station> { it.playCount }.thenBy { stationSortKey(it.name) },
+                )
+            }
+        }
+        val startIndex = resolveQueueStart(queue, station)
 
         controller?.apply {
             if (startIndex != null) {
-                val mediaItems = stations.value.map { it.toPlayableMediaItem(getApplication()) }
+                val mediaItems = queue.map { it.toPlayableMediaItem(getApplication()) }
                 setMediaItems(mediaItems, startIndex, C.TIME_UNSET)
             } else {
                 setMediaItem(station.toPlayableMediaItem(getApplication()))


### PR DESCRIPTION
## Summary

- preserve the full Favorites queue when restoring paused playback after screen sleep
- resume the same queue when the system restarts the service directly (lock-screen/notification press with the app process dead), via `onPlaybackResumption`
- route Recently played taps through the Recently played queue
- make notification and lock-screen Forward/Back navigate media items for live radio
- use Media3 ForwardingPlayer instead of the deprecated command interception callback

## Root cause

Restored playback built its queue from a UI StateFlow that can retain its empty initial value while the app is not being collected. Notification navigation could also use generic live-stream seek behavior, which restarts the current item instead of moving through the station queue. Separately, `onPlaybackResumption` was unimplemented, so a lock-screen/notification press that restarted the whole process (no app UI involved) got Media3's default failed future instead of a real queue.

## Validation

- `./gradlew compileDebugKotlin`
- `./gradlew installDebug`
- manually tested, including lock-screen Previous with the app process killed and never reopened

Issue #148 was investigated during this work; the animation mismatch was not reproducible.