### PR TITLE
chore(release): v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-08-12
+
 ### Added
 
+- Long track and station titles now scroll in the mini player and Now Playing screen. (#142, #160)
 - Russian translation, contributed by `kTmepg` and `chip` via Weblate. (#139, #145)
 - Estonian translation, contributed by Priit Jõerüüt via Weblate. (#145)
+- Turkish translation, contributed by Nuri Efe via Weblate.
+
+### Fixed
+
+- Restoring paused playback after screen sleep now keeps the full Favourites queue, including notification navigation. (#158)
+- Hardened the Now Playing artwork pager against settling on the wrong station. (#159)
 
 ## [0.6.0] - 2026-07-31
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,8 +32,8 @@ android {
         applicationId "com.shapeshed.aerial"
         minSdk 26
         targetSdk 37
-        versionCode 15
-        versionName "0.6.0"
+        versionCode 16
+        versionName "0.6.1"
     }
 
     signingConfigs {

--- a/app/src/main/java/com/shapeshed/aerial/ui/LanguagePicker.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/LanguagePicker.kt
@@ -37,17 +37,20 @@ data class AppLanguage(val tag: String, val autonym: String)
 
 // Must stay in sync with res/xml/locales_config.xml and the values-* resource dirs.
 val APP_LANGUAGES: List<AppLanguage> = listOf(
+    AppLanguage("de", "Deutsch"),
     AppLanguage("en", "English (US)"),
     AppLanguage("en-GB", "English (UK)"),
     AppLanguage("es", "Español"),
+    AppLanguage("et", "Eesti"),
     AppLanguage("fr", "Français"),
-    AppLanguage("de", "Deutsch"),
     AppLanguage("it", "Italiano"),
-    AppLanguage("pt", "Português"),
-    AppLanguage("nl", "Nederlands"),
-    AppLanguage("zh-CN", "简体中文"),
     AppLanguage("ja", "日本語"),
     AppLanguage("ko", "한국어"),
+    AppLanguage("nl", "Nederlands"),
+    AppLanguage("pt", "Português"),
+    AppLanguage("ru", "Русский"),
+    AppLanguage("tr", "Türkçe"),
+    AppLanguage("zh-CN", "简体中文"),
 )
 
 private fun setAppLanguage(tag: String) {

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="de" />
     <locale android:name="en" />
     <locale android:name="en-GB" />
     <locale android:name="es" />
+    <locale android:name="et" />
     <locale android:name="fr" />
-    <locale android:name="de" />
     <locale android:name="it" />
-    <locale android:name="pt" />
-    <locale android:name="nl" />
-    <locale android:name="zh-CN" />
     <locale android:name="ja" />
     <locale android:name="ko" />
+    <locale android:name="nl" />
+    <locale android:name="pt" />
+    <locale android:name="ru" />
+    <locale android:name="tr" />
+    <locale android:name="zh-CN" />
 </locale-config>

--- a/fastlane/metadata/android/en-US/changelogs/16.txt
+++ b/fastlane/metadata/android/en-US/changelogs/16.txt
@@ -1,0 +1,3 @@
+- Scroll long track and station titles in the mini player and Now Playing screen.
+- Fix restoring paused playback and notification navigation after screen sleep.
+- Add Russian, Estonian, and Turkish translations.


### PR DESCRIPTION
Prepare the 0.6.1 release.

## Release notes

### Added
- Long track and station titles now scroll in the mini player and Now Playing screen. (#142, #160)
- Russian translation, contributed by `kTmepg` and `chip` via Weblate. (#139, #145)
- Estonian translation, contributed by Priit Jõerüüt via Weblate. (#145)
- Turkish translation, contributed by Nuri Efe via Weblate.

### Fixed
- Restoring paused playback after screen sleep now keeps the full Favourites queue, including notification navigation. (#158)
- Hardened the Now Playing artwork pager against settling on the wrong station. (#159)

## Validation

- `scripts/bump-version.sh 0.6.1`
- `scripts/prepare-release.sh --skip-fdroid` (test, lint, assembleRelease, bundleRelease all pass; F-Droid metadata sync skipped — no local `fdroiddata` checkout on this machine)

This PR does not tag, push a release, or publish to Google Play — that stays a separate, deliberate step.