### PR TITLE
fix(playback): keep station state synced after sleep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,23 @@ Build only debug Kotlin when checking a small UI/code change:
 ./gradlew compileDebugKotlin
 ```
 
+## On-device tests
+
+Instrumented tests use the `deviceTest` build type and the isolated application id
+`com.shapeshed.aerial.deviceTest`. This keeps the test APK, database, preferences,
+and cleanup separate from the normal development application
+`com.shapeshed.aerial`.
+
+Run them with:
+
+```sh
+./gradlew connectedDeviceTestAndroidTest
+```
+
+Do not change `testBuildType` to `debug` or run test automation against the normal
+application id: installing or clearing that target can replace or wipe a developer's
+local app and data.
+
 ## Release Versioning
 
 Release versions use:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,7 @@ android {
         targetSdk 37
         versionCode 16
         versionName "0.6.1"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     signingConfigs {
@@ -48,6 +49,11 @@ android {
     }
 
     buildTypes {
+        deviceTest {
+            initWith debug
+            applicationIdSuffix ".deviceTest"
+            matchingFallbacks = ['debug']
+        }
         release {
             if (hasReleaseSigning) {
                 signingConfig signingConfigs.release
@@ -57,6 +63,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    testBuildType "deviceTest"
 
     ksp {
         arg("room.schemaLocation", "$projectDir/schemas")
@@ -179,4 +187,9 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.json:json:20240303'
     testImplementation 'org.mockito.kotlin:mockito-kotlin:6.3.0'
+
+    androidTestImplementation 'androidx.test:runner:1.7.0'
+    androidTestImplementation 'androidx.test:rules:1.7.0'
+    androidTestImplementation 'androidx.test:core-ktx:1.7.0'
+    androidTestImplementation 'androidx.test.ext:junit-ktx:1.3.0'
 }

--- a/app/src/androidTest/java/com/shapeshed/aerial/Media3QueueNavigationTest.kt
+++ b/app/src/androidTest/java/com/shapeshed/aerial/Media3QueueNavigationTest.kt
@@ -1,0 +1,50 @@
+package com.shapeshed.aerial
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class Media3QueueNavigationTest {
+
+    @Test
+    fun nextAndPreviousNavigateAndWrapWhilePausedOrPlaying() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<AerialApp>()
+        withContext(Dispatchers.Main) {
+            val player = ExoPlayer.Builder(context).build()
+            try {
+                player.repeatMode = Player.REPEAT_MODE_ALL
+                player.setMediaItems(
+                    listOf("left", "right").map { id ->
+                        MediaItem.Builder()
+                            .setMediaId(id)
+                            .setUri("https://example.invalid/$id")
+                            .build()
+                    },
+                )
+
+                assertEquals("left", player.currentMediaItem?.mediaId)
+                player.seekToNextMediaItem()
+                assertEquals("right", player.currentMediaItem?.mediaId)
+                player.seekToNextMediaItem()
+                assertEquals("left", player.currentMediaItem?.mediaId)
+
+                player.playWhenReady = true
+                player.seekToPreviousMediaItem()
+                assertEquals("right", player.currentMediaItem?.mediaId)
+                player.seekToPreviousMediaItem()
+                assertEquals("left", player.currentMediaItem?.mediaId)
+            } finally {
+                player.release()
+            }
+        }
+    }
+}

--- a/app/src/androidTest/java/com/shapeshed/aerial/ui/Issue148PlaybackSyncTest.kt
+++ b/app/src/androidTest/java/com/shapeshed/aerial/ui/Issue148PlaybackSyncTest.kt
@@ -1,0 +1,156 @@
+package com.shapeshed.aerial.ui
+
+import androidx.datastore.preferences.core.edit
+import androidx.media3.common.Player
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.shapeshed.aerial.AerialApp
+import com.shapeshed.aerial.toPlayableMediaItem
+import com.shapeshed.aerial.data.LAST_PLAYED_STATION_KEY
+import com.shapeshed.aerial.data.Station
+import com.shapeshed.aerial.data.lastPlayedStationSnapshot
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class Issue148PlaybackSyncTest {
+
+    @Test
+    fun playbackSnapshotKeepsStationQueueAndPlayStateCoherent() = runBlocking {
+        val app = ApplicationProvider.getApplicationContext<AerialApp>()
+        val leftId = app.repository.insertOrGetExisting(station("Snapshot left", "snapshot-left"))
+        val rightId = app.repository.insertOrGetExisting(station("Snapshot right", "snapshot-right"))
+        val left = app.repository.getById(leftId)!!
+        val right = app.repository.getById(rightId)!!
+        val queue = listOf(left, right)
+        app.settingsDataStore.edit { preferences ->
+            preferences.remove(LAST_PLAYED_STATION_KEY)
+        }
+        val viewModel = withContext(Dispatchers.Main) {
+            MainViewModel(app, app.repository, app.registryRepository, app.settingsDataStore)
+        }
+        withTimeout(5_000) {
+            viewModel.stations.first { stations -> stations.count { it.id in setOf(leftId, rightId) } == 2 }
+        }
+
+        withContext(Dispatchers.Main) {
+            viewModel.handlePlaybackEvents(left.toPlayableMediaItem(app), isPlaying = false, queue = queue)
+        }
+        assertEquals(
+            PlaybackUiState(left, isPlaying = false, isBuffering = false, queue = queue),
+            viewModel.playbackUiState.value,
+        )
+
+        withContext(Dispatchers.Main) {
+            viewModel.handlePlaybackEvents(
+                mediaItem = right.toPlayableMediaItem(app),
+                isPlaying = false,
+                playbackState = Player.STATE_BUFFERING,
+                playWhenReady = true,
+                queue = queue,
+            )
+        }
+        assertEquals(
+            PlaybackUiState(right, isPlaying = false, isBuffering = true, queue = queue),
+            viewModel.playbackUiState.value,
+        )
+
+        withContext(Dispatchers.Main) {
+            viewModel.handlePlaybackEvents(right.toPlayableMediaItem(app), isPlaying = true, queue = queue)
+        }
+        assertEquals(
+            PlaybackUiState(right, isPlaying = true, isBuffering = false, queue = queue),
+            viewModel.playbackUiState.value,
+        )
+    }
+
+    @Test
+    fun immediatePlayStateAfterExternalTransitionPersistsTransitionedStation() = runBlocking {
+        val app = ApplicationProvider.getApplicationContext<AerialApp>()
+        val left = station("Left station", "left")
+        val right = station("Right station", "right")
+        val leftId = app.repository.insertOrGetExisting(left)
+        val rightId = app.repository.insertOrGetExisting(right)
+        val savedLeft = app.repository.getById(leftId)!!
+        val savedRight = app.repository.getById(rightId)!!
+        app.settingsDataStore.edit { preferences ->
+            preferences.remove(LAST_PLAYED_STATION_KEY)
+        }
+
+        val viewModel = withContext(Dispatchers.Main) {
+            MainViewModel(app, app.repository, app.registryRepository, app.settingsDataStore)
+        }
+        val collection = launch(Dispatchers.Main) { viewModel.playbackUiState.collect {} }
+        withTimeout(5_000) {
+            viewModel.stations.first { stations ->
+                stations.any { it.id == leftId } && stations.any { it.id == rightId }
+            }
+        }
+
+        withContext(Dispatchers.Main) {
+            viewModel.handlePlaybackEvents(
+                mediaItem = savedLeft.toPlayableMediaItem(app),
+                isPlaying = false,
+            )
+        }
+        awaitCurrentStation(viewModel, leftId)
+        collection.cancelAndJoin()
+        // Lifecycle-aware Compose collection stops while the activity is sleeping. Let the
+        // WhileSubscribed station state stop before the system media control changes station.
+        delay(5_100)
+
+        // Media3 batches these callbacks when a lock-screen/notification Next action
+        // transitions an item and resumes it while the app UI is asleep. Issue #148 is the
+        // dormant derived station value read by the immediately following playback callback.
+        withContext(Dispatchers.Main) {
+            viewModel.handlePlaybackEvents(
+                mediaItem = savedRight.toPlayableMediaItem(app),
+                isPlaying = true,
+            )
+        }
+
+        val persisted = awaitPersistedStation(app, rightId)
+        assertEquals(
+            "The persisted station must follow the MediaSession transition",
+            rightId,
+            persisted,
+        )
+        assertEquals(savedRight, viewModel.playbackUiState.value.station)
+        assertEquals(true, viewModel.playbackUiState.value.isPlaying)
+    }
+
+    private suspend fun awaitCurrentStation(viewModel: MainViewModel, id: Long) {
+        withTimeout(5_000) {
+            viewModel.playbackUiState.first { it.station?.id == id }
+        }
+    }
+
+    private suspend fun awaitPersistedStation(app: AerialApp, expectedId: Long): Long {
+        var lastId: Long? = null
+        repeat(100) {
+            val json = app.settingsDataStore.data.first()[LAST_PLAYED_STATION_KEY]
+            val id = json?.let(::lastPlayedStationSnapshot)?.station?.id
+            if (id == expectedId) return id
+            lastId = id
+            delay(10)
+        }
+        return lastId ?: error("No last-played station was persisted")
+    }
+
+    private fun station(name: String, providerId: String) = Station(
+        name = name,
+        streamUrl = "https://example.invalid/$providerId",
+        isFavorite = true,
+        provider = "issue-148-test",
+        providerId = providerId,
+    )
+}

--- a/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
+++ b/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.os.SystemClock
 import android.util.Log
 import androidx.annotation.OptIn
+import androidx.datastore.preferences.core.edit
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.ForwardingPlayer
@@ -15,6 +16,7 @@ import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Metadata
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
+import androidx.media3.common.Timeline
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.datasource.ResolvingDataSource
@@ -60,6 +62,7 @@ import com.shapeshed.aerial.data.sortStations
 import com.shapeshed.aerial.data.Station
 import com.shapeshed.aerial.data.StationRepository
 import com.shapeshed.aerial.data.parseIcyTitle
+import com.shapeshed.aerial.data.toLastPlayedJson
 import com.shapeshed.aerial.SHOW_HOME_KEY
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -217,6 +220,11 @@ class PlayerService : MediaLibraryService() {
             lastIcyTitle = null
             lastId3Title = null
             updateFavoriteButton()
+            persistPlaybackSnapshot()
+        }
+
+        override fun onTimelineChanged(timeline: Timeline, reason: Int) {
+            persistPlaybackSnapshot()
         }
 
         @OptIn(UnstableApi::class)
@@ -471,11 +479,17 @@ class PlayerService : MediaLibraryService() {
                 ?: throw UnsupportedOperationException("No last-played station to resume")
             val savedStation = snapshot.station.id.takeIf { it > 0 }?.let { repository.getById(it) }
                 ?: repository.getByStreamUrl(snapshot.station.streamUrl)
-            val sort = dataStore.data.first()[FAVORITES_SORT_KEY]
-                ?.let { saved -> FavoritesSort.entries.firstOrNull { it.name == saved } }
-                ?: FavoritesSort.AZ
-            val queue = sortStations(repository.getAll().first(), sort)
-            val startIndex = savedStation?.let { resolveQueueStart(queue, it) }
+            val queue = snapshot.queue.takeIf { it.size > 1 } ?: run {
+                // Backward compatibility for snapshots written before ordered queues were
+                // persisted. New snapshots restore the exact Media3 timeline instead of
+                // rebuilding it from mutable Last/Most Played statistics.
+                val sort = dataStore.data.first()[FAVORITES_SORT_KEY]
+                    ?.let { saved -> FavoritesSort.entries.firstOrNull { it.name == saved } }
+                    ?: FavoritesSort.AZ
+                sortStations(repository.getAll().first(), sort)
+            }
+            val resumed = savedStation ?: snapshot.station.copy(id = 0)
+            val startIndex = resolveQueueStart(queue, resumed)
             if (startIndex != null) {
                 MediaSession.MediaItemsWithStartPosition(
                     queue.map { it.toPlayableMediaItem(this@PlayerService) },
@@ -483,7 +497,6 @@ class PlayerService : MediaLibraryService() {
                     C.TIME_UNSET,
                 )
             } else {
-                val resumed = savedStation ?: snapshot.station.copy(id = 0)
                 MediaSession.MediaItemsWithStartPosition(
                     listOf(resumed.toPlayableMediaItem(this@PlayerService)),
                     0,
@@ -601,6 +614,17 @@ class PlayerService : MediaLibraryService() {
     }
 
     private fun currentStation(): Station? = stationForMediaItem(player.currentMediaItem)
+
+    private fun persistPlaybackSnapshot() {
+        val current = currentStation() ?: return
+        val queue = (0 until player.mediaItemCount)
+            .mapNotNull { index -> stationForMediaItem(player.getMediaItemAt(index)) }
+        serviceScope.launch {
+            dataStore.edit { preferences ->
+                preferences[LAST_PLAYED_STATION_KEY] = current.toLastPlayedJson(queue).toString()
+            }
+        }
+    }
 
     private fun stationForMediaItem(mediaItem: MediaItem?): Station? {
         if (mediaItem == null) return null

--- a/app/src/main/java/com/shapeshed/aerial/data/StationQueue.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/StationQueue.kt
@@ -17,40 +17,53 @@ enum class FavoritesSort {
 
 data class LastPlayedStationSnapshot(
     val station: Station,
+    val queue: List<Station> = emptyList(),
 )
 
-fun Station.toLastPlayedJson(): JSONObject =
+fun Station.toLastPlayedJson(queue: List<Station> = emptyList()): JSONObject =
+    stationJson(this)
+        .put("queue", org.json.JSONArray().apply {
+            queue.forEach { put(stationJson(it)) }
+        })
+
+private fun stationJson(station: Station): JSONObject =
     JSONObject()
-        .put("id", id)
-        .put("name", name)
-        .put("streamUrl", streamUrl)
-        .put("logoPath", logoPath)
-        .put("isFavorite", isFavorite)
-        .put("provider", provider)
-        .put("providerId", providerId)
-        .put("tags", tags)
-        .put("description", description)
-        .put("country", country)
-        .put("countryCode", countryCode)
+        .put("id", station.id)
+        .put("name", station.name)
+        .put("streamUrl", station.streamUrl)
+        .put("logoPath", station.logoPath)
+        .put("isFavorite", station.isFavorite)
+        .put("provider", station.provider)
+        .put("providerId", station.providerId)
+        .put("tags", station.tags)
+        .put("description", station.description)
+        .put("country", station.country)
+        .put("countryCode", station.countryCode)
 
 fun lastPlayedStationSnapshot(json: String): LastPlayedStationSnapshot {
     val obj = JSONObject(json)
     return LastPlayedStationSnapshot(
-        station = Station(
-            id = obj.optLong("id"),
-            name = obj.optString("name"),
-            streamUrl = obj.optString("streamUrl"),
-            logoPath = obj.optString("logoPath"),
-            isFavorite = obj.optBoolean("isFavorite"),
-            provider = obj.optString("provider"),
-            providerId = obj.optString("providerId"),
-            tags = obj.optString("tags"),
-            description = obj.optString("description"),
-            country = obj.optString("country"),
-            countryCode = obj.optString("countryCode"),
-        ),
+        station = obj.toStation(),
+        queue = obj.optJSONArray("queue")?.let { array ->
+            (0 until array.length()).map { index -> array.getJSONObject(index).toStation() }
+        }.orEmpty(),
     )
 }
+
+private fun JSONObject.toStation(): Station =
+    Station(
+        id = optLong("id"),
+        name = optString("name"),
+        streamUrl = optString("streamUrl"),
+        logoPath = optString("logoPath"),
+        isFavorite = optBoolean("isFavorite"),
+        provider = optString("provider"),
+        providerId = optString("providerId"),
+        tags = optString("tags"),
+        description = optString("description"),
+        country = optString("country"),
+        countryCode = optString("countryCode"),
+    )
 
 fun sortStations(stations: List<Station>, sort: FavoritesSort): List<Station> = when (sort) {
     FavoritesSort.AZ -> stations.sortedWith(compareBy { stationSortKey(it.name) })

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -304,9 +304,10 @@ fun MainScreen(
 ) {
     val context = LocalContext.current
     val stations by viewModel.stations.collectAsStateWithLifecycle()
-    val currentStation by viewModel.currentStation.collectAsStateWithLifecycle()
-    val isPlaying by viewModel.isPlaying.collectAsStateWithLifecycle()
-    val isBuffering by viewModel.isBuffering.collectAsStateWithLifecycle()
+    val playbackUiState by viewModel.playbackUiState.collectAsStateWithLifecycle()
+    val currentStation = playbackUiState.station
+    val isPlaying = playbackUiState.isPlaying
+    val isBuffering = playbackUiState.isBuffering
     val currentTrackTitle by viewModel.currentTrackTitle.collectAsStateWithLifecycle()
     val currentTrackArtist by viewModel.currentTrackArtist.collectAsStateWithLifecycle()
     val currentBitrateKbps by viewModel.currentBitrateKbps.collectAsStateWithLifecycle()
@@ -374,9 +375,6 @@ fun MainScreen(
     val stationContentBottomPadding = if (currentStation != null) with(density) { miniPlayerHeightPx.toDp() } else 0.dp
     val selectedMood = selectedMoodId?.let { id -> CURATED_MOODS.firstOrNull { it.id == id } }
     val selectedMoodStations = selectedMoodId?.let { curatedMoodStations[it] }.orEmpty()
-    val moodSwipeStations = remember(selectedMoodStations) {
-        selectedMoodStations.map { it.toPlaybackStation() }
-    }
 
     BackHandler(enabled = showNowPlaying) { viewModel.setShowNowPlaying(false) }
     BackHandler(enabled = selectedMood != null && !showNowPlaying) { selectedMoodId = null }
@@ -784,11 +782,10 @@ fun MainScreen(
                 // Swipe order frozen for the lifetime of the pane: under the Last/Most played
                 // sorts, playing a station immediately re-sorts the live list, which would make
                 // consecutive swipes ping-pong between the same two stations.
-                val favoriteSwipeStations = remember { viewModel.stations.value }
-                val useMoodSwipeStations = selectedMood != null &&
-                    moodSwipeStations.size > 1 &&
-                    moodSwipeStations.any { moodStation -> station.matches(moodStation) }
-                val swipeStations = if (useMoodSwipeStations) moodSwipeStations else favoriteSwipeStations
+                val fallbackSwipeStations = remember { viewModel.stations.value }
+                val swipeStations = playbackUiState.queue
+                    .takeIf { queue -> queue.size > 1 && queue.any(station::matches) }
+                    ?: fallbackSwipeStations
                 NowPlayingScreen(
                     station = station,
                     isPlaying = isPlaying,

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -218,6 +218,8 @@ class MainViewModel(
 
     private val _currentStationId = MutableStateFlow<Long?>(null)
     private val _ephemeralStation = MutableStateFlow<Station?>(null)
+    private val _playbackUiState = MutableStateFlow(PlaybackUiState())
+    val playbackUiState: StateFlow<PlaybackUiState> = _playbackUiState.asStateFlow()
     // Carries the last-played station to loadStationPaused() once the MediaController connects.
     // CompletableDeferred ensures the handoff is safe regardless of which side wins the race.
     private val pendingRestoreStation = CompletableDeferred<Station?>()
@@ -234,28 +236,15 @@ class MainViewModel(
                 val id = _currentStationId.value
                 if (id != null && list.none { it.id == id }) {
                     previous.firstOrNull { it.id == id }?.let { removed ->
-                        _ephemeralStation.value = removed.copy(id = 0, isFavorite = false)
-                        _currentStationId.value = null
+                        setCurrentStation(removed.copy(id = 0, isFavorite = false))
                     }
+                } else if (id != null) {
+                    list.firstOrNull { it.id == id }?.let(::refreshCurrentStation)
                 }
                 previous = list
             }
         }
     }
-
-    val currentStation: StateFlow<Station?> = combine(
-        _allStations,
-        _currentStationId,
-        _ephemeralStation,
-    ) { list, id, ephemeral ->
-        ephemeral ?: id?.let { i -> list.firstOrNull { s -> s.id == i } }
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
-
-    private val _isPlaying = MutableStateFlow(false)
-    val isPlaying: StateFlow<Boolean> = _isPlaying.asStateFlow()
-
-    private val _isBuffering = MutableStateFlow(false)
-    val isBuffering: StateFlow<Boolean> = _isBuffering.asStateFlow()
 
     private val _currentTrackTitle = MutableStateFlow<String?>(null)
     val currentTrackTitle: StateFlow<String?> = _currentTrackTitle.asStateFlow()
@@ -273,11 +262,11 @@ class MainViewModel(
     // current station changes so the UI never has
     // to reconcile the sources itself.
     val nowPlayingDisplay: StateFlow<NowPlayingDisplay> = combine(
-        currentStation,
+        playbackUiState,
         _currentTrackTitle,
         _currentTrackArtist,
-    ) { station, icyTitle, icyArtist ->
-        computeNowPlayingDisplay(station?.name.orEmpty(), icyTitle, icyArtist, liveRadio())
+    ) { playback, icyTitle, icyArtist ->
+        computeNowPlayingDisplay(playback.station?.name.orEmpty(), icyTitle, icyArtist, liveRadio())
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), NowPlayingDisplay("", ""))
 
     // Localized "Live Radio" — the placeholder shown in the notification / mini player when a
@@ -543,18 +532,12 @@ class MainViewModel(
             controller?.currentMediaItem?.mediaId?.toLongOrNull()?.let { id ->
                 val station = _allStations.value.firstOrNull { it.id == id }
                 if (station != null) {
-                    _currentStationId.value = station.id
-                    if (_ephemeralStation.value?.streamUrl == station.streamUrl) {
-                        _ephemeralStation.value = null
-                    }
-                    _isPlaying.value = controller?.isPlaying ?: false
-                    updateCurrentBitrate(controller?.currentTracks ?: Tracks.EMPTY)
+                    syncPlaybackState(controller, station)
                     controller?.mediaMetadata?.artist?.toString()?.trim()
                         ?.takeIf { it.isNotEmpty() && it != liveRadio() }
                         ?.let { _currentTrackTitle.value = it }
                 } else if (_currentStationId.value == null) {
-                    _isPlaying.value = controller?.isPlaying ?: false
-                    updateCurrentBitrate(controller?.currentTracks ?: Tracks.EMPTY)
+                    syncPlaybackState(controller)
                 }
             }
             if (controller?.currentMediaItem == null) {
@@ -574,7 +557,7 @@ class MainViewModel(
                 val id = repository.saveAsFavorite(ensureLocalLogo(station))
                 _currentStationId.value = id
                 _allStations.first { list -> list.any { it.id == id } }
-                _ephemeralStation.value = null
+                setCurrentStation(repository.getById(id) ?: station.copy(id = id, isFavorite = true))
                 return@launch
             }
             if (!station.isFavorite) {
@@ -589,8 +572,7 @@ class MainViewModel(
             // its logo files so re-favouriting restores the same artwork.
             val isCurrent = _currentStationId.value == station.id
             if (isCurrent) {
-                _ephemeralStation.value = station.copy(id = 0, isFavorite = false)
-                _currentStationId.value = null
+                setCurrentStation(station.copy(id = 0, isFavorite = false))
             } else {
                 clearLastPlayedStationIfMatching(station)
             }
@@ -607,74 +589,29 @@ class MainViewModel(
         // session's media item, not just this ViewModel's own play() calls. When play() did
         // initiate the change the state already matches and the guards below make this a
         // no-op.
-        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-            val item = mediaItem ?: return
-            val extras = item.mediaMetadata.extras
-            val streamUrl = extras?.getString("streamUrl").orEmpty()
-            val provider = extras?.getString("provider").orEmpty()
-            val providerId = extras?.getString("providerId").orEmpty()
-            // Resolve to a saved row the same way PlayerService.stationForMediaItem does:
-            // numeric mediaId first, then provider identity, then stream URL.
-            val saved = item.mediaId.toLongOrNull()
-                ?.let { id -> _allStations.value.firstOrNull { it.id == id } }
-                ?: _allStations.value.firstOrNull {
-                    provider.isNotBlank() && providerId.isNotBlank() &&
-                        it.provider == provider && it.providerId == providerId
-                }
-                ?: _allStations.value.firstOrNull { streamUrl.isNotBlank() && it.streamUrl == streamUrl }
-            val current = currentStation.value
-            when {
-                saved != null -> {
-                    if (current?.id == saved.id) return
-                    _ephemeralStation.value = null
-                    _currentStationId.value = saved.id
-                }
-                streamUrl.isNotBlank() -> {
-                    if (current?.id == 0L && current.streamUrl == streamUrl) return
-                    _currentStationId.value = null
-                    _ephemeralStation.value = Station(
-                        name = item.mediaMetadata.title?.toString().orEmpty(),
-                        streamUrl = streamUrl,
-                        logoPath = extras?.getString("logoPath").orEmpty(),
-                        provider = provider,
-                        providerId = providerId,
-                    )
-                }
-                else -> return
-            }
-            // Per-track state belongs to the previous station; onMediaMetadataChanged
-            // repopulates it for the new one.
-            _currentTrackTitle.value = null
-            _currentTrackArtist.value = null
-            _currentBitrateKbps.value = null
-            _playbackError.value = null
-        }
-
-        override fun onIsPlayingChanged(isPlaying: Boolean) {
-            _isPlaying.value = isPlaying
-            if (!suppressLastPlayedPersist) {
-                currentStation.value?.let { station ->
-                    persistLastPlayedStation(station)
-                }
-            }
-        }
         override fun onEvents(player: Player, events: Player.Events) {
-            if (events.containsAny(Player.EVENT_PLAYBACK_STATE_CHANGED, Player.EVENT_PLAY_WHEN_READY_CHANGED)) {
-                // Only show buffering when the user intends to play; suppress the transient
-                // STATE_BUFFERING that fires during prepare() when restoring a paused station.
-                // Read both off the player itself (settled as of this batch) rather than off
-                // the individual onPlaybackStateChanged callback, whose isolated playWhenReady
-                // read can still be stale mid-batch — e.g. the very first play() of a session,
-                // where STATE_BUFFERING can be delivered before playWhenReady=true has
-                // propagated, silently dropping the buffering spinner for that first play.
-                _isBuffering.value = player.playbackState == Player.STATE_BUFFERING && player.playWhenReady
+            if (events.containsAny(
+                    Player.EVENT_MEDIA_ITEM_TRANSITION,
+                    Player.EVENT_TIMELINE_CHANGED,
+                    Player.EVENT_IS_PLAYING_CHANGED,
+                    Player.EVENT_PLAYBACK_STATE_CHANGED,
+                    Player.EVENT_PLAY_WHEN_READY_CHANGED,
+                )
+            ) {
+                // onEvents runs after the individual callbacks in the batch. Reading the Player
+                // here gives the UI one coherent station/playback snapshot even while lifecycle-
+                // aware Compose collection is stopped during screen sleep.
+                syncPlaybackState(player)
             }
         }
         override fun onPlayerError(error: PlaybackException) {
-            _isBuffering.value = false
-            _isPlaying.value = false
+            _playbackUiState.value = _playbackUiState.value.copy(
+                isPlaying = false,
+                isBuffering = false,
+            )
             _playbackError.value = error.userMessage()
         }
+
         override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
             val title = mediaMetadata.title?.toString()?.trim()
             val artist = mediaMetadata.artist?.toString()?.trim()
@@ -684,8 +621,130 @@ class MainViewModel(
             }
             _currentTrackArtist.value = artist?.takeIf { it.isNotEmpty() && it != liveRadio() }
         }
+
         override fun onTracksChanged(tracks: Tracks) {
             updateCurrentBitrate(tracks)
+        }
+    }
+
+    @androidx.annotation.VisibleForTesting
+    internal fun handlePlaybackEvents(
+        mediaItem: MediaItem?,
+        isPlaying: Boolean,
+        playbackState: Int = Player.STATE_READY,
+        playWhenReady: Boolean = isPlaying,
+        queue: List<Station> = emptyList(),
+    ) {
+        syncPlaybackState(mediaItem, isPlaying, playbackState, playWhenReady, queue = queue)
+    }
+
+    private fun syncPlaybackState(player: Player?, resolvedStation: Station? = null) {
+        if (player == null) return
+        syncPlaybackState(
+            mediaItem = player.currentMediaItem,
+            isPlaying = player.isPlaying,
+            playbackState = player.playbackState,
+            playWhenReady = player.playWhenReady,
+            resolvedStation = resolvedStation,
+            queue = (0 until player.mediaItemCount)
+                .mapNotNull { index -> resolveStation(player.getMediaItemAt(index)) },
+        )
+        updateCurrentBitrate(player.currentTracks)
+    }
+
+    private fun syncPlaybackState(
+        mediaItem: MediaItem?,
+        isPlaying: Boolean,
+        playbackState: Int,
+        playWhenReady: Boolean,
+        resolvedStation: Station? = null,
+        queue: List<Station> = emptyList(),
+    ) {
+        val station = resolvedStation ?: resolveStation(mediaItem)
+        if (station != null) {
+            val changed = stationChanged(station)
+            updateStationIdentity(station)
+            clearPerStationStateIfChanged(changed)
+            if (!suppressLastPlayedPersist) {
+                persistLastPlayedStation(station, queue)
+            }
+        }
+        _playbackUiState.value = PlaybackUiState(
+            station = station ?: _playbackUiState.value.station,
+            isPlaying = isPlaying,
+            isBuffering = playbackState == Player.STATE_BUFFERING && playWhenReady,
+            queue = queue.ifEmpty { _playbackUiState.value.queue },
+        )
+    }
+
+    private fun resolveStation(mediaItem: MediaItem?): Station? {
+        val item = mediaItem ?: return null
+        val extras = item.mediaMetadata.extras
+        val streamUrl = extras?.getString("streamUrl").orEmpty()
+        val provider = extras?.getString("provider").orEmpty()
+        val providerId = extras?.getString("providerId").orEmpty()
+        // Resolve to a saved row the same way PlayerService.stationForMediaItem does:
+        // numeric mediaId first, then provider identity, then stream URL.
+        val saved = item.mediaId.toLongOrNull()
+            ?.let { id -> _allStations.value.firstOrNull { it.id == id } }
+            ?: _allStations.value.firstOrNull {
+                provider.isNotBlank() && providerId.isNotBlank() &&
+                    it.provider == provider && it.providerId == providerId
+            }
+            ?: _allStations.value.firstOrNull { streamUrl.isNotBlank() && it.streamUrl == streamUrl }
+        return saved ?: streamUrl.takeIf { it.isNotBlank() }?.let {
+            Station(
+                name = item.mediaMetadata.title?.toString().orEmpty(),
+                streamUrl = streamUrl,
+                logoPath = extras?.getString("logoPath").orEmpty(),
+                provider = provider,
+                providerId = providerId,
+            )
+        }
+    }
+
+    private fun setCurrentStation(station: Station?) {
+        val changed = stationChanged(station)
+        updateStationIdentity(station)
+        _playbackUiState.value = _playbackUiState.value.copy(station = station)
+        clearPerStationStateIfChanged(changed)
+    }
+
+    private fun updateStationIdentity(station: Station?) {
+        if (station == null) {
+            _currentStationId.value = null
+            _ephemeralStation.value = null
+        } else if (station.id == 0L) {
+            _currentStationId.value = null
+            _ephemeralStation.value = station
+        } else {
+            _currentStationId.value = station.id
+            _ephemeralStation.value = null
+        }
+    }
+
+    private fun stationChanged(station: Station?): Boolean {
+        val previous = _playbackUiState.value.station
+        return when {
+            previous == null -> station != null
+            station == null -> true
+            else -> !previous.matches(station)
+        }
+    }
+
+    private fun clearPerStationStateIfChanged(changed: Boolean) {
+        if (!changed) return
+        // Per-track state belongs to the previous station; onMediaMetadataChanged
+        // repopulates it for the new one.
+        _currentTrackTitle.value = null
+        _currentTrackArtist.value = null
+        _currentBitrateKbps.value = null
+        _playbackError.value = null
+    }
+
+    private fun refreshCurrentStation(station: Station) {
+        if (_playbackUiState.value.station?.id == station.id) {
+            _playbackUiState.value = _playbackUiState.value.copy(station = station)
         }
     }
 
@@ -711,18 +770,11 @@ class MainViewModel(
     // next/previous work: Media3's default session callback already handles those by seeking
     // within the player's timeline, it just needs a timeline with neighbours to seek to.
     fun play(station: Station, queue: List<Station> = emptyList()) {
-        if (station.id == 0L) {
-            _ephemeralStation.value = station
-            _currentStationId.value = null
-        } else {
-            _ephemeralStation.value = null
-            _currentStationId.value = station.id
-        }
-        _currentTrackTitle.value = null
-        _currentTrackArtist.value = null
-        _currentBitrateKbps.value = null
-        _playbackError.value = null
-        persistLastPlayedStation(station)
+        setCurrentStation(station)
+        _playbackUiState.value = _playbackUiState.value.copy(
+            queue = queue.takeIf { resolveQueueStart(it, station) != null } ?: listOf(station),
+        )
+        persistLastPlayedStation(station, queue)
         val startIndex = resolveQueueStart(queue, station)
         controller?.apply {
             if (startIndex != null) {
@@ -762,14 +814,12 @@ class MainViewModel(
             stop()
             clearMediaItems()
         }
-        _currentStationId.value = null
-        _ephemeralStation.value = null
+        setCurrentStation(null)
         _currentTrackTitle.value = null
         _currentTrackArtist.value = null
         _currentBitrateKbps.value = null
         _playbackError.value = null
-        _isPlaying.value = false
-        _isBuffering.value = false
+        _playbackUiState.value = PlaybackUiState()
         viewModelScope.launch {
             dataStore.edit { prefs -> prefs.remove(LAST_PLAYED_STATION_KEY) }
             suppressLastPlayedPersist = false
@@ -832,10 +882,10 @@ class MainViewModel(
     private suspend fun deleteStationRecord(station: Station) {
         if (_currentStationId.value == station.id) {
             controller?.stop()
-            _currentStationId.value = null
+            setCurrentStation(null)
         }
         if (_ephemeralStation.value?.streamUrl == station.streamUrl) {
-            _ephemeralStation.value = null
+            setCurrentStation(null)
         }
         clearLastPlayedStationIfMatching(station)
         repository.delete(station)
@@ -858,19 +908,25 @@ class MainViewModel(
         } ?: repository.getByStreamUrl(snapshot.station.streamUrl)
 
         if (savedStation != null) {
-            _currentStationId.value = savedStation.id
-            _ephemeralStation.value = null
+            setCurrentStation(savedStation)
         } else {
-            _ephemeralStation.value = snapshot.station.toEphemeral()
+            setCurrentStation(snapshot.station.toEphemeral())
         }
+        _playbackUiState.value = _playbackUiState.value.copy(queue = snapshot.queue)
 
         pendingRestoreStation.complete(savedStation ?: snapshot.station.toEphemeral())
     }
 
-    private fun persistLastPlayedStation(station: Station) {
+    private fun persistLastPlayedStation(station: Station, queue: List<Station> = emptyList()) {
         viewModelScope.launch {
             dataStore.edit { prefs ->
-                prefs[LAST_PLAYED_STATION_KEY] = station.toLastPlayedJson().toString()
+                val existingQueue = prefs[LAST_PLAYED_STATION_KEY]
+                    ?.let(::lastPlayedStationSnapshot)
+                    ?.queue
+                    .orEmpty()
+                prefs[LAST_PLAYED_STATION_KEY] = station
+                    .toLastPlayedJson(queue.ifEmpty { existingQueue })
+                    .toString()
             }
         }
     }
@@ -885,11 +941,12 @@ class MainViewModel(
     }
 
     private suspend fun loadStationPaused(station: Station) {
-        // `stations` is a WhileSubscribed StateFlow because it is primarily a UI stream. During
-        // screen sleep there may be no collector, leaving its initial empty value in place. Using
-        // that value here restores only the current station, so the lock-screen Next action has
-        // no favourite to advance to. Read the database directly for service/resumption work.
-        val queue = sortStations(repository.getAll().first(), _favoritesSort.value)
+        // Prefer the exact timeline captured by the Media3 session. Legacy snapshots did not
+        // include a queue, so only those fall back to rebuilding from the database and sort.
+        val snapshot = dataStore.data.first()[LAST_PLAYED_STATION_KEY]
+            ?.let(::lastPlayedStationSnapshot)
+        val queue = snapshot?.queue?.takeIf { it.size > 1 }
+            ?: sortStations(repository.getAll().first(), _favoritesSort.value)
         val startIndex = resolveQueueStart(queue, station)
 
         controller?.apply {
@@ -904,6 +961,14 @@ class MainViewModel(
         }
     }
 }
+
+/** Coherent player snapshot consumed by Compose as one lifecycle-aware state value. */
+data class PlaybackUiState(
+    val station: Station? = null,
+    val isPlaying: Boolean = false,
+    val isBuffering: Boolean = false,
+    val queue: List<Station> = emptyList(),
+)
 
 /** Two-line "what's playing" summary for the mini player / notifications. */
 data class NowPlayingDisplay(val title: String, val subtitle: String)
@@ -966,4 +1031,3 @@ private fun PlaybackException.userMessage(): String {
         else -> "Playback failed"
     }
 }
-

--- a/app/src/test/java/com/shapeshed/aerial/data/StationQueueTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/data/StationQueueTest.kt
@@ -1,0 +1,57 @@
+package com.shapeshed.aerial.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StationQueueTest {
+
+    @Test
+    fun snapshotRoundTripPreservesCurrentStationAndQueueOrder() {
+        val left = station(1, "Left")
+        val middle = station(2, "Middle")
+        val right = station(3, "Right")
+
+        val restored = lastPlayedStationSnapshot(
+            middle.toLastPlayedJson(listOf(right, left, middle)).toString(),
+        )
+
+        assertEquals(middle, restored.station)
+        assertEquals(listOf(right, left, middle), restored.queue)
+        assertEquals(2, resolveQueueStart(restored.queue, restored.station))
+    }
+
+    @Test
+    fun legacySnapshotWithoutQueueStillRestoresStation() {
+        val restored = lastPlayedStationSnapshot(station(7, "Legacy").toLastPlayedJson().toString())
+
+        assertEquals(7L, restored.station.id)
+        assertTrue(restored.queue.isEmpty())
+    }
+
+    @Test
+    fun persistedQueueDoesNotChangeWhenLastPlayedSortChanges() {
+        val left = station(1, "Left", lastPlayedAt = 1_000)
+        val right = station(2, "Right", lastPlayedAt = 2_000)
+        val activeQueue = sortStations(listOf(left, right), FavoritesSort.LAST_PLAYED)
+        val snapshot = lastPlayedStationSnapshot(
+            right.toLastPlayedJson(activeQueue).toString(),
+        )
+
+        val updated = listOf(
+            left.copy(lastPlayedAt = 3_000),
+            right.copy(lastPlayedAt = 2_000),
+        )
+
+        assertEquals(listOf(1L, 2L), sortStations(updated, FavoritesSort.LAST_PLAYED).map { it.id })
+        assertEquals(listOf(2L, 1L), snapshot.queue.map { it.id })
+    }
+
+    private fun station(id: Long, name: String, lastPlayedAt: Long = 0) = Station(
+        id = id,
+        name = name,
+        streamUrl = "https://stream.example/$id",
+        isFavorite = true,
+        lastPlayedAt = lastPlayedAt,
+    )
+}

--- a/build.gradle
+++ b/build.gradle
@@ -8,5 +8,5 @@ plugins {
 tasks.register('quality') {
     group = 'verification'
     description = 'Runs the maintenance quality gate for compile errors, lint, and unit tests.'
-    dependsOn ':app:compileDebugKotlin', ':app:lintDebug', ':app:testDebugUnitTest'
+    dependsOn ':app:compileDebugKotlin', ':app:lintDebug', ':app:testDeviceTestUnitTest'
 }


### PR DESCRIPTION
## Summary
- make Media3 player events update one coherent playback UI snapshot
- preserve the active queue order across last-played reordering and process resumption
- add an isolated on-device test build plus lifecycle and next/previous regression coverage

## Verification
- `./gradlew test lint assembleRelease bundleRelease`
- `./gradlew connectedDeviceTestAndroidTest` (Pixel 9 Pro XL, Android 17)

Fixes #148