### PR TITLE
fix(artwork): use Coil for remote image loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,25 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - Hindi and Punjabi translations are now available in the app, contributed by
   `whistlingwoods` via Weblate. (#177, #178)
+- Now Playing and the mini player can navigate to the next or previous station
+  in the active playback queue. (#173, #185)
 
 ### Fixed
 
 - Sleep timer hour labels now use locale-aware plural forms. (#166, #176)
+- Playback metadata now follows station transitions without retaining the
+  previous station's track information. (#175, #183)
+- Now Playing controls remain accessible at large font sizes. (#172, #184)
+- Tag and country pickers now close and reopen smoothly, keep selected tags at
+  the top, and restore the search bar when switching destinations. (#171, #188)
 
 ### Changed
 
 - Partial translations now fall back to the default locale without failing the lint gate.
+- Compose navigation and test infrastructure now use the Navigation 3 APIs and
+  isolated on-device test application. (#180)
+- Remote artwork loading now uses Coil for fetching, caching, decoding, and
+  bounded sampling, including Media3 artwork surfaces. (#169)
 
 ## [0.6.1] - 2026-08-12
 

--- a/app/src/main/java/com/shapeshed/aerial/ArtworkProvider.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ArtworkProvider.kt
@@ -63,7 +63,7 @@ class ArtworkProvider : ContentProvider() {
     companion object {
         const val REGISTRY_ARTWORK_DIR = "registry_artwork"
 
-        // Matches the download directory MainViewModel.downloadLogo caches favourited logos in.
+        // Matches the download directory used by the artwork loader for favourited logos.
         const val LOCAL_LOGO_DIR = "logos"
 
         fun uriFor(context: android.content.Context, dir: String, fileName: String): Uri =

--- a/app/src/main/java/com/shapeshed/aerial/CoilBitmapLoader.kt
+++ b/app/src/main/java/com/shapeshed/aerial/CoilBitmapLoader.kt
@@ -2,7 +2,6 @@ package com.shapeshed.aerial
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.net.Uri
 import androidx.concurrent.futures.SuspendToFutureAdapter
 import androidx.media3.common.util.BitmapLoader
@@ -28,8 +27,13 @@ class CoilBitmapLoader(private val context: Context) : BitmapLoader {
 
     override fun decodeBitmap(data: ByteArray): ListenableFuture<Bitmap> =
         SuspendToFutureAdapter.launchFuture(Dispatchers.Default, false) {
-            BitmapFactory.decodeByteArray(data, 0, data.size)
+            val request = ImageRequest.Builder(context)
+                .data(data)
+                .size(512)
+                .build()
+            val result = SingletonImageLoader.get(context).execute(request) as? SuccessResult
                 ?: error("Could not decode artwork bytes")
+            result.image.toOpaqueBitmap(context)
         }
 
     override fun loadBitmap(uri: Uri): ListenableFuture<Bitmap> =

--- a/app/src/main/java/com/shapeshed/aerial/data/HttpUtils.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/HttpUtils.kt
@@ -1,6 +1,5 @@
 package com.shapeshed.aerial.data
 
-import android.util.LruCache
 import com.shapeshed.aerial.BuildConfig
 import java.net.HttpURLConnection
 import java.net.URL
@@ -51,30 +50,6 @@ internal fun httpPostJson(url: String, body: String, extraHeaders: Map<String, S
             conn.outputStream.use { it.write(body.toByteArray()) }
             if (conn.responseCode !in 200..299) return null
             conn.inputStream.bufferedReader().use { it.readText() }
-        } finally {
-            conn.disconnect()
-        }
-    } catch (_: Exception) {
-        null
-    }
-}
-
-/**
- * Fetch image bytes from [url], storing results in [cache]. Returns null on any error.
- * Caller is responsible for running this on a background thread (e.g. Dispatchers.IO).
- */
-internal fun httpFetchBytes(url: String, cache: LruCache<String, ByteArray>): ByteArray? {
-    cache[url]?.let { return it }
-    return try {
-        val conn = URL(url).openConnection() as HttpURLConnection
-        conn.connectTimeout = 10_000
-        conn.readTimeout = 10_000
-        conn.setRequestProperty("User-Agent", AERIAL_USER_AGENT)
-        try {
-            if (conn.responseCode !in 200..299) return null
-            conn.inputStream.use { input ->
-                input.readBytes().also { bytes -> cache.put(url, bytes) }
-            }
         } finally {
             conn.disconnect()
         }

--- a/app/src/main/java/com/shapeshed/aerial/ui/ArtworkLoader.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/ArtworkLoader.kt
@@ -1,0 +1,36 @@
+package com.shapeshed.aerial.ui
+
+import android.content.Context
+import coil3.SingletonImageLoader
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.size.Size
+import java.io.File
+
+/** Downloads and persists artwork through the app's configured image-loading pipeline. */
+interface ArtworkLoader {
+    suspend fun download(url: String, directory: File): String?
+}
+
+class CoilArtworkLoader(private val context: Context) : ArtworkLoader {
+    override suspend fun download(url: String, directory: File): String? {
+        return try {
+            val request = ImageRequest.Builder(context)
+                .data(url)
+                .size(512)
+                .build()
+            val result = SingletonImageLoader.get(context).execute(request) as? SuccessResult ?: return null
+            val destination = logoFileForUrl(url, directory, "image/png")
+            val bitmap = result.image.toOpaqueBitmap(context)
+            val encoded = destination.outputStream().use { output ->
+                bitmap.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, output)
+            }
+            if (!encoded) {
+                return null
+            }
+            destination.absolutePath
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/shapeshed/aerial/ui/LogoFiles.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/LogoFiles.kt
@@ -176,7 +176,7 @@ suspend fun cachedRemoteArtworkUri(context: Context, logoUrl: String): Uri? {
 
 /**
  * A stable content:// URI for a favourited station's locally-cached logo file (already on disk
- * under filesDir/logos — see MainViewModel.downloadLogo), for the same reason
+ * under filesDir/logos — see [ArtworkLoader]), for the same reason
  * [cachedRemoteArtworkUri] proxies remote logos: Media3's legacy queue bridge only decodes and
  * embeds a Bitmap in a queue item when its MediaMetadata carries embedded artworkData bytes — an
  * artworkUri-only item is skipped entirely. Handing the phone/Bluetooth playback queue a URI

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -54,8 +54,6 @@ import com.shapeshed.aerial.data.toLastPlayedJson
 import com.shapeshed.aerial.toEphemeralStation
 import com.shapeshed.aerial.toPlayableMediaItem
 import java.io.File
-import java.net.HttpURLConnection
-import java.net.URL
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -90,6 +88,7 @@ class MainViewModel(
     // always passes an explicit SavedStateHandle via CreationExtras.createSavedStateHandle().
     @Suppress("VisibleForTests")
     private val savedStateHandle: SavedStateHandle = SavedStateHandle(),
+    private val artworkLoader: ArtworkLoader = CoilArtworkLoader(application),
 ) : AndroidViewModel(application) {
 
     val isOnline = (application as AerialApp).networkMonitor.isOnline
@@ -439,7 +438,10 @@ class MainViewModel(
     fun addFromRegistry(registryStation: RegistryStation) {
         viewModelScope.launch {
             val localLogoPath = if (registryStation.logoUrl.isNotBlank()) {
-                withContext(Dispatchers.IO) { downloadLogo(registryStation.logoUrl) } ?: registryStation.logoUrl
+                withContext(Dispatchers.IO) {
+                    val dir = File(getApplication<Application>().filesDir, "logos").also { it.mkdirs() }
+                    artworkLoader.download(registryStation.logoUrl, dir)
+                } ?: registryStation.logoUrl
             } else {
                 ""
             }
@@ -929,41 +931,11 @@ class MainViewModel(
     // restore — a bare remote URL isn't embedded in the backup zip (see SettingsViewModel).
     private suspend fun ensureLocalLogo(station: Station): Station {
         if (!station.logoPath.startsWith("http")) return station
-        val localPath = withContext(Dispatchers.IO) { downloadLogo(station.logoPath) } ?: return station
-        return station.copy(logoPath = localPath)
-    }
-
-    private suspend fun downloadLogo(url: String): String? {
-        return try {
+        val localPath = withContext(Dispatchers.IO) {
             val dir = File(getApplication<Application>().filesDir, "logos").also { it.mkdirs() }
-            val conn = URL(url).openConnection() as HttpURLConnection
-            conn.connectTimeout = 10_000
-            conn.readTimeout = 10_000
-            try {
-                // A dead/moved logo URL can respond with a redirect or an HTML error page
-                // instead of an image (e.g. a 301 whose body is just an nginx redirect
-                // notice) — without this check that body gets saved to disk as if it were
-                // the logo. On rejection the caller falls back to the raw URL, which Coil's
-                // own HTTP client can still resolve correctly at render time (it isn't
-                // restricted to same-protocol redirects the way HttpURLConnection is).
-                val contentType = conn.contentType?.substringBefore(';')?.trim()
-                if (conn.responseCode != HttpURLConnection.HTTP_OK ||
-                    (contentType != null && !contentType.startsWith("image/"))
-                ) {
-                    return null
-                }
-                val dest = logoFileForUrl(url, dir, contentType)
-                conn.inputStream.use { input ->
-                    dest.outputStream().use { output -> input.copyTo(output) }
-                }
-                ensureMediaArtworkForLogo(getApplication(), dest)
-                dest.absolutePath
-            } finally {
-                conn.disconnect()
-            }
-        } catch (_: Exception) {
-            null
-        }
+            artworkLoader.download(station.logoPath, dir)
+        } ?: return station
+        return station.copy(logoPath = localPath)
     }
 
     fun deleteStation(station: Station) {

--- a/app/src/test/java/com/shapeshed/aerial/ui/MainViewModelStateTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/ui/MainViewModelStateTest.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.emptyPreferences
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import android.os.Bundle
+import java.io.File
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import com.shapeshed.aerial.AerialApp
@@ -34,6 +35,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.atLeastOnce
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -289,10 +291,28 @@ class MainViewModelStateTest {
         verify(repository).insertOrGetExisting(any())
     }
 
+    @Test
+    fun addingRegistryStationUsesArtworkLoaderForRemoteLogo() = runTest {
+        val repository = mock<StationRepository>()
+        val registryRepository = mock<RegistryRepository>()
+        whenever(repository.getAll()).thenReturn(flowOf(emptyList()))
+        whenever(repository.recentlyPlayedAsFlow(any())).thenReturn(flowOf(emptyList()))
+        whenever(repository.insertOrGetExisting(any())).thenReturn(42L)
+        val artworkLoader = RecordingArtworkLoader("/tmp/aerial-logo.png")
+        val viewModel = viewModel(repository, registryRepository, artworkLoader = artworkLoader)
+
+        viewModel.addFromRegistry(registry("Mango Radio").copy(logoUrl = "https://example.test/mango.png"))
+        runCurrent()
+
+        assertEquals("https://example.test/mango.png", artworkLoader.url)
+        verify(repository).insertOrGetExisting(argThat { logoPath == "/tmp/aerial-logo.png" })
+    }
+
     private fun viewModel(
         repository: StationRepository,
         registryRepository: RegistryRepository,
         dataStore: DataStore<Preferences> = MemoryDataStore(),
+        artworkLoader: ArtworkLoader = CoilArtworkLoader(mock()),
     ): MainViewModel {
         val app = mock<AerialApp>()
         val network = mock<NetworkMonitor>()
@@ -300,7 +320,15 @@ class MainViewModelStateTest {
         whenever(app.getString(R.string.live_radio)).thenReturn("test-live-radio")
         whenever(network.isOnline).thenReturn(MutableStateFlow(true).asStateFlow())
         whenever(registryRepository.countAsFlow()).thenReturn(flowOf(0))
-        return MainViewModel(app, repository, registryRepository, dataStore, SavedStateHandle()).also(viewModels::add)
+        return MainViewModel(app, repository, registryRepository, dataStore, SavedStateHandle(), artworkLoader).also(viewModels::add)
+    }
+
+    private class RecordingArtworkLoader(private val path: String) : ArtworkLoader {
+        var url: String? = null
+        override suspend fun download(url: String, directory: File): String? {
+            this.url = url
+            return path
+        }
     }
 
     private fun station(id: Long, name: String, lastPlayedAt: Long = 0, playCount: Int = 0) = Station(


### PR DESCRIPTION
## Summary
- route remote artwork fetching and decoding through the configured Coil image loader
- bound artwork requests to 512px before persisting local PNG caches
- use Coil for the Media3 bitmap adapter instead of direct byte-array decoding
- remove the unused manual image-byte downloader
- document the change in the unreleased changelog

Closes #169

## Validation
- `./gradlew test lint`
- `./gradlew test --rerun-tasks`
- verified the ViewModel artwork-loader regression test