### PR TITLE
fix(ui): de-risk pager effects, trim Compose audit findings

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/MainActivity.kt
+++ b/app/src/main/java/com/shapeshed/aerial/MainActivity.kt
@@ -16,7 +16,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.remember
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -24,12 +27,10 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.shapeshed.aerial.ui.MainScreen
 import com.shapeshed.aerial.ui.MainViewModel
-import com.shapeshed.aerial.ui.MainViewModelFactory
 import com.shapeshed.aerial.ui.SettingsScreen
-import com.shapeshed.aerial.ui.SettingsViewModelFactory
+import com.shapeshed.aerial.ui.SettingsViewModel
 import com.shapeshed.aerial.ui.StationEditScreen
 import com.shapeshed.aerial.ui.StationEditViewModel
-import com.shapeshed.aerial.ui.StationEditViewModelFactory
 import com.shapeshed.aerial.ui.theme.AerialTheme
 
 object Routes {
@@ -44,12 +45,18 @@ class MainActivity : AppCompatActivity() {
 
     private val mainViewModel: MainViewModel by viewModels {
         val app = application as AerialApp
-        MainViewModelFactory(app, app.repository, app.registryRepository, app.settingsDataStore)
+        viewModelFactory {
+            initializer {
+                MainViewModel(app, app.repository, app.registryRepository, app.settingsDataStore, createSavedStateHandle())
+            }
+        }
     }
 
-    private val settingsViewModel: com.shapeshed.aerial.ui.SettingsViewModel by viewModels {
+    private val settingsViewModel: SettingsViewModel by viewModels {
         val app = application as AerialApp
-        com.shapeshed.aerial.ui.SettingsViewModelFactory(app, app.repository, app.settingsDataStore)
+        viewModelFactory {
+            initializer { SettingsViewModel(app, app.repository, app.settingsDataStore) }
+        }
     }
 
     @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -93,7 +100,9 @@ class MainActivity : AppCompatActivity() {
                     }
                     composable(Routes.STATION_ADD) {
                         val vm: StationEditViewModel = viewModel(
-                            factory = StationEditViewModelFactory(repository, null)
+                            factory = viewModelFactory {
+                                initializer { StationEditViewModel(repository, null) }
+                            }
                         )
                         StationEditScreen(
                             viewModel = vm,
@@ -106,7 +115,9 @@ class MainActivity : AppCompatActivity() {
                     ) { backStackEntry ->
                         val stationId = backStackEntry.arguments?.getLong("stationId")
                         val vm: StationEditViewModel = viewModel(
-                            factory = StationEditViewModelFactory(repository, stationId)
+                            factory = viewModelFactory {
+                                initializer { StationEditViewModel(repository, stationId) }
+                            }
                         )
                         StationEditScreen(
                             viewModel = vm,

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -288,6 +288,11 @@ enum class HomeViewMode {
 private const val TAB_HOME = 0
 private const val TAB_FAVORITES = 1
 
+// Bottom sheets in this app only ever hide or expand, never partially — shared so it isn't
+// reallocated on every recomposition of each sheet's host composable.
+@OptIn(ExperimentalMaterial3Api::class)
+internal val SHEET_ENABLED_VALUES = setOf(SheetValue.Hidden, SheetValue.Expanded)
+
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun MainScreen(
@@ -343,11 +348,11 @@ fun MainScreen(
     var selectedMoodId by rememberSaveable { mutableStateOf<String?>(null) }
     val countrySheetState = rememberBottomSheetState(
         initialValue = SheetValue.Hidden,
-        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        enabledValues = SHEET_ENABLED_VALUES,
     )
     val genreSheetState = rememberBottomSheetState(
         initialValue = SheetValue.Hidden,
-        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        enabledValues = SHEET_ENABLED_VALUES,
     )
     var countryFilterQuery by remember { mutableStateOf("") }
     var genreFilterQuery by remember { mutableStateOf("") }
@@ -942,7 +947,7 @@ fun MainScreen(
                 onDismissRequest = { contextStation = null },
                 sheetState = rememberBottomSheetState(
                     initialValue = SheetValue.Hidden,
-                    enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+                    enabledValues = SHEET_ENABLED_VALUES,
                 ),
                 dragHandle = { BottomSheetDefaults.DragHandle() },
             ) {
@@ -1203,13 +1208,14 @@ private fun FavoriteResultItem(
     onTap: () -> Unit,
     onPreviewPlay: () -> Unit,
     onTogglePlayback: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val pauseLabel = stringResource(R.string.pause)
     val countryLabel = station.countryCode.takeIf { it.isNotBlank() }
         ?.let { countryName(it, LocalConfiguration.current.locales[0]) }
         ?: station.country
     ListItem(
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onTap),
+        modifier = modifier.fillMaxWidth().clickable(onClick = onTap),
         leadingContent = {
             val context = LocalContext.current
             val logoModel = logoModelFor(station.logoPath)
@@ -1293,6 +1299,7 @@ private fun RegistryResultItem(
     onTogglePlayback: () -> Unit,
     onAdd: () -> Unit,
     onRemove: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val pauseLabel = stringResource(R.string.pause)
     // Localize the country from its ISO code (falling back to the registry's own name).
@@ -1300,7 +1307,7 @@ private fun RegistryResultItem(
         ?.let { countryName(it, LocalConfiguration.current.locales[0]) }
         ?: station.country
     ListItem(
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onTap),
+        modifier = modifier.fillMaxWidth().clickable(onClick = onTap),
         leadingContent = {
             StationLogoCircle(
                 logoModel = logoModelFor(station.logoUrl),
@@ -2042,7 +2049,7 @@ private fun FavoritesSortSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberBottomSheetState(
             initialValue = SheetValue.Hidden,
-            enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+            enabledValues = SHEET_ENABLED_VALUES,
         ),
         dragHandle = { BottomSheetDefaults.DragHandle() },
     ) {

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -13,10 +13,7 @@ import android.os.Bundle
 import org.json.JSONArray
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.media3.common.C
 import androidx.media3.common.Format
 import androidx.media3.common.MediaItem
@@ -88,8 +85,8 @@ class MainViewModel(
     private val repository: StationRepository,
     private val registryRepository: RegistryRepository,
     private val dataStore: DataStore<Preferences>,
-    // Default is test/preview-only — MainViewModelFactory always passes an explicit
-    // SavedStateHandle via CreationExtras.createSavedStateHandle() in production.
+    // Default is test/preview-only — the viewModelFactory { initializer { } } in MainActivity
+    // always passes an explicit SavedStateHandle via CreationExtras.createSavedStateHandle().
     @Suppress("VisibleForTests")
     private val savedStateHandle: SavedStateHandle = SavedStateHandle(),
 ) : AndroidViewModel(application) {
@@ -970,14 +967,3 @@ private fun PlaybackException.userMessage(): String {
     }
 }
 
-class MainViewModelFactory(
-    private val application: Application,
-    private val repository: StationRepository,
-    private val registryRepository: RegistryRepository,
-    private val dataStore: DataStore<Preferences>,
-) : ViewModelProvider.Factory {
-    override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
-        @Suppress("UNCHECKED_CAST")
-        return MainViewModel(application, repository, registryRepository, dataStore, extras.createSavedStateHandle()) as T
-    }
-}

--- a/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
@@ -249,7 +249,13 @@ fun NowPlayingScreen(
                             midpoint - circularPageIndex(midpoint, swipeStations.size) + swipeIndex
                         }
                         val pagerState = rememberPagerState(initialPage = initialPage) { virtualPageCount }
+                        // Set while the effect below is correcting the pager to match an external
+                        // station change, so that correction's own settle doesn't loop back into
+                        // onPlayStation below — a settle it causes reflects a decision already made
+                        // elsewhere, not a new one the user just swiped to.
+                        var isSyncingToStation by remember { mutableStateOf(false) }
                         LaunchedEffect(pagerState.settledPage) {
+                            if (isSyncingToStation) return@LaunchedEffect
                             val target = swipeStations[circularPageIndex(pagerState.settledPage, swipeStations.size)]
                             if (!target.matches(station)) onPlayStation(target)
                         }
@@ -261,7 +267,12 @@ fun NowPlayingScreen(
                                 val forwardDelta = circularPageIndex(swipeIndex - currentIndex, swipeStations.size)
                                 val backwardDelta = forwardDelta - swipeStations.size
                                 val delta = if (abs(backwardDelta) < forwardDelta) backwardDelta else forwardDelta
-                                pagerState.animateScrollToPage(pagerState.currentPage + delta)
+                                isSyncingToStation = true
+                                try {
+                                    pagerState.animateScrollToPage(pagerState.currentPage + delta)
+                                } finally {
+                                    isSyncingToStation = false
+                                }
                             }
                         }
                         HorizontalPager(

--- a/app/src/main/java/com/shapeshed/aerial/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/SettingsViewModel.kt
@@ -7,8 +7,6 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.shapeshed.aerial.FAVORITES_GRID_COLUMNS_DEFAULT
 import com.shapeshed.aerial.FAVORITES_GRID_COLUMNS_KEY
@@ -227,15 +225,4 @@ class SettingsViewModel(
 
     private fun safeFileName(name: String): String =
         name.replace(Regex("[^A-Za-z0-9._-]"), "_").ifBlank { "logo" }
-}
-
-class SettingsViewModelFactory(
-    private val application: Application,
-    private val repository: StationRepository,
-    private val dataStore: DataStore<Preferences>,
-) : ViewModelProvider.Factory {
-    override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        @Suppress("UNCHECKED_CAST")
-        return SettingsViewModel(application, repository, dataStore) as T
-    }
 }

--- a/app/src/main/java/com/shapeshed/aerial/ui/SleepTimerSheet.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/SleepTimerSheet.kt
@@ -137,7 +137,7 @@ fun SleepTimerSheet(
 ) {
     val sheetState = rememberBottomSheetState(
         initialValue = SheetValue.Hidden,
-        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        enabledValues = SHEET_ENABLED_VALUES,
     )
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(

--- a/app/src/main/java/com/shapeshed/aerial/ui/StationEditViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/StationEditViewModel.kt
@@ -3,7 +3,6 @@ package com.shapeshed.aerial.ui
 import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.shapeshed.aerial.data.Station
 import com.shapeshed.aerial.data.StationRepository
@@ -88,15 +87,5 @@ class StationEditViewModel(
             if (stationId == null) repository.insert(station) else repository.update(station)
             withContext(Dispatchers.Main) { onDone() }
         }
-    }
-}
-
-class StationEditViewModelFactory(
-    private val repository: StationRepository,
-    private val stationId: Long?,
-) : ViewModelProvider.Factory {
-    override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        @Suppress("UNCHECKED_CAST")
-        return StationEditViewModel(repository, stationId) as T
     }
 }


### PR DESCRIPTION
## Summary

- Guard `NowPlayingScreen`'s swipe-pager effects so a programmatic catch-up scroll can't re-trigger `onPlayStation` — the likely mechanism behind #148 (wrong-station animation after screen sleep)
- Hoist the repeated bottom-sheet `enabledValues` `Set` literal to a shared constant
- Add `modifier` param to `FavoriteResultItem`/`RegistryResultItem` for consistency with the app's other list rows
- Replace the 3 hand-written `ViewModelFactory` classes with `viewModelFactory { initializer { } }`

## Validation

- `./gradlew compileDebugKotlin`
- `./gradlew testDebugUnitTest`
- `./gradlew quality` (lint gate)
- `./gradlew installDebug`, manually tested