### PR TITLE
feat(player): scroll long track titles in the mini player and Now Playing pane

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -753,12 +753,14 @@ fun MainScreen(
                                 style = MaterialTheme.typography.titleMedium,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.safeMarquee(),
                             )
                             Text(
                                 text = miniPlayerSubtitle,
                                 style = MaterialTheme.typography.bodyMedium,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.safeMarquee(),
                             )
                         }
                 }

--- a/app/src/main/java/com/shapeshed/aerial/ui/Marquee.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/Marquee.kt
@@ -1,0 +1,21 @@
+package com.shapeshed.aerial.ui
+
+import android.provider.Settings
+import androidx.compose.foundation.basicMarquee
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+
+/** [basicMarquee] ignores the system "Remove animations" accessibility setting (animator
+ * duration scale == 0) — unlike native Android views, which respect it everywhere. That setting
+ * exists for users who get physically sick from motion, so check it first and no-op otherwise,
+ * leaving whatever ellipsis/wrap behavior the Text already has. */
+@Composable
+fun Modifier.safeMarquee(): Modifier {
+    val context = LocalContext.current
+    val animationsRemoved = remember(context) {
+        Settings.Global.getFloat(context.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f) == 0f
+    }
+    return if (animationsRemoved) this else this.basicMarquee()
+}

--- a/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
@@ -353,6 +353,7 @@ fun NowPlayingScreen(
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,
                                     textAlign = androidx.compose.ui.text.style.TextAlign.Start,
+                                    modifier = Modifier.fillMaxWidth().safeMarquee(),
                                 )
                                 if (!trackArtist.isNullOrBlank() && !trackTitle.isNullOrBlank()) {
                                     Text(
@@ -362,6 +363,7 @@ fun NowPlayingScreen(
                                         maxLines = 1,
                                         overflow = TextOverflow.Ellipsis,
                                         textAlign = androidx.compose.ui.text.style.TextAlign.Start,
+                                        modifier = Modifier.fillMaxWidth().safeMarquee(),
                                     )
                                 }
                             }


### PR DESCRIPTION
Closes #142

## Summary

- Add `Modifier.safeMarquee()` (`ui/Marquee.kt`), wrapping the stable `androidx.compose.foundation.basicMarquee()`
- Apply it to the mini player title/subtitle and the Now Playing pane's track artist/title — the two places showing the currently-playing track/station name
- List and grid station names elsewhere (favourites, search, mood cards) are unchanged — ellipsis is the right call there, not marquee

## Why `safeMarquee()` and not bare `basicMarquee()`

`basicMarquee()` ignores the system "Remove animations" accessibility setting (animator duration scale = 0), unlike native Android views, which respect it everywhere. That setting exists for users who get physically sick from motion. `safeMarquee()` checks it first and no-ops otherwise, falling back to the existing ellipsis behavior.

Marquee is scoped to just the currently-playing title/artist because that's the one thing the user is actively looking at — this also matches how the system media notification already scrolls the same text, so the in-app UI and the notification are now consistent instead of one scrolling and the other truncating.

## Validation

- `./gradlew compileDebugKotlin`
- `./gradlew testDebugUnitTest`
- `./gradlew quality`
- `./gradlew installDebug`, manually tested