### PR TITLE
fix(playback): preserve metadata across station transitions

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
+++ b/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
@@ -300,7 +300,7 @@ class PlayerService : MediaLibraryService() {
             session: MediaSession,
             controller: MediaSession.ControllerInfo,
         ): MediaSession.ConnectionResult {
-            return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
+            return MediaSession.ConnectionResult.AcceptedResultBuilder(session, controller)
                 .setAvailableSessionCommands(
                     MediaSession.ConnectionResult.DEFAULT_SESSION_AND_LIBRARY_COMMANDS
                         .buildUpon()

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -221,6 +221,12 @@ class MainViewModel(
     private val _ephemeralStation = MutableStateFlow<Station?>(null)
     private val _playbackUiState = MutableStateFlow(PlaybackUiState())
     val playbackUiState: StateFlow<PlaybackUiState> = _playbackUiState.asStateFlow()
+    private data class PendingPlaybackMetadata(
+        val station: Station,
+        val title: String?,
+        val artist: String?,
+    )
+    private var pendingPlaybackMetadata: PendingPlaybackMetadata? = null
     // Carries the last-played station to loadStationPaused() once the MediaController connects.
     // CompletableDeferred ensures the handoff is safe regardless of which side wins the race.
     private val pendingRestoreStation = CompletableDeferred<Station?>()
@@ -671,6 +677,7 @@ class MainViewModel(
 
         override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
             handlePlaybackMetadata(
+                mediaItem = controller?.currentMediaItem,
                 title = mediaMetadata.title?.toString(),
                 artist = mediaMetadata.artist?.toString(),
             )
@@ -695,6 +702,18 @@ class MainViewModel(
     @androidx.annotation.VisibleForTesting
     internal fun handlePlaybackMetadata(title: String?, artist: String?) {
         applyPlaybackMetadata(title, artist)
+    }
+
+    @androidx.annotation.VisibleForTesting
+    internal fun handlePlaybackMetadata(mediaItem: MediaItem?, title: String?, artist: String?) {
+        val station = resolveStation(mediaItem)
+        val currentStation = _playbackUiState.value.station
+        if (station != null && (currentStation == null || !currentStation.matches(station))) {
+            pendingPlaybackMetadata = PendingPlaybackMetadata(station, title, artist)
+        } else {
+            pendingPlaybackMetadata = null
+            applyPlaybackMetadata(title, artist)
+        }
     }
 
     private fun applyPlaybackMetadata(title: String?, artist: String?) {
@@ -733,6 +752,12 @@ class MainViewModel(
             val changed = stationChanged(station)
             updateStationIdentity(station)
             clearPerStationStateIfChanged(changed)
+            pendingPlaybackMetadata
+                ?.takeIf { it.station.matches(station) }
+                ?.let { pending ->
+                    applyPlaybackMetadata(pending.title, pending.artist)
+                    pendingPlaybackMetadata = null
+                }
             if (!suppressLastPlayedPersist) {
                 persistLastPlayedStation(station, queue)
             }

--- a/app/src/test/java/com/shapeshed/aerial/ui/MainViewModelStateTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/ui/MainViewModelStateTest.kt
@@ -5,7 +5,11 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import android.os.Bundle
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
 import com.shapeshed.aerial.AerialApp
+import com.shapeshed.aerial.R
 import com.shapeshed.aerial.data.FavoritesSort
 import com.shapeshed.aerial.data.NetworkMonitor
 import com.shapeshed.aerial.data.PlayHistoryEntry
@@ -105,6 +109,31 @@ class MainViewModelStateTest {
         assertEquals(emptySet<String>(), viewModel.selectedCountries.value)
         assertEquals(emptySet<String>(), viewModel.selectedTags.value)
         verify(registryRepository, atLeastOnce()).search("mango", emptySet(), emptySet())
+    }
+
+    @Test
+    fun metadataBeforeStationTransitionRemainsVisibleForNowPlaying() = runTest {
+        val repository = mock<StationRepository>()
+        val registryRepository = mock<RegistryRepository>()
+        val left = station(1, "Metadata-less station")
+        val right = station(2, "Song station")
+        whenever(repository.getAll()).thenReturn(flowOf(listOf(left, right)))
+        whenever(repository.recentlyPlayedAsFlow(any())).thenReturn(flowOf(emptyList()))
+        val viewModel = viewModel(repository, registryRepository)
+        runCurrent()
+
+        viewModel.handlePlaybackEvents(mediaItem(left.name, left.id.toString()), isPlaying = true)
+        assertEquals("Metadata-less station", viewModel.playbackUiState.value.station?.name)
+        viewModel.handlePlaybackMetadata(
+            mediaItem = mediaItem(right.name, right.id.toString()),
+            title = "Song delivered by stream",
+            artist = "Artist",
+        )
+        viewModel.handlePlaybackEvents(mediaItem(right.name, right.id.toString()), isPlaying = true)
+
+        assertEquals("Song station", viewModel.playbackUiState.value.station?.name)
+        assertEquals("Song delivered by stream", viewModel.playbackUiState.value.trackTitle)
+        assertEquals("Artist", viewModel.playbackUiState.value.trackArtist)
     }
 
     @Test
@@ -260,13 +289,18 @@ class MainViewModelStateTest {
         verify(repository).insertOrGetExisting(any())
     }
 
-    private fun viewModel(repository: StationRepository, registryRepository: RegistryRepository): MainViewModel {
+    private fun viewModel(
+        repository: StationRepository,
+        registryRepository: RegistryRepository,
+        dataStore: DataStore<Preferences> = MemoryDataStore(),
+    ): MainViewModel {
         val app = mock<AerialApp>()
         val network = mock<NetworkMonitor>()
         whenever(app.networkMonitor).thenReturn(network)
+        whenever(app.getString(R.string.live_radio)).thenReturn("test-live-radio")
         whenever(network.isOnline).thenReturn(MutableStateFlow(true).asStateFlow())
         whenever(registryRepository.countAsFlow()).thenReturn(flowOf(0))
-        return MainViewModel(app, repository, registryRepository, MemoryDataStore(), SavedStateHandle()).also(viewModels::add)
+        return MainViewModel(app, repository, registryRepository, dataStore, SavedStateHandle()).also(viewModels::add)
     }
 
     private fun station(id: Long, name: String, lastPlayedAt: Long = 0, playCount: Int = 0) = Station(
@@ -284,6 +318,19 @@ class MainViewModelStateTest {
         provider = "test",
         providerId = "mango",
     )
+
+    private fun mediaItem(stationName: String, id: String): MediaItem = MediaItem.Builder()
+        .setMediaId(id)
+        .setMediaMetadata(
+            MediaMetadata.Builder()
+                .setTitle(stationName)
+                .setExtras(Bundle().apply {
+                    putString("streamUrl", "https://example.test/$id")
+                    putString("stationName", stationName)
+                })
+                .build(),
+        )
+        .build()
 
     private class MemoryDataStore(initial: Preferences = emptyPreferences()) : DataStore<Preferences> {
         private val state = MutableStateFlow(initial)


### PR DESCRIPTION
## Summary
- preserve incoming station metadata when a transition event arrives before station state
- add a regression test for issue #175
- migrate Media3 AcceptedResultBuilder to the non-deprecated controller-aware constructor

## Validation
- `./gradlew testDeviceTestUnitTest lint`

Fixes #175