### PR TITLE
fix(playback): refresh favorites queue when sort changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   the sort is changed during playback. (#190)
 - Now Playing now presents the song title above the artist with the same
   hierarchy used by Android's media controls. (#190)
+- Favourite rows now use Material 3 swipe-to-dismiss with an Undo action and
+  animated list-item settling. (#165)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   the top, and restore the search bar when switching destinations. (#171, #188)
 - The active Favourites playback queue now follows the selected sort order when
   the sort is changed during playback. (#190)
+- Last Played Favourites navigation now keeps the visible order stable while
+  skipping and refreshes from the latest play history when returning to the
+  screen. (#190)
+- The Home Recently Played row now appears at the top on first launch without
+  interrupting an in-progress scroll.
 - Now Playing now presents the song title above the artist with the same
   hierarchy used by Android's media controls. (#190)
 - Favourite rows now use Material 3 swipe-to-dismiss with an Undo action and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Now Playing controls remain accessible at large font sizes. (#172, #184)
 - Tag and country pickers now close and reopen smoothly, keep selected tags at
   the top, and restore the search bar when switching destinations. (#171, #188)
+- The active Favourites playback queue now follows the selected sort order when
+  the sort is changed during playback. (#190)
+- Now Playing now presents the song title above the artist with the same
+  hierarchy used by Android's media controls. (#190)
 
 ### Changed
 
@@ -29,6 +33,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   isolated on-device test application. (#180)
 - Remote artwork loading now uses Coil for fetching, caching, decoding, and
   bounded sampling, including Media3 artwork surfaces. (#169)
+- Material Expressive themes now use the library's default typography and
+  color scheme fallbacks, while retaining dynamic color on supported devices.
 
 ## [0.6.1] - 2026-08-12
 

--- a/app/src/androidTest/java/com/shapeshed/aerial/ui/NowPlayingGestureTest.kt
+++ b/app/src/androidTest/java/com/shapeshed/aerial/ui/NowPlayingGestureTest.kt
@@ -19,6 +19,37 @@ class NowPlayingGestureTest {
     val composeRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
+    fun songTitleAppearsAboveArtistLikeSystemMediaControls() {
+        composeRule.setContent {
+            AerialTheme(dynamicColor = false) {
+                NowPlayingScreen(
+                    station = Station(id = 1, name = "Radio One", streamUrl = "https://example.test/stream"),
+                    isPlaying = true,
+                    isBuffering = false,
+                    currentTrackTitle = "Song title",
+                    currentTrackArtist = "Artist",
+                    currentBitrateKbps = null,
+                    showStreamBitrate = false,
+                    sleepTimer = null,
+                    swipeStations = emptyList(),
+                    onPlayStation = {},
+                    onPreviousStation = {},
+                    onNextStation = {},
+                    onToggle = {},
+                    onToggleFavorite = {},
+                    onSetSleepTimer = {},
+                    onCancelSleepTimer = {},
+                    onDismiss = {},
+                )
+            }
+        }
+
+        val titleTop = composeRule.onNodeWithTag("now_playing_track_title").fetchSemanticsNode().boundsInRoot.top
+        val artistTop = composeRule.onNodeWithTag("now_playing_track_artist").fetchSemanticsNode().boundsInRoot.top
+        assertTrue(titleTop < artistTop)
+    }
+
+    @Test
     fun swipeDownFromScrollableMetadataDismissesPlayer() {
         var dismissed = false
         composeRule.setContent {

--- a/app/src/main/java/com/shapeshed/aerial/CoilBitmapLoader.kt
+++ b/app/src/main/java/com/shapeshed/aerial/CoilBitmapLoader.kt
@@ -9,7 +9,6 @@ import androidx.media3.common.util.UnstableApi
 import coil3.SingletonImageLoader
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
-import coil3.size.Size
 import com.google.common.util.concurrent.ListenableFuture
 import com.shapeshed.aerial.ui.toOpaqueBitmap
 import kotlinx.coroutines.Dispatchers
@@ -23,13 +22,17 @@ import kotlinx.coroutines.Dispatchers
 @UnstableApi
 class CoilBitmapLoader(private val context: Context) : BitmapLoader {
 
+    private companion object {
+        const val MAX_ARTWORK_SIZE_PX = 512
+    }
+
     override fun supportsMimeType(mimeType: String): Boolean = true
 
     override fun decodeBitmap(data: ByteArray): ListenableFuture<Bitmap> =
         SuspendToFutureAdapter.launchFuture(Dispatchers.Default, false) {
             val request = ImageRequest.Builder(context)
                 .data(data)
-                .size(512)
+                .size(MAX_ARTWORK_SIZE_PX)
                 .build()
             val result = SingletonImageLoader.get(context).execute(request) as? SuccessResult
                 ?: error("Could not decode artwork bytes")
@@ -41,7 +44,9 @@ class CoilBitmapLoader(private val context: Context) : BitmapLoader {
             val imageLoader = SingletonImageLoader.get(context)
             val request = ImageRequest.Builder(context)
                 .data(uri)
-                .size(Size.ORIGINAL)
+                // Media3 applies its own SizeLimitedBitmapLoader around the session loader.
+                // Keep Coil bounded too, so a large remote image is not fully decoded first.
+                .size(MAX_ARTWORK_SIZE_PX)
                 .build()
             val result = imageLoader.execute(request) as? SuccessResult
                 ?: error("Could not load artwork from $uri")

--- a/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
+++ b/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
@@ -27,6 +27,7 @@ import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.session.CommandButton
+import androidx.media3.session.CacheBitmapLoader
 import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.LibraryResult
 import androidx.media3.session.MediaConstants
@@ -176,7 +177,9 @@ class PlayerService : MediaLibraryService() {
         mediaSession = MediaLibrarySession.Builder(this, sessionPlayer, librarySessionCallback)
             .setSessionActivity(pendingIntent())
             .setMediaButtonPreferences(listOf(favoriteButton(null)))
-            .setBitmapLoader(CoilBitmapLoader(this))
+            // Coil provides SVG support and the app's configured network client. Media3 still
+            // applies its own size limit; caching avoids repeating equivalent artwork requests.
+            .setBitmapLoader(CacheBitmapLoader(CoilBitmapLoader(this)))
             .build()
         log("onCreate")
         serviceScope.launch {

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryDao.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryDao.kt
@@ -33,6 +33,9 @@ abstract class RegistryDao {
     @Query("SELECT * FROM registry_stations WHERE provider = :provider AND providerId = :providerId LIMIT 1")
     abstract suspend fun getByProviderId(provider: String, providerId: String): RegistryStation?
 
+    @Query("SELECT * FROM registry_stations WHERE streamUrl = :streamUrl LIMIT 1")
+    abstract suspend fun getByStreamUrl(streamUrl: String): RegistryStation?
+
     @Query("SELECT * FROM registry_stations WHERE id = :id")
     abstract suspend fun getById(id: Long): RegistryStation?
 

--- a/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
+++ b/app/src/main/java/com/shapeshed/aerial/data/RegistryRepository.kt
@@ -210,6 +210,8 @@ class RegistryRepository(private val dao: RegistryDao) {
     suspend fun getByProviderId(provider: String, providerId: String): RegistryStation? =
         dao.getByProviderId(provider, providerId)
 
+    suspend fun getByStreamUrl(streamUrl: String): RegistryStation? = dao.getByStreamUrl(streamUrl)
+
     suspend fun availableCountryCodes(): List<String> = dao.distinctCountryCodes()
 
     suspend fun availableTags(): List<String> {

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainAppContent.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainAppContent.kt
@@ -18,6 +18,7 @@ internal fun MainAppContent(
     selectedDestination: Int,
     showHome: Boolean,
     onDestinationSelected: (Int) -> Unit,
+    snackbarHost: @Composable () -> Unit = {},
     modifier: Modifier = Modifier,
     content: @Composable BoxScope.() -> Unit,
 ) {
@@ -30,6 +31,7 @@ internal fun MainAppContent(
         Scaffold(
             modifier = Modifier.semantics { traversalIndex = 0f },
             contentWindowInsets = WindowInsets.navigationBars,
+            snackbarHost = snackbarHost,
         ) { padding ->
             Box(
                 modifier = Modifier

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -541,6 +541,8 @@ fun MainScreen(
                     uiState = uiState,
                     selectedMood = selectedMood,
                     selectedMoodStations = selectedMoodStations,
+                    savedStreamUrls = savedStreamUrls,
+                    savedRegistryKeys = savedRegistryKeys,
                     bottomPadding = stationContentBottomPadding,
                     selectedTab = effectiveSelectedTab,
                     appLocale = appLocale,
@@ -554,6 +556,7 @@ fun MainScreen(
                     onPlayRegistryStation = viewModel::playFromRegistry,
                     onPlayRegistryQueue = viewModel::playFromRegistry,
                     onAddRegistryStation = viewModel::addFromRegistry,
+                    onRemoveRegistryStation = viewModel::removeFromRegistry,
                     onPlayFavorite = { viewModel.play(it, stations) },
                     onRemoveFavorite = { station ->
                         viewModel.toggleFavorite(station)
@@ -707,6 +710,8 @@ private fun MainDestinationContent(
     uiState: MainUiState,
     selectedMood: CuratedMood?,
     selectedMoodStations: List<RegistryStation>,
+    savedStreamUrls: Set<String>,
+    savedRegistryKeys: Set<RegistryStationKey>,
     bottomPadding: Dp,
     selectedTab: Int,
     appLocale: java.util.Locale,
@@ -720,6 +725,7 @@ private fun MainDestinationContent(
     onPlayRegistryStation: (RegistryStation) -> Unit,
     onPlayRegistryQueue: (RegistryStation, List<RegistryStation>) -> Unit,
     onAddRegistryStation: (RegistryStation) -> Unit,
+    onRemoveRegistryStation: (RegistryStation) -> Unit,
     onPlayFavorite: (Station) -> Unit,
     onRemoveFavorite: (Station) -> Unit,
     onHomeViewModeChange: (HomeViewMode) -> Unit,
@@ -737,11 +743,14 @@ private fun MainDestinationContent(
             currentStation = playback.station,
             isPlaying = playback.isPlaying,
             isBuffering = playback.isBuffering,
+            savedStreamUrls = savedStreamUrls,
+            savedRegistryKeys = savedRegistryKeys,
             bottomPadding = bottomPadding,
             onBack = onMoodBack,
             onPlay = { selectedMoodStations.firstOrNull()?.let { onPlayRegistryQueue(it, selectedMoodStations) } },
             onSave = { selectedMoodStations.forEach(onAddRegistryStation) },
             onAddStation = onAddRegistryStation,
+            onRemoveStation = onRemoveRegistryStation,
             onPlayStation = { onPlayRegistryQueue(it, selectedMoodStations) },
         )
     } else if (selectedTab == TAB_HOME) {
@@ -1689,11 +1698,14 @@ private fun MoodDetailScreen(
     currentStation: Station?,
     isPlaying: Boolean,
     isBuffering: Boolean,
+    savedStreamUrls: Set<String>,
+    savedRegistryKeys: Set<RegistryStationKey>,
     bottomPadding: Dp,
     onBack: () -> Unit,
     onPlay: () -> Unit,
     onSave: () -> Unit,
     onAddStation: (RegistryStation) -> Unit,
+    onRemoveStation: (RegistryStation) -> Unit,
     onPlayStation: (RegistryStation) -> Unit,
 ) {
     LazyColumn(
@@ -1792,12 +1804,17 @@ private fun MoodDetailScreen(
                         active.provider == station.provider &&
                         active.providerId == station.providerId)
             } ?: false
+            val isSaved = station.streamUrl in savedStreamUrls || station.savedKey() in savedRegistryKeys
             MoodStationRow(
                 station = station,
                 isActive = isActive,
                 isPlaying = isPlaying && isActive,
                 isBuffering = isBuffering && isActive,
                 onPlay = { onPlayStation(station) },
+                isSaved = isSaved,
+                onToggleFavorite = {
+                    if (isSaved) onRemoveStation(station) else onAddStation(station)
+                },
             )
         }
     }
@@ -1810,6 +1827,8 @@ private fun MoodStationRow(
     isPlaying: Boolean,
     isBuffering: Boolean,
     onPlay: () -> Unit,
+    isSaved: Boolean,
+    onToggleFavorite: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val pauseLabel = stringResource(R.string.pause)
@@ -1851,25 +1870,39 @@ private fun MoodStationRow(
                     )
                 }
             },
-            trailingContent = if (isActive && (isPlaying || isBuffering)) {
-                {
-                    when {
-                        isBuffering -> CircularWavyProgressIndicator(
-                            modifier = Modifier.size(24.dp),
-                            color = MaterialTheme.colorScheme.onSecondaryContainer,
-                            trackColor = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.3f),
-                        )
-                        isPlaying -> EqualizerBars(
-                            color = MaterialTheme.colorScheme.onSecondaryContainer,
-                            modifier = Modifier
-                                .size(width = 28.dp, height = 22.dp)
-                                .semantics { contentDescription = pauseLabel },
-                            barCount = 3,
+            trailingContent = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (isActive && (isPlaying || isBuffering)) {
+                        when {
+                            isBuffering -> CircularWavyProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                trackColor = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.3f),
+                            )
+                            isPlaying -> EqualizerBars(
+                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                modifier = Modifier
+                                    .size(width = 28.dp, height = 22.dp)
+                                    .semantics { contentDescription = pauseLabel },
+                                barCount = 3,
+                            )
+                        }
+                    }
+                    IconButton(
+                        onClick = onToggleFavorite,
+                        shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
+                    ) {
+                        Icon(
+                            imageVector = if (isSaved) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
+                            contentDescription = stringResource(
+                                if (isSaved) R.string.remove_from_favorites else R.string.save_to_favorites,
+                            ),
+                            tint = if (isSaved) MaterialTheme.colorScheme.primary else {
+                                if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
+                            },
                         )
                     }
                 }
-            } else {
-                null
             },
         ) {
             Text(

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -1833,7 +1833,7 @@ private fun MoodStationRow(
 ) {
     val pauseLabel = stringResource(R.string.pause)
     Surface(
-        color = if (isActive) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface,
+        color = if (isActive) MaterialTheme.colorScheme.surfaceContainerHigh else MaterialTheme.colorScheme.surface,
         shape = MaterialTheme.shapes.medium,
         tonalElevation = if (isActive) 0.dp else 1.dp,
         modifier = modifier
@@ -1851,7 +1851,7 @@ private fun MoodStationRow(
                     Icon(
                         imageVector = Icons.Rounded.Radio,
                         contentDescription = null,
-                        tint = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(26.dp),
                     )
                 }
@@ -1864,7 +1864,7 @@ private fun MoodStationRow(
                     Text(
                         text = countryLabel,
                         style = MaterialTheme.typography.bodyMedium,
-                        color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
@@ -1876,11 +1876,11 @@ private fun MoodStationRow(
                         when {
                             isBuffering -> CircularWavyProgressIndicator(
                                 modifier = Modifier.size(24.dp),
-                                color = MaterialTheme.colorScheme.onSecondaryContainer,
-                                trackColor = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.3f),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            trackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
                             )
                             isPlaying -> EqualizerBars(
-                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 modifier = Modifier
                                     .size(width = 28.dp, height = 22.dp)
                                     .semantics { contentDescription = pauseLabel },
@@ -1898,7 +1898,7 @@ private fun MoodStationRow(
                                 if (isSaved) R.string.remove_from_favorites else R.string.save_to_favorites,
                             ),
                             tint = if (isSaved) MaterialTheme.colorScheme.primary else {
-                                if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
+                                MaterialTheme.colorScheme.onSurfaceVariant
                             },
                         )
                     }
@@ -1908,7 +1908,7 @@ private fun MoodStationRow(
             Text(
                 text = station.name,
                 style = MaterialTheme.typography.titleMedium,
-                color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface,
+                color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
@@ -2179,7 +2179,7 @@ private fun StationListRow(
     )
     SwipeToDismissBox(
         state = dismissState,
-        enableDismissFromStartToEnd = true,
+        enableDismissFromStartToEnd = false,
         enableDismissFromEndToStart = true,
         backgroundContent = {
             Box(
@@ -2216,7 +2216,7 @@ private fun StationListRow(
         },
     ) {
         Surface(
-            color = if (isActive) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface,
+        color = if (isActive) MaterialTheme.colorScheme.surfaceContainerHigh else MaterialTheme.colorScheme.surface,
             shape = MaterialTheme.shapes.medium,
             tonalElevation = if (isActive) 0.dp else 1.dp,
             modifier = modifier
@@ -2247,11 +2247,11 @@ private fun StationListRow(
                             when {
                                 isBuffering -> CircularWavyProgressIndicator(
                                     modifier = Modifier.size(24.dp),
-                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                                    trackColor = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.3f),
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    trackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
                                 )
                                 isPlaying -> EqualizerBars(
-                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     modifier = Modifier
                                         .size(width = 28.dp, height = 22.dp)
                                         .semantics { contentDescription = pauseLabel },
@@ -2267,7 +2267,7 @@ private fun StationListRow(
                 Text(
                     text = station.name,
                     style = MaterialTheme.typography.titleMedium,
-                    color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface,
+            color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -1516,17 +1516,15 @@ internal fun HomeTabContent(
     onFeaturedStationTap: (com.shapeshed.aerial.data.RegistryStation) -> Unit,
     onForYouViewAll: () -> Unit,
 ) {
-    // On launch the splash screen holds until the Recently Played row is resolved (see
-    // MainViewModel.isInitialized), so scroll restoration composes against the full list. The
-    // one remaining shift is the section's very first appearance mid-session (first play ever
-    // recorded): keyed items keep the viewport anchored, hiding the new section above it, so
-    // snap to the top when it appears — but only if the user is in the top header region and
-    // not mid-scroll.
+    // Recently Played can arrive after the grid's first composition. Re-anchor only when the
+    // user has not moved the Home list at all; never interrupt an in-progress or mid-list scroll.
     val hasRecentlyPlayed = recentlyPlayedStations.isNotEmpty()
     var hadRecentlyPlayed by rememberSaveable { mutableStateOf(hasRecentlyPlayed) }
     LaunchedEffect(hasRecentlyPlayed) {
         if (hasRecentlyPlayed && !hadRecentlyPlayed &&
-            !listState.isScrollInProgress && listState.firstVisibleItemIndex <= 2
+            !listState.isScrollInProgress &&
+            listState.firstVisibleItemIndex <= 2 &&
+            listState.firstVisibleItemScrollOffset == 0
         ) {
             listState.scrollToItem(0)
         }

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -3,6 +3,7 @@ package com.shapeshed.aerial.ui
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
@@ -75,6 +76,7 @@ import androidx.compose.material.icons.rounded.NightsStay
 import androidx.compose.material.icons.rounded.Landscape
 import androidx.compose.material.icons.rounded.Psychology
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -112,6 +114,10 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.SearchBar
 import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.SearchBarScrollBehavior
@@ -374,6 +380,9 @@ fun MainScreen(
     var genreFilterQuery by remember { mutableStateOf("") }
 
     val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val favoriteRemovedMessage = stringResource(R.string.favorite_removed_message)
+    val undoLabel = stringResource(R.string.undo)
     val dismissCountrySheet = {
         scope.launch {
             countrySheetState.hide()
@@ -493,6 +502,7 @@ fun MainScreen(
                 selectedMoodId = null
                 viewModel.setSelectedHomeTab(destination)
             },
+            snackbarHost = { SnackbarHost(snackbarHostState) },
             modifier = Modifier
                 .fillMaxSize()
                 .nestedScroll(searchScrollBehavior.nestedScrollConnection),
@@ -550,6 +560,19 @@ fun MainScreen(
                     onPlayFavorite = { viewModel.play(it, stations) },
                     onTogglePlayback = viewModel::togglePlayback,
                     onToggleFavorite = viewModel::toggleFavorite,
+                    onRemoveFavorite = { station ->
+                        viewModel.toggleFavorite(station)
+                        scope.launch {
+                            val result = snackbarHostState.showSnackbar(
+                                message = favoriteRemovedMessage.format(station.name),
+                                actionLabel = undoLabel,
+                                duration = SnackbarDuration.Short,
+                            )
+                            if (result == SnackbarResult.ActionPerformed) {
+                                viewModel.restoreFavorite(station)
+                            }
+                        }
+                    },
                     onHomeViewModeChange = viewModel::setHomeViewMode,
                     onSortSelected = viewModel::setFavoritesSort,
                     onStationLongPress = { contextStation = it },
@@ -708,6 +731,7 @@ private fun MainDestinationContent(
     onPlayFavorite: (Station) -> Unit,
     onTogglePlayback: () -> Unit,
     onToggleFavorite: (Station) -> Unit,
+    onRemoveFavorite: (Station) -> Unit,
     onHomeViewModeChange: (HomeViewMode) -> Unit,
     onSortSelected: (FavoritesSort) -> Unit,
     onStationLongPress: (Station) -> Unit,
@@ -766,6 +790,7 @@ private fun MainDestinationContent(
             onPlay = onPlayFavorite,
             onTogglePlayback = onTogglePlayback,
             onToggleFavorite = onToggleFavorite,
+            onRemoveFavorite = onRemoveFavorite,
             onHomeViewModeChange = onHomeViewModeChange,
             onSortSelected = onSortSelected,
             onStationLongPress = onStationLongPress,
@@ -1818,7 +1843,13 @@ private fun MoodStationRow(
 ) {
     val pauseLabel = stringResource(R.string.pause)
     ListItem(
-        modifier = modifier.fillMaxWidth().clickable(onClick = onPlay),
+        colors = ListItemDefaults.colors(
+            containerColor = if (isActive) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface,
+        ),
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 2.dp)
+            .clickable(onClick = onPlay),
         leadingContent = {
             // Circle rather than a rounded square, matching the search and favourites rows.
             StationLogoCircle(
@@ -1828,7 +1859,7 @@ private fun MoodStationRow(
                 Icon(
                     imageVector = Icons.Rounded.Radio,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    tint = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.size(26.dp),
                 )
             }
@@ -1842,7 +1873,7 @@ private fun MoodStationRow(
                 Text(
                     text = countryLabel,
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
@@ -1857,11 +1888,12 @@ private fun MoodStationRow(
                     when {
                         isBuffering -> CircularWavyProgressIndicator(
                             modifier = Modifier.size(24.dp),
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            trackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+                            color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+                            trackColor = (if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant)
+                                .copy(alpha = 0.3f),
                         )
                         isPlaying -> EqualizerBars(
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier
                                 .size(width = 28.dp, height = 22.dp)
                                 .semantics { contentDescription = pauseLabel },
@@ -1877,7 +1909,9 @@ private fun MoodStationRow(
                     Icon(
                         imageVector = if (isSaved) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
                         contentDescription = stringResource(if (isSaved) R.string.remove_from_favorites else R.string.save_to_favorites),
-                        tint = if (isSaved) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                        tint = if (isSaved) MaterialTheme.colorScheme.primary else {
+                            if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
+                        },
                     )
                 }
             }
@@ -1886,6 +1920,7 @@ private fun MoodStationRow(
         Text(
             text = station.name,
             style = MaterialTheme.typography.titleMedium,
+            color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
         )
@@ -1916,6 +1951,7 @@ internal fun FavoritesTabContent(
     onPlay: (Station) -> Unit,
     onTogglePlayback: () -> Unit,
     onToggleFavorite: (Station) -> Unit,
+    onRemoveFavorite: (Station) -> Unit,
     onHomeViewModeChange: (HomeViewMode) -> Unit,
     onSortSelected: (FavoritesSort) -> Unit,
     onStationLongPress: (Station) -> Unit,
@@ -2019,7 +2055,9 @@ internal fun FavoritesTabContent(
                     onPlay = { onPlay(station) },
                     onTogglePlayback = onTogglePlayback,
                     onToggleFavorite = { onToggleFavorite(station) },
+                    onDismiss = { onRemoveFavorite(station) },
                     onLongClick = { onStationLongPress(station) },
+                    modifier = Modifier.animateItem(),
                 )
             }
         }
@@ -2126,6 +2164,7 @@ private fun HomeViewModeToggle(
 }
 
 @Composable
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 private fun StationListRow(
     station: Station,
     isActive: Boolean,
@@ -2134,6 +2173,7 @@ private fun StationListRow(
     onPlay: () -> Unit,
     onTogglePlayback: () -> Unit,
     onToggleFavorite: () -> Unit,
+    onDismiss: () -> Unit,
     onLongClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -2144,72 +2184,124 @@ private fun StationListRow(
     val countryLabel = station.countryCode.takeIf { it.isNotBlank() }
         ?.let { countryName(it, appLocale) }
         ?: station.country
-    ListItem(
-        modifier = modifier
-            .fillMaxWidth()
-            .combinedClickable(
-                onClick = onPlay,
-                onLongClickLabel = stationOptionsLabel,
-                onLongClick = {
-                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                    onLongClick()
-                },
-            ),
-        leadingContent = {
-            StationAvatar(station = station, isActive = isActive, size = 50.dp)
+    val dismissState = rememberSwipeToDismissBoxState()
+    val swipeBackgroundColor by animateColorAsState(
+        targetValue = when (dismissState.targetValue) {
+            SwipeToDismissBoxValue.Settled -> MaterialTheme.colorScheme.surface
+            SwipeToDismissBoxValue.StartToEnd,
+            SwipeToDismissBoxValue.EndToStart,
+            -> MaterialTheme.colorScheme.errorContainer
         },
-        supportingContent = countryLabel.takeIf { it.isNotBlank() }?.let { label ->
-            {
+        label = "favorite swipe background",
+    )
+    SwipeToDismissBox(
+        state = dismissState,
+        enableDismissFromStartToEnd = true,
+        enableDismissFromEndToStart = true,
+        backgroundContent = {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(swipeBackgroundColor),
+            ) {
+                when (dismissState.dismissDirection) {
+                    SwipeToDismissBoxValue.StartToEnd,
+                    SwipeToDismissBoxValue.EndToStart,
+                    -> Icon(
+                        imageVector = Icons.Rounded.Delete,
+                        contentDescription = stringResource(R.string.remove_from_favorites),
+                        tint = MaterialTheme.colorScheme.onErrorContainer,
+                        modifier = Modifier
+                            .align(
+                                if (dismissState.dismissDirection == SwipeToDismissBoxValue.StartToEnd) {
+                                    Alignment.CenterStart
+                                } else {
+                                    Alignment.CenterEnd
+                                },
+                            )
+                            .padding(12.dp),
+                    )
+                    SwipeToDismissBoxValue.Settled -> Unit
+                }
+            }
+        },
+        onDismiss = { direction ->
+            if (direction != SwipeToDismissBoxValue.Settled) {
+                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                onDismiss()
+            }
+        },
+    ) {
+        Surface(
+            color = if (isActive) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface,
+            shape = MaterialTheme.shapes.medium,
+            tonalElevation = if (isActive) 0.dp else 1.dp,
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 2.dp),
+        ) {
+            ListItem(
+                colors = ListItemDefaults.colors(containerColor = androidx.compose.ui.graphics.Color.Transparent),
+                modifier = Modifier.combinedClickable(
+                    onClick = onPlay,
+                    onLongClickLabel = stationOptionsLabel,
+                    onLongClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        onLongClick()
+                    },
+                ),
+                leadingContent = {
+                    StationAvatar(station = station, isActive = isActive, size = 50.dp)
+                },
+                supportingContent = countryLabel.takeIf { it.isNotBlank() }?.let { label ->
+                    {
+                        Text(text = label, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    }
+                },
+                trailingContent = {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        IconButton(
+                            onClick = if (isActive && isPlaying) onTogglePlayback else onPlay,
+                            shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
+                        ) {
+                            when {
+                                isBuffering -> CircularWavyProgressIndicator(
+                                    modifier = Modifier.size(24.dp),
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    trackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+                                )
+                                isActive && isPlaying -> EqualizerBars(
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier
+                                        .size(width = 28.dp, height = 22.dp)
+                                        .semantics { contentDescription = pauseLabel },
+                                    barCount = 3,
+                                )
+                                else -> Icon(Icons.Rounded.PlayArrow, contentDescription = stringResource(R.string.play))
+                            }
+                        }
+                        IconButton(
+                            onClick = onToggleFavorite,
+                            shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
+                        ) {
+                            Icon(
+                                imageVector = if (station.isFavorite) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
+                                contentDescription = stringResource(if (station.isFavorite) R.string.remove_from_favorites else R.string.save_to_favorites),
+                                tint = if (station.isFavorite) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                },
+            ) {
                 Text(
-                    text = label,
+                    text = station.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-        },
-        trailingContent = {
-            // Same preview-play + favourite pattern as the mood and search rows: a dedicated
-            // button toggles playback in place (rather than only via the row tap), and the
-            // heart removes the row directly.
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                IconButton(
-                    onClick = if (isActive && isPlaying) onTogglePlayback else onPlay,
-                    shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
-                ) {
-                    when {
-                        isBuffering -> CircularWavyProgressIndicator(
-                            modifier = Modifier.size(24.dp),
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            trackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
-                        )
-                        isActive && isPlaying -> EqualizerBars(
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier
-                                .size(width = 28.dp, height = 22.dp)
-                                .semantics { contentDescription = pauseLabel },
-                            barCount = 3,
-                        )
-                        else -> Icon(Icons.Rounded.PlayArrow, contentDescription = stringResource(R.string.play))
-                    }
-                }
-                IconButton(
-                    onClick = onToggleFavorite,
-                    shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
-                ) {
-                    Icon(
-                        imageVector = if (station.isFavorite) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
-                        contentDescription = stringResource(if (station.isFavorite) R.string.remove_from_favorites else R.string.save_to_favorites),
-                        tint = if (station.isFavorite) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-        },
-    ) {
-        Text(
-            text = station.name,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
+        }
     }
 }
 
@@ -2250,7 +2342,9 @@ private fun StationTile(
         Surface(
             // Same plate treatment as the other artwork surfaces: an adaptive plate behind
             // rendered logos (visible only through transparency), tonal otherwise.
-            color = if (showLogo) stationLogoPlateColor(logoIsLight) else tileColor,
+            color = if (showLogo) stationLogoPlateColor(logoIsLight) else {
+                if (isActive) MaterialTheme.colorScheme.primaryContainer else tileColor
+            },
             // Medium card radius like the other cards: a fixed 28dp reads far rounder on
             // the small tiles of a 4-5 column grid, so keep the modest spec radius at
             // every grid width.
@@ -2296,11 +2390,15 @@ private fun StationTile(
                         Box(
                             modifier = Modifier
                                 .fillMaxSize()
-                                .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.35f)),
+                                .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.72f)),
                         )
                     }
                 }
-                val indicatorColor = MaterialTheme.colorScheme.onSurfaceVariant
+                val indicatorColor = if (isActive) {
+                    MaterialTheme.colorScheme.onPrimaryContainer
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                }
                 when {
                     !showActivityIndicator -> Unit
                     isBuffering -> CircularWavyProgressIndicator(
@@ -2319,7 +2417,7 @@ private fun StationTile(
         Text(
             text = station.name,
             style = MaterialTheme.typography.bodyMedium,
-            color = if (isActive) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant,
+            color = if (isActive) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             textAlign = TextAlign.Center,

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -541,8 +541,6 @@ fun MainScreen(
                     uiState = uiState,
                     selectedMood = selectedMood,
                     selectedMoodStations = selectedMoodStations,
-                    savedStreamUrls = savedStreamUrls,
-                    savedRegistryKeys = savedRegistryKeys,
                     bottomPadding = stationContentBottomPadding,
                     selectedTab = effectiveSelectedTab,
                     appLocale = appLocale,
@@ -556,10 +554,7 @@ fun MainScreen(
                     onPlayRegistryStation = viewModel::playFromRegistry,
                     onPlayRegistryQueue = viewModel::playFromRegistry,
                     onAddRegistryStation = viewModel::addFromRegistry,
-                    onRemoveRegistryStation = viewModel::removeFromRegistry,
                     onPlayFavorite = { viewModel.play(it, stations) },
-                    onTogglePlayback = viewModel::togglePlayback,
-                    onToggleFavorite = viewModel::toggleFavorite,
                     onRemoveFavorite = { station ->
                         viewModel.toggleFavorite(station)
                         scope.launch {
@@ -712,8 +707,6 @@ private fun MainDestinationContent(
     uiState: MainUiState,
     selectedMood: CuratedMood?,
     selectedMoodStations: List<RegistryStation>,
-    savedStreamUrls: Set<String>,
-    savedRegistryKeys: Set<RegistryStationKey>,
     bottomPadding: Dp,
     selectedTab: Int,
     appLocale: java.util.Locale,
@@ -727,10 +720,7 @@ private fun MainDestinationContent(
     onPlayRegistryStation: (RegistryStation) -> Unit,
     onPlayRegistryQueue: (RegistryStation, List<RegistryStation>) -> Unit,
     onAddRegistryStation: (RegistryStation) -> Unit,
-    onRemoveRegistryStation: (RegistryStation) -> Unit,
     onPlayFavorite: (Station) -> Unit,
-    onTogglePlayback: () -> Unit,
-    onToggleFavorite: (Station) -> Unit,
     onRemoveFavorite: (Station) -> Unit,
     onHomeViewModeChange: (HomeViewMode) -> Unit,
     onSortSelected: (FavoritesSort) -> Unit,
@@ -747,15 +737,11 @@ private fun MainDestinationContent(
             currentStation = playback.station,
             isPlaying = playback.isPlaying,
             isBuffering = playback.isBuffering,
-            savedStreamUrls = savedStreamUrls,
-            savedRegistryKeys = savedRegistryKeys,
             bottomPadding = bottomPadding,
             onBack = onMoodBack,
             onPlay = { selectedMoodStations.firstOrNull()?.let { onPlayRegistryQueue(it, selectedMoodStations) } },
             onSave = { selectedMoodStations.forEach(onAddRegistryStation) },
-            onTogglePlayback = onTogglePlayback,
             onAddStation = onAddRegistryStation,
-            onRemoveStation = onRemoveRegistryStation,
             onPlayStation = { onPlayRegistryQueue(it, selectedMoodStations) },
         )
     } else if (selectedTab == TAB_HOME) {
@@ -788,8 +774,6 @@ private fun MainDestinationContent(
             listState = favoritesListState,
             bottomPadding = bottomPadding,
             onPlay = onPlayFavorite,
-            onTogglePlayback = onTogglePlayback,
-            onToggleFavorite = onToggleFavorite,
             onRemoveFavorite = onRemoveFavorite,
             onHomeViewModeChange = onHomeViewModeChange,
             onSortSelected = onSortSelected,
@@ -1705,15 +1689,11 @@ private fun MoodDetailScreen(
     currentStation: Station?,
     isPlaying: Boolean,
     isBuffering: Boolean,
-    savedStreamUrls: Set<String>,
-    savedRegistryKeys: Set<RegistryStationKey>,
     bottomPadding: Dp,
     onBack: () -> Unit,
     onPlay: () -> Unit,
     onSave: () -> Unit,
-    onTogglePlayback: () -> Unit,
     onAddStation: (RegistryStation) -> Unit,
-    onRemoveStation: (RegistryStation) -> Unit,
     onPlayStation: (RegistryStation) -> Unit,
 ) {
     LazyColumn(
@@ -1812,18 +1792,12 @@ private fun MoodDetailScreen(
                         active.provider == station.provider &&
                         active.providerId == station.providerId)
             } ?: false
-            val isSaved = station.streamUrl in savedStreamUrls || station.savedKey() in savedRegistryKeys
             MoodStationRow(
                 station = station,
                 isActive = isActive,
                 isPlaying = isPlaying && isActive,
                 isBuffering = isBuffering && isActive,
                 onPlay = { onPlayStation(station) },
-                onTogglePlayback = onTogglePlayback,
-                isSaved = isSaved,
-                onToggleFavorite = {
-                    if (isSaved) onRemoveStation(station) else onAddStation(station)
-                },
             )
         }
     }
@@ -1836,94 +1810,76 @@ private fun MoodStationRow(
     isPlaying: Boolean,
     isBuffering: Boolean,
     onPlay: () -> Unit,
-    onTogglePlayback: () -> Unit,
-    isSaved: Boolean,
-    onToggleFavorite: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val pauseLabel = stringResource(R.string.pause)
-    ListItem(
-        colors = ListItemDefaults.colors(
-            containerColor = if (isActive) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface,
-        ),
+    Surface(
+        color = if (isActive) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface,
+        shape = MaterialTheme.shapes.medium,
+        tonalElevation = if (isActive) 0.dp else 1.dp,
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 2.dp)
-            .clickable(onClick = onPlay),
-        leadingContent = {
-            // Circle rather than a rounded square, matching the search and favourites rows.
-            StationLogoCircle(
-                logoModel = logoModelFor(station.logoUrl),
-                size = 56.dp,
-            ) {
-                Icon(
-                    imageVector = Icons.Rounded.Radio,
-                    contentDescription = null,
-                    tint = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(26.dp),
-                )
-            }
-        },
-        supportingContent = {
-            // Localized country from the ISO code, matching the search result rows.
-            val countryLabel = station.countryCode.takeIf { it.isNotBlank() }
-                ?.let { countryName(it, LocalConfiguration.current.locales[0]) }
-                ?: station.country
-            if (countryLabel.isNotBlank()) {
-                Text(
-                    text = countryLabel,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-        },
-        trailingContent = {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                IconButton(
-                    onClick = if (isPlaying) onTogglePlayback else onPlay,
-                    shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
+            .padding(horizontal = 16.dp, vertical = 2.dp),
+    ) {
+        ListItem(
+            colors = ListItemDefaults.colors(containerColor = androidx.compose.ui.graphics.Color.Transparent),
+            modifier = Modifier.clickable(onClick = onPlay),
+            leadingContent = {
+                StationLogoCircle(
+                    logoModel = logoModelFor(station.logoUrl),
+                    size = 50.dp,
                 ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Radio,
+                        contentDescription = null,
+                        tint = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(26.dp),
+                    )
+                }
+            },
+            supportingContent = {
+                val countryLabel = station.countryCode.takeIf { it.isNotBlank() }
+                    ?.let { countryName(it, LocalConfiguration.current.locales[0]) }
+                    ?: station.country
+                if (countryLabel.isNotBlank()) {
+                    Text(
+                        text = countryLabel,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            },
+            trailingContent = if (isActive && (isPlaying || isBuffering)) {
+                {
                     when {
                         isBuffering -> CircularWavyProgressIndicator(
                             modifier = Modifier.size(24.dp),
-                            color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
-                            trackColor = (if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant)
-                                .copy(alpha = 0.3f),
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                            trackColor = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.3f),
                         )
                         isPlaying -> EqualizerBars(
-                            color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
                             modifier = Modifier
                                 .size(width = 28.dp, height = 22.dp)
                                 .semantics { contentDescription = pauseLabel },
                             barCount = 3,
                         )
-                        else -> Icon(Icons.Rounded.PlayArrow, contentDescription = stringResource(R.string.play))
                     }
                 }
-                IconButton(
-                    onClick = onToggleFavorite,
-                    shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
-                ) {
-                    Icon(
-                        imageVector = if (isSaved) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
-                        contentDescription = stringResource(if (isSaved) R.string.remove_from_favorites else R.string.save_to_favorites),
-                        tint = if (isSaved) MaterialTheme.colorScheme.primary else {
-                            if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
-                        },
-                    )
-                }
-            }
-        },
-    ) {
-        Text(
-            text = station.name,
-            style = MaterialTheme.typography.titleMedium,
-            color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-        )
+            } else {
+                null
+            },
+        ) {
+            Text(
+                text = station.name,
+                style = MaterialTheme.typography.titleMedium,
+                color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
     }
 }
 
@@ -1949,8 +1905,6 @@ internal fun FavoritesTabContent(
     listState: LazyGridState,
     bottomPadding: androidx.compose.ui.unit.Dp,
     onPlay: (Station) -> Unit,
-    onTogglePlayback: () -> Unit,
-    onToggleFavorite: (Station) -> Unit,
     onRemoveFavorite: (Station) -> Unit,
     onHomeViewModeChange: (HomeViewMode) -> Unit,
     onSortSelected: (FavoritesSort) -> Unit,
@@ -2053,8 +2007,6 @@ internal fun FavoritesTabContent(
                     isPlaying = isPlaying && isActive,
                     isBuffering = isBuffering && isActive,
                     onPlay = { onPlay(station) },
-                    onTogglePlayback = onTogglePlayback,
-                    onToggleFavorite = { onToggleFavorite(station) },
                     onDismiss = { onRemoveFavorite(station) },
                     onLongClick = { onStationLongPress(station) },
                     modifier = Modifier.animateItem(),
@@ -2171,8 +2123,6 @@ private fun StationListRow(
     isPlaying: Boolean,
     isBuffering: Boolean,
     onPlay: () -> Unit,
-    onTogglePlayback: () -> Unit,
-    onToggleFavorite: () -> Unit,
     onDismiss: () -> Unit,
     onLongClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -2258,39 +2208,27 @@ private fun StationListRow(
                         Text(text = label, maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 },
-                trailingContent = {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        IconButton(
-                            onClick = if (isActive && isPlaying) onTogglePlayback else onPlay,
-                            shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
-                        ) {
+                trailingContent = if (isActive && (isPlaying || isBuffering)) {
+                    {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
                             when {
                                 isBuffering -> CircularWavyProgressIndicator(
                                     modifier = Modifier.size(24.dp),
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    trackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    trackColor = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.3f),
                                 )
-                                isActive && isPlaying -> EqualizerBars(
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                isPlaying -> EqualizerBars(
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
                                     modifier = Modifier
                                         .size(width = 28.dp, height = 22.dp)
                                         .semantics { contentDescription = pauseLabel },
                                     barCount = 3,
                                 )
-                                else -> Icon(Icons.Rounded.PlayArrow, contentDescription = stringResource(R.string.play))
                             }
                         }
-                        IconButton(
-                            onClick = onToggleFavorite,
-                            shapes = IconButtonShapes(IconButtonDefaults.smallRoundShape, IconButtonDefaults.smallPressedShape),
-                        ) {
-                            Icon(
-                                imageVector = if (station.isFavorite) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
-                                contentDescription = stringResource(if (station.isFavorite) R.string.remove_from_favorites else R.string.save_to_favorites),
-                                tint = if (station.isFavorite) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
                     }
+                } else {
+                    null
                 },
             ) {
                 Text(

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -1833,7 +1833,7 @@ private fun MoodStationRow(
 ) {
     val pauseLabel = stringResource(R.string.pause)
     Surface(
-        color = if (isActive) MaterialTheme.colorScheme.surfaceContainerHigh else MaterialTheme.colorScheme.surface,
+        color = if (isActive) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface,
         shape = MaterialTheme.shapes.medium,
         tonalElevation = if (isActive) 0.dp else 1.dp,
         modifier = modifier
@@ -1851,7 +1851,7 @@ private fun MoodStationRow(
                     Icon(
                         imageVector = Icons.Rounded.Radio,
                         contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        tint = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(26.dp),
                     )
                 }
@@ -1864,7 +1864,7 @@ private fun MoodStationRow(
                     Text(
                         text = countryLabel,
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
@@ -1876,11 +1876,11 @@ private fun MoodStationRow(
                         when {
                             isBuffering -> CircularWavyProgressIndicator(
                                 modifier = Modifier.size(24.dp),
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            trackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                trackColor = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.3f),
                             )
                             isPlaying -> EqualizerBars(
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                color = MaterialTheme.colorScheme.onSecondaryContainer,
                                 modifier = Modifier
                                     .size(width = 28.dp, height = 22.dp)
                                     .semantics { contentDescription = pauseLabel },
@@ -1898,7 +1898,7 @@ private fun MoodStationRow(
                                 if (isSaved) R.string.remove_from_favorites else R.string.save_to_favorites,
                             ),
                             tint = if (isSaved) MaterialTheme.colorScheme.primary else {
-                                MaterialTheme.colorScheme.onSurfaceVariant
+                                if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
                             },
                         )
                     }
@@ -1908,7 +1908,7 @@ private fun MoodStationRow(
             Text(
                 text = station.name,
                 style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
+                color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
@@ -2216,7 +2216,7 @@ private fun StationListRow(
         },
     ) {
         Surface(
-        color = if (isActive) MaterialTheme.colorScheme.surfaceContainerHigh else MaterialTheme.colorScheme.surface,
+            color = if (isActive) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface,
             shape = MaterialTheme.shapes.medium,
             tonalElevation = if (isActive) 0.dp else 1.dp,
             modifier = modifier
@@ -2238,7 +2238,12 @@ private fun StationListRow(
                 },
                 supportingContent = countryLabel.takeIf { it.isNotBlank() }?.let { label ->
                     {
-                        Text(text = label, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        Text(
+                            text = label,
+                            color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
                     }
                 },
                 trailingContent = if (isActive && (isPlaying || isBuffering)) {
@@ -2247,11 +2252,11 @@ private fun StationListRow(
                             when {
                                 isBuffering -> CircularWavyProgressIndicator(
                                     modifier = Modifier.size(24.dp),
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    trackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    trackColor = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.3f),
                                 )
                                 isPlaying -> EqualizerBars(
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
                                     modifier = Modifier
                                         .size(width = 28.dp, height = 22.dp)
                                         .semantics { contentDescription = pauseLabel },
@@ -2267,7 +2272,7 @@ private fun StationListRow(
                 Text(
                     text = station.name,
                     style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface,
+                    color = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.items
@@ -414,7 +415,8 @@ fun MainScreen(
     val effectiveSelectedTab = if (showHome) selectedTab else TAB_FAVORITES
     // Hoisted so each tab keeps its scroll position across tab switches.
     val homeListState = rememberLazyGridState()
-    val favoritesListState = rememberLazyGridState()
+    val favoritesGridState = rememberLazyGridState()
+    val favoritesListState = rememberLazyListState()
 
     var miniPlayerHeightPx by remember { mutableIntStateOf(0) }
     val density = LocalDensity.current
@@ -547,6 +549,7 @@ fun MainScreen(
                     selectedTab = effectiveSelectedTab,
                     appLocale = appLocale,
                     homeListState = homeListState,
+                    favoritesGridState = favoritesGridState,
                     favoritesListState = favoritesListState,
                     onMoodBack = { selectedMoodId = null },
                     onMoodSelected = { selectedMoodId = it.id },
@@ -716,7 +719,8 @@ private fun MainDestinationContent(
     selectedTab: Int,
     appLocale: java.util.Locale,
     homeListState: LazyGridState,
-    favoritesListState: LazyGridState,
+    favoritesGridState: LazyGridState,
+    favoritesListState: LazyListState,
     onMoodBack: () -> Unit,
     onMoodSelected: (CuratedMood) -> Unit,
     onSetForYouCountry: (String) -> Unit,
@@ -780,6 +784,7 @@ private fun MainDestinationContent(
             homeViewMode = home.preferences.viewMode,
             favoritesSort = home.preferences.favoritesSort,
             gridColumns = home.preferences.gridColumns,
+            gridState = favoritesGridState,
             listState = favoritesListState,
             bottomPadding = bottomPadding,
             onPlay = onPlayFavorite,
@@ -1935,7 +1940,8 @@ internal fun FavoritesTabContent(
     homeViewMode: HomeViewMode,
     favoritesSort: FavoritesSort,
     gridColumns: Int,
-    listState: LazyGridState,
+    gridState: LazyGridState,
+    listState: LazyListState,
     bottomPadding: androidx.compose.ui.unit.Dp,
     onPlay: (Station) -> Unit,
     onRemoveFavorite: (Station) -> Unit,
@@ -1970,46 +1976,16 @@ internal fun FavoritesTabContent(
         )
     }
 
-    LazyVerticalGrid(
-        columns = if (homeViewMode == HomeViewMode.Cards) {
-            GridCells.Adaptive(favoriteCardMinimumWidthDp(gridColumns).dp)
-        } else {
-            GridCells.Adaptive(400.dp)
-        },
-        state = listState,
-        horizontalArrangement = Arrangement.spacedBy(if (homeViewMode == HomeViewMode.Cards) 12.dp else 0.dp),
-        contentPadding = PaddingValues(
-            start = if (homeViewMode == HomeViewMode.Cards) 16.dp else 0.dp,
-            end = if (homeViewMode == HomeViewMode.Cards) 16.dp else 0.dp,
-            bottom = bottomPadding + 16.dp,
-        ),
-    ) {
-        item("favorites-header", span = { GridItemSpan(maxLineSpan) }) {
-            // No headline — the Favourites tab already names the screen (Material tabs
-            // convention); just the sort selector and the view-mode toggle.
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 8.dp, end = 16.dp, top = 8.dp, bottom = 8.dp),
-            ) {
-                TextButton(onClick = { showSortSheet = true }) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Rounded.Sort,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp),
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(favoritesSortLabel(favoritesSort))
-                }
-                Spacer(modifier = Modifier.weight(1f))
-                HomeViewModeToggle(
-                    selected = homeViewMode,
-                    onSelected = onHomeViewModeChange,
-                )
+    if (homeViewMode == HomeViewMode.Cards) {
+        LazyVerticalGrid(
+            columns = GridCells.Adaptive(favoriteCardMinimumWidthDp(gridColumns).dp),
+            state = gridState,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = bottomPadding + 16.dp),
+        ) {
+            item("favorites-header", span = { GridItemSpan(maxLineSpan) }) {
+                FavoritesHeader(favoritesSort, homeViewMode, { showSortSheet = true }, onHomeViewModeChange)
             }
-        }
-        if (homeViewMode == HomeViewMode.Cards) {
             gridItems(
                 items = stations,
                 key = { station -> "favorite-card-${station.id}" },
@@ -2027,8 +2003,16 @@ internal fun FavoritesTabContent(
                     modifier = Modifier.padding(bottom = 12.dp),
                 )
             }
-        } else {
-            gridItems(
+        }
+    } else {
+        LazyColumn(
+            state = listState,
+            contentPadding = PaddingValues(bottom = bottomPadding + 16.dp),
+        ) {
+            item("favorites-header") {
+                FavoritesHeader(favoritesSort, homeViewMode, { showSortSheet = true }, onHomeViewModeChange)
+            }
+            items(
                 items = stations,
                 key = { station -> "favorite-list-${station.id}" },
                 contentType = { "favorite-list-row" },
@@ -2046,6 +2030,29 @@ internal fun FavoritesTabContent(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun FavoritesHeader(
+    favoritesSort: FavoritesSort,
+    homeViewMode: HomeViewMode,
+    onSortClick: () -> Unit,
+    onHomeViewModeChange: (HomeViewMode) -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 8.dp, end = 16.dp, top = 8.dp, bottom = 8.dp),
+    ) {
+        TextButton(onClick = onSortClick) {
+            Icon(Icons.AutoMirrored.Rounded.Sort, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(favoritesSortLabel(favoritesSort))
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        HomeViewModeToggle(selected = homeViewMode, onSelected = onHomeViewModeChange)
     }
 }
 

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -87,6 +87,18 @@ internal fun recoverLogoPath(storedPath: String, remoteLogoUrl: String, fileExis
         else -> storedPath
     }
 
+/** Reorders an existing Media3 playlist without clearing or preparing the active item. */
+internal fun reorderPlayerPlaylist(player: Player, current: List<Station>, desired: List<Station>) {
+    val working = current.toMutableList()
+    desired.forEachIndexed { targetIndex, station ->
+        val currentIndex = working.indexOfFirst { it.matches(station) }
+        if (currentIndex >= 0 && currentIndex != targetIndex) {
+            player.moveMediaItem(currentIndex, targetIndex)
+            working.add(targetIndex, working.removeAt(currentIndex))
+        }
+    }
+}
+
 class MainViewModel(
     application: Application,
     private val repository: StationRepository,
@@ -246,19 +258,8 @@ class MainViewModel(
 
         val reorderedQueue = sortStations(favorites, sort)
         _playbackUiState.value = _playbackUiState.value.copy(queue = reorderedQueue)
+        controller?.let { player -> reorderPlayerPlaylist(player, activeQueue, reorderedQueue) }
         val currentStation = _playbackUiState.value.station ?: return
-        val startIndex = resolveQueueStart(reorderedQueue, currentStation) ?: return
-        controller?.let { player ->
-            val wasPlaying = player.isPlaying
-            val position = player.currentPosition
-            player.setMediaItems(
-                reorderedQueue.map { it.toPlayableMediaItem(getApplication()) },
-                startIndex,
-                position,
-            )
-            player.prepare()
-            if (wasPlaying) player.play() else player.pause()
-        }
         persistLastPlayedStation(currentStation, reorderedQueue)
     }
 

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -207,9 +207,38 @@ class MainViewModel(
 
     fun setFavoritesSort(sort: FavoritesSort) {
         _favoritesSort.value = sort
+        refreshActiveFavoritesQueue(sort)
         viewModelScope.launch {
             dataStore.edit { prefs -> prefs[FAVORITES_SORT_KEY] = sort.name }
         }
+    }
+
+    /** Keeps next/previous aligned with the order currently shown in the favourites tab. */
+    private fun refreshActiveFavoritesQueue(sort: FavoritesSort) {
+        val activeQueue = _playbackUiState.value.queue
+        if (activeQueue.size < 2) return
+
+        val favorites = _allStations.value.filter(Station::isFavorite)
+        val isFavoritesQueue = favorites.size == activeQueue.size &&
+            favorites.all { favorite -> activeQueue.any { it.matches(favorite) } }
+        if (!isFavoritesQueue) return
+
+        val reorderedQueue = sortStations(favorites, sort)
+        _playbackUiState.value = _playbackUiState.value.copy(queue = reorderedQueue)
+        val currentStation = _playbackUiState.value.station ?: return
+        val startIndex = resolveQueueStart(reorderedQueue, currentStation) ?: return
+        controller?.let { player ->
+            val wasPlaying = player.isPlaying
+            val position = player.currentPosition
+            player.setMediaItems(
+                reorderedQueue.map { it.toPlayableMediaItem(getApplication()) },
+                startIndex,
+                position,
+            )
+            player.prepare()
+            if (wasPlaying) player.play() else player.pause()
+        }
+        persistLastPlayedStation(currentStation, reorderedQueue)
     }
 
     val stations: StateFlow<List<Station>> = combine(_allStations, _favoritesSort) { list, sort ->

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -675,6 +675,16 @@ class MainViewModel(
         }
     }
 
+    fun restoreFavorite(station: Station) {
+        viewModelScope.launch {
+            val id = repository.saveAsFavorite(station.copy(isFavorite = true))
+            if (_ephemeralStation.value?.streamUrl == station.streamUrl) {
+                _currentStationId.value = id
+                _ephemeralStation.value = null
+            }
+        }
+    }
+
     private val playerListener = object : Player.Listener {
         // Playback can start or change from outside this ViewModel — Android Auto, voice
         // search, a queue skip — so the phone's current-station state must follow the

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -79,6 +79,14 @@ private val LAST_HOME_TAB_KEY = intPreferencesKey("last_home_tab")
 private const val MAX_RECENT_SEARCHES = 5
 private const val RECENTLY_PLAYED_LIMIT = 10
 
+/** Keeps a favourite usable when its app-private cached logo disappeared during reinstall. */
+internal fun recoverLogoPath(storedPath: String, remoteLogoUrl: String, fileExists: Boolean): String =
+    when {
+        storedPath.startsWith("http") || fileExists -> storedPath
+        remoteLogoUrl.isNotBlank() -> remoteLogoUrl
+        else -> storedPath
+    }
+
 class MainViewModel(
     application: Application,
     private val repository: StationRepository,
@@ -198,7 +206,20 @@ class MainViewModel(
     }
 
     private val _allStations: StateFlow<List<Station>> = repository.getAll()
+        .map { stations -> stations.map { recoverStationArtwork(it) } }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    private suspend fun recoverStationArtwork(station: Station): Station {
+        val localPath = station.logoPath
+        if (localPath.startsWith("http") || localPath.isBlank() || File(localPath).isFile) return station
+        val registry = when {
+            station.provider.isNotBlank() && station.providerId.isNotBlank() ->
+                registryRepository.getByProviderId(station.provider, station.providerId)
+            else -> registryRepository.getByStreamUrl(station.streamUrl)
+        }
+        val recoveredPath = recoverLogoPath(localPath, registry?.logoUrl.orEmpty(), fileExists = false)
+        return if (recoveredPath == localPath) station else station.copy(logoPath = recoveredPath)
+    }
 
     // Sort order for the Favourites tab. Updated synchronously so the list reorders
     // immediately; the DataStore write catches up in the background.

--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -238,6 +238,19 @@ class MainViewModel(
     private val _favoritesSort = MutableStateFlow(FavoritesSort.AZ)
     val favoritesSort: StateFlow<FavoritesSort> = _favoritesSort.asStateFlow()
 
+    private val _activeFavoritesOrder = MutableStateFlow<List<Long>?>(null)
+
+    private fun favoritesOrder(queue: List<Station>): List<Long>? {
+        if (queue.size < 2 || queue.any { it.id == 0L }) return null
+        val favorites = _allStations.value.filter(Station::isFavorite)
+        return queue.takeIf { ordered ->
+            ordered.size == favorites.size && favorites.all { favorite -> ordered.any { it.matches(favorite) } }
+        }?.map(Station::id)
+    }
+
+    private fun sortFavorites(stations: List<Station>, sort: FavoritesSort): List<Station> =
+        sortStations(stations.filter(Station::isFavorite), sort)
+
     fun setFavoritesSort(sort: FavoritesSort) {
         _favoritesSort.value = sort
         refreshActiveFavoritesQueue(sort)
@@ -257,14 +270,18 @@ class MainViewModel(
         if (!isFavoritesQueue) return
 
         val reorderedQueue = sortStations(favorites, sort)
+        _activeFavoritesOrder.value = reorderedQueue.map(Station::id)
         _playbackUiState.value = _playbackUiState.value.copy(queue = reorderedQueue)
         controller?.let { player -> reorderPlayerPlaylist(player, activeQueue, reorderedQueue) }
         val currentStation = _playbackUiState.value.station ?: return
         persistLastPlayedStation(currentStation, reorderedQueue)
     }
 
-    val stations: StateFlow<List<Station>> = combine(_allStations, _favoritesSort) { list, sort ->
-        sortStations(list, sort)
+    val stations: StateFlow<List<Station>> = combine(_allStations, _favoritesSort, _activeFavoritesOrder) { list, sort, activeOrder ->
+        val sorted = sortFavorites(list, sort)
+        activeOrder?.let { order ->
+            sorted.sortedBy { station -> order.indexOf(station.id).takeIf { it >= 0 } ?: Int.MAX_VALUE }
+        } ?: sorted
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     private val _currentStationId = MutableStateFlow<Long?>(null)
@@ -348,6 +365,7 @@ class MainViewModel(
 
     fun setSelectedHomeTab(tab: Int) {
         _selectedHomeTab.value = tab
+        if (tab != 1) _activeFavoritesOrder.value = null
         viewModelScope.launch {
             dataStore.edit { prefs -> prefs[LAST_HOME_TAB_KEY] = tab }
         }
@@ -809,6 +827,9 @@ class MainViewModel(
         queue: List<Station> = emptyList(),
     ) {
         val station = resolvedStation ?: resolveStation(mediaItem)
+        if (queue.isNotEmpty()) {
+            _activeFavoritesOrder.value = favoritesOrder(queue)
+        }
         if (station != null) {
             val changed = stationChanged(station)
             updateStationIdentity(station)
@@ -930,6 +951,7 @@ class MainViewModel(
     // next/previous work: Media3's default session callback already handles those by seeking
     // within the player's timeline, it just needs a timeline with neighbours to seek to.
     fun play(station: Station, queue: List<Station> = emptyList()) {
+        _activeFavoritesOrder.value = favoritesOrder(queue)
         setCurrentStation(station)
         _playbackUiState.value = _playbackUiState.value.copy(
             queue = queue.takeIf { resolveQueueStart(it, station) != null } ?: listOf(station),
@@ -970,6 +992,7 @@ class MainViewModel(
     // play() afterwards goes through the same path as starting a station with no player active.
     fun stopAndClear() {
         suppressLastPlayedPersist = true
+        _activeFavoritesOrder.value = null
         controller?.apply {
             stop()
             clearMediaItems()

--- a/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/NowPlayingScreen.kt
@@ -402,19 +402,23 @@ fun NowPlayingScreen(
                                 horizontalAlignment = Alignment.Start,
                             ) {
                                 Text(
-                                    text = trackArtist ?: trackTitle.orEmpty(),
-                                    style = MaterialTheme.typography.titleMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    text = trackTitle.orEmpty(),
+                                    style = MaterialTheme.typography.titleMediumEmphasized,
+                                    color = MaterialTheme.colorScheme.onSurface,
                                     textAlign = androidx.compose.ui.text.style.TextAlign.Start,
-                                    modifier = Modifier.fillMaxWidth(),
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .testTag("now_playing_track_title"),
                                 )
-                                if (!trackArtist.isNullOrBlank() && !trackTitle.isNullOrBlank()) {
+                                if (!trackArtist.isNullOrBlank() && trackArtist != trackTitle) {
                                     Text(
-                                        text = trackTitle,
+                                        text = trackArtist,
                                         style = MaterialTheme.typography.bodyMedium,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                                         textAlign = androidx.compose.ui.text.style.TextAlign.Start,
-                                        modifier = Modifier.fillMaxWidth(),
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .testTag("now_playing_track_artist"),
                                     )
                                 }
                             }

--- a/app/src/main/java/com/shapeshed/aerial/ui/theme/Theme.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/theme/Theme.kt
@@ -7,12 +7,11 @@ import androidx.compose.material3.MaterialExpressiveTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
-import androidx.compose.material3.Typography
 import androidx.compose.material3.expressiveLightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 
-private val darkScheme = darkColorScheme()
+private val darkFallbackScheme = darkColorScheme()
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -26,13 +25,12 @@ fun AerialTheme(
             val context = LocalContext.current
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
-        darkTheme -> darkScheme
+        darkTheme -> darkFallbackScheme
         else -> expressiveLightColorScheme()
     }
 
     MaterialExpressiveTheme(
         colorScheme = colorScheme,
-        typography = Typography(),
         content = content,
     )
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -116,4 +116,6 @@
     <string name="no_favorites_desc">Füge Sender hinzu, die du liebst, um sie hier leicht wiederzufinden</string>
     <string name="car_moods">Stimmungen</string>
     <string name="recently_played">Zuletzt gespielt</string>
+    <string name="favorite_removed_message">%1$s aus Favoriten entfernt</string>
+    <string name="undo">Rückgängig</string>
 </resources>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -20,4 +20,6 @@
     <string name="for_you">For you</string>
     <string name="favorites_grid_columns">Favourites grid width</string>
     <string name="favorites_grid_columns_desc">Columns shown in the cards view</string>
+    <string name="favorite_removed_message">%1$s removed from favourites</string>
+    <string name="undo">Undo</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -116,4 +116,6 @@
     <string name="no_favorites_desc">Añade las emisoras que te gustan para encontrarlas fácilmente aquí</string>
     <string name="car_moods">Estados de ánimo</string>
     <string name="recently_played">Reproducidos recientemente</string>
+    <string name="favorite_removed_message">%1$s eliminado de favoritos</string>
+    <string name="undo">Deshacer</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -110,4 +110,6 @@
     <string name="no_favorites_desc">Lisa lemmikjaamad, et need siit hõlpsalt leida</string>
     <string name="car_moods">Meeleolud</string>
     <string name="recently_played">Hiljuti esitatud</string>
+    <string name="favorite_removed_message">%1$s eemaldati lemmikutest</string>
+    <string name="undo">Võta tagasi</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -116,4 +116,6 @@
     <string name="no_favorites_desc">Ajoutez vos stations préférées pour les retrouver facilement ici</string>
     <string name="car_moods">Humeurs</string>
     <string name="recently_played">Écouté récemment</string>
+    <string name="favorite_removed_message">%1$s retirée des favoris</string>
+    <string name="undo">Annuler</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -116,4 +116,6 @@
     <string name="no_favorites_desc">Aggiungi le stazioni che ami per ritrovarle facilmente qui</string>
     <string name="car_moods">Umori</string>
     <string name="recently_played">Ascoltati di recente</string>
+    <string name="favorite_removed_message">%1$s rimosso dai preferiti</string>
+    <string name="undo">Annulla</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -116,4 +116,6 @@
     <string name="no_favorites_desc">お気に入りの放送局を追加すると、ここからすぐに見つけられます</string>
     <string name="car_moods">気分</string>
     <string name="recently_played">最近再生</string>
+    <string name="favorite_removed_message">%1$sをお気に入りから削除しました</string>
+    <string name="undo">元に戻す</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -116,4 +116,6 @@
     <string name="no_favorites_desc">좋아하는 방송국을 추가하면 여기서 쉽게 찾을 수 있어요</string>
     <string name="car_moods">기분</string>
     <string name="recently_played">최근 재생</string>
+    <string name="favorite_removed_message">%1$s을(를) 즐겨찾기에서 삭제했습니다</string>
+    <string name="undo">실행 취소</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -116,4 +116,6 @@
     <string name="no_favorites_desc">Voeg zenders toe die je leuk vindt om ze hier snel terug te vinden</string>
     <string name="car_moods">Stemmingen</string>
     <string name="recently_played">Laatst afgespeeld</string>
+    <string name="favorite_removed_message">%1$s verwijderd uit favorieten</string>
+    <string name="undo">Ongedaan maken</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -117,4 +117,6 @@
     <string name="no_favorites_desc">Adicione as estações que você gosta para encontrá-las facilmente aqui</string>
     <string name="car_moods">Humores</string>
     <string name="recently_played">Reproduzidos recentemente</string>
+    <string name="favorite_removed_message">%1$s removida dos favoritos</string>
+    <string name="undo">Desfazer</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -112,4 +112,6 @@
     <string name="no_favorites_desc">Добавьте любимые станции, чтобы легко находить их здесь</string>
     <string name="car_moods">Настроения</string>
     <string name="recently_played">Недавно прослушанные</string>
+    <string name="favorite_removed_message">%1$s удалена из избранного</string>
+    <string name="undo">Отменить</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -110,4 +110,6 @@
     <string name="no_favorites_desc">Burada kolayca bulabilmek için sevdiğiniz istasyonları ekleyin</string>
     <string name="car_moods">Ruh halleri</string>
     <string name="recently_played">Son oynatılanlar</string>
+    <string name="favorite_removed_message">%1$s favorilerden kaldırıldı</string>
+    <string name="undo">Geri al</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -116,4 +116,6 @@
     <string name="no_favorites_desc">添加喜欢的电台，方便在此快速找到</string>
     <string name="car_moods">心情</string>
     <string name="recently_played">最近播放</string>
+    <string name="favorite_removed_message">已从收藏中移除 %1$s</string>
+    <string name="undo">撤销</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,8 @@
     <string name="add_your_own_station">Add your own station</string>
     <string name="save_to_favorites">Save to favorites</string>
     <string name="remove_from_favorites">Remove from favorites</string>
+    <string name="favorite_removed_message">%1$s removed from favorites</string>
+    <string name="undo">Undo</string>
     <string name="no_internet_title">No internet connection</string>
     <string name="no_internet_desc">Radio streams require an active internet connection.</string>
     <string name="favorites_header">Your favorites</string>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
-        <exclude domain="file" path="logos/" />
     </cloud-backup>
     <device-transfer>
-        <exclude domain="file" path="logos/" />
     </device-transfer>
 </data-extraction-rules>

--- a/app/src/main/res/xml/full_backup_rules.xml
+++ b/app/src/main/res/xml/full_backup_rules.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-    <exclude domain="file" path="logos/" />
 </full-backup-content>

--- a/app/src/test/java/com/shapeshed/aerial/data/MediaBrowseTreeTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/data/MediaBrowseTreeTest.kt
@@ -253,6 +253,8 @@ class MediaBrowseTreeTest {
             stations.filter { it.providerId in ids }
         override suspend fun getByProviderId(provider: String, providerId: String): RegistryStation? =
             stations.firstOrNull { it.provider == provider && it.providerId == providerId }
+        override suspend fun getByStreamUrl(streamUrl: String): RegistryStation? =
+            stations.firstOrNull { it.streamUrl == streamUrl }
         override suspend fun getById(id: Long): RegistryStation? = stations.firstOrNull { it.id == id }
         override suspend fun getByNames(names: List<String>): List<RegistryStation> =
             stations.filter { it.name in names }

--- a/app/src/test/java/com/shapeshed/aerial/ui/LogoPathRecoveryTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/ui/LogoPathRecoveryTest.kt
@@ -1,0 +1,32 @@
+package com.shapeshed.aerial.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LogoPathRecoveryTest {
+    @Test
+    fun staleCachedLogoFallsBackToPersistedRemoteUrlAfterReinstall() {
+        assertEquals(
+            "https://cdn.example.test/station.svg",
+            recoverLogoPath(
+                storedPath = "/data/user/0/com.shapeshed.aerial/files/logos/station.svg",
+                remoteLogoUrl = "https://cdn.example.test/station.svg",
+                fileExists = false,
+            ),
+        )
+    }
+
+    @Test
+    fun existingEditedLocalLogoRemainsTheSourceOfTruth() {
+        val editedLogo = "/data/user/0/com.shapeshed.aerial/files/logos/my-edited-logo.png"
+
+        assertEquals(
+            editedLogo,
+            recoverLogoPath(
+                storedPath = editedLogo,
+                remoteLogoUrl = "https://cdn.example.test/original.svg",
+                fileExists = true,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/shapeshed/aerial/ui/MainViewModelStateTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/ui/MainViewModelStateTest.kt
@@ -193,6 +193,23 @@ class MainViewModelStateTest {
     }
 
     @Test
+    fun favoritesStateDoesNotPutNonFavoritesIntoTheSkipQueue() = runTest {
+        val favoriteAlpha = station(1, "Alpha")
+        val nonFavoriteBravo = station(2, "Bravo").copy(isFavorite = false)
+        val favoriteCharlie = station(3, "Charlie")
+        val repository = mock<StationRepository>()
+        whenever(repository.getAll()).thenReturn(flowOf(listOf(favoriteAlpha, nonFavoriteBravo, favoriteCharlie)))
+        whenever(repository.recentlyPlayedAsFlow(any())).thenReturn(flowOf(emptyList()))
+        val viewModel = viewModel(repository, mock())
+        runCurrent()
+
+        assertEquals(
+            listOf(favoriteAlpha.id, favoriteCharlie.id),
+            viewModel.stations.first { it.size == 2 }.map(Station::id),
+        )
+    }
+
+    @Test
     fun changingFavoritesSortUpdatesTheActivePlaybackQueue() = runTest {
         val alpha = station(1, "Alpha", lastPlayedAt = 1_000)
         val bravo = station(2, "Bravo", lastPlayedAt = 3_000)
@@ -213,6 +230,112 @@ class MainViewModelStateTest {
         assertEquals(
             listOf(bravo.id, alpha.id),
             viewModel.playbackUiState.value.queue.map(Station::id),
+        )
+    }
+
+    @Test
+    fun switchingBackToAzKeepsNextNavigationInDisplayedOrder() = runTest {
+        val zulu = station(1, "Zulu", lastPlayedAt = 3_000)
+        val alpha = station(2, "Alpha", lastPlayedAt = 1_000)
+        val mike = station(3, "Mike", lastPlayedAt = 2_000)
+        val repository = mock<StationRepository>()
+        whenever(repository.getAll()).thenReturn(flowOf(listOf(zulu, alpha, mike)))
+        whenever(repository.recentlyPlayedAsFlow(any())).thenReturn(flowOf(emptyList()))
+        val viewModel = viewModel(repository, mock())
+        runCurrent()
+
+        viewModel.handlePlaybackEvents(
+            mediaItem(alpha.name, alpha.id.toString()),
+            isPlaying = true,
+            queue = listOf(zulu, alpha, mike),
+        )
+        viewModel.setFavoritesSort(FavoritesSort.AZ)
+        runCurrent()
+
+        val orderedQueue = viewModel.playbackUiState.value.queue
+        assertEquals(listOf(alpha.id, mike.id, zulu.id), orderedQueue.map(Station::id))
+        assertEquals(mike.id, orderedQueue.stationAtOffset(alpha, 1)?.id)
+        assertEquals(zulu.id, orderedQueue.stationAtOffset(mike, 1)?.id)
+    }
+
+    @Test
+    fun lastPlayedSortKeepsTheStationPlayedImmediatelyBeforeSortingAtTheFront() = runTest {
+        val radio4 = station(1, "BBC Radio 4", lastPlayedAt = 2_000)
+        val radio1Dance = station(2, "BBC Radio 1 Dance", lastPlayedAt = 1_000)
+        val third = station(3, "Third Station", lastPlayedAt = 500)
+        val queue = listOf(radio1Dance, radio4, third)
+        val repository = mock<StationRepository>()
+        // This models the collection lag between PlayerService recording a play and
+        // Room's station Flow delivering the updated lastPlayedAt value.
+        val rows = MutableStateFlow(listOf(radio4, radio1Dance, third))
+        whenever(repository.getAll()).thenReturn(rows)
+        whenever(repository.recentlyPlayedAsFlow(any())).thenReturn(flowOf(emptyList()))
+        val viewModel = viewModel(repository, mock())
+        runCurrent()
+
+        viewModel.play(radio4, queue)
+        viewModel.play(radio1Dance, queue)
+        rows.value = listOf(radio4, radio1Dance.copy(lastPlayedAt = 5_000), third)
+        runCurrent()
+        viewModel.setFavoritesSort(FavoritesSort.LAST_PLAYED)
+        runCurrent()
+
+        assertEquals(
+            radio1Dance.id,
+            viewModel.playbackUiState.value.queue.first().id,
+        )
+    }
+
+    @Test
+    fun advancingARecentlyPlayedQueueDoesNotResortTheVisibleLastPlayedList() = runTest {
+        val worldwide = station(1, "Worldwide FM", lastPlayedAt = 4_000)
+        val radio4 = station(2, "BBC Radio 4", lastPlayedAt = 3_000)
+        val kool = station(3, "Kool FM", lastPlayedAt = 2_000)
+        val radio1Dance = station(4, "BBC Radio 1 Dance", lastPlayedAt = 1_000)
+        val stationRows = MutableStateFlow(listOf(worldwide, radio4, kool, radio1Dance))
+        val repository = mock<StationRepository>()
+        whenever(repository.getAll()).thenReturn(stationRows)
+        whenever(repository.recentlyPlayedAsFlow(any())).thenReturn(flowOf(emptyList()))
+        val viewModel = viewModel(repository, mock())
+        runCurrent()
+        viewModel.setFavoritesSort(FavoritesSort.LAST_PLAYED)
+        runCurrent()
+        val initialOrder = viewModel.stations.first { it.size == 4 }.map(Station::id)
+
+        viewModel.play(worldwide, listOf(worldwide, radio4, kool, radio1Dance))
+        viewModel.play(radio4, listOf(worldwide, radio4, kool, radio1Dance))
+        stationRows.value = listOf(worldwide, radio4.copy(lastPlayedAt = 5_000), kool, radio1Dance)
+        runCurrent()
+
+        assertEquals(initialOrder, viewModel.stations.value.map(Station::id))
+    }
+
+    @Test
+    fun returningToFavoritesRefreshesLastPlayedOrderFromLatestRows() = runTest {
+        val worldwide = station(1, "Worldwide FM", lastPlayedAt = 4_000)
+        val radio4 = station(2, "BBC Radio 4", lastPlayedAt = 3_000)
+        val rows = MutableStateFlow(listOf(worldwide, radio4))
+        val repository = mock<StationRepository>()
+        whenever(repository.getAll()).thenReturn(rows)
+        whenever(repository.recentlyPlayedAsFlow(any())).thenReturn(flowOf(emptyList()))
+        val viewModel = viewModel(repository, mock())
+        runCurrent()
+        viewModel.setFavoritesSort(FavoritesSort.LAST_PLAYED)
+        viewModel.play(worldwide, listOf(worldwide, radio4))
+        rows.value = listOf(worldwide, radio4.copy(lastPlayedAt = 5_000))
+        runCurrent()
+        assertEquals(
+            listOf(worldwide.id, radio4.id),
+            viewModel.stations.first { it.size == 2 }.map(Station::id),
+        )
+
+        viewModel.setSelectedHomeTab(0)
+        viewModel.setSelectedHomeTab(1)
+        runCurrent()
+
+        assertEquals(
+            listOf(radio4.id, worldwide.id),
+            viewModel.stations.first { it.size == 2 && it.first().id == radio4.id }.map(Station::id),
         )
     }
 

--- a/app/src/test/java/com/shapeshed/aerial/ui/MainViewModelStateTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/ui/MainViewModelStateTest.kt
@@ -193,6 +193,30 @@ class MainViewModelStateTest {
     }
 
     @Test
+    fun changingFavoritesSortUpdatesTheActivePlaybackQueue() = runTest {
+        val alpha = station(1, "Alpha", lastPlayedAt = 1_000)
+        val bravo = station(2, "Bravo", lastPlayedAt = 3_000)
+        val repository = mock<StationRepository>()
+        whenever(repository.getAll()).thenReturn(flowOf(listOf(alpha, bravo)))
+        whenever(repository.recentlyPlayedAsFlow(any())).thenReturn(flowOf(emptyList()))
+        val viewModel = viewModel(repository, mock())
+        runCurrent()
+
+        viewModel.handlePlaybackEvents(
+            mediaItem(alpha.name, alpha.id.toString()),
+            isPlaying = true,
+            queue = listOf(alpha, bravo),
+        )
+        viewModel.setFavoritesSort(FavoritesSort.LAST_PLAYED)
+        runCurrent()
+
+        assertEquals(
+            listOf(bravo.id, alpha.id),
+            viewModel.playbackUiState.value.queue.map(Station::id),
+        )
+    }
+
+    @Test
     fun recentlyPlayedFlowResolvesRegistryEntriesForHomepage() = runTest {
         val entry = PlayHistoryEntry("test", "mango", 5_000L)
         val registryStation = registry("Mango Radio")

--- a/app/src/test/java/com/shapeshed/aerial/ui/MainViewModelStateTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/ui/MainViewModelStateTest.kt
@@ -326,7 +326,7 @@ class MainViewModelStateTest {
         val viewModel = viewModel(repository, registryRepository, artworkLoader = artworkLoader)
 
         viewModel.addFromRegistry(registry("Mango Radio").copy(logoUrl = "https://example.test/mango.png"))
-        runCurrent()
+        viewModel.recentlyAddedStationId.first { it == 42L }
 
         assertEquals("https://example.test/mango.png", artworkLoader.url)
         verify(repository).insertOrGetExisting(argThat { logoPath == "/tmp/aerial-logo.png" })

--- a/app/src/test/java/com/shapeshed/aerial/ui/PlaylistReorderTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/ui/PlaylistReorderTest.kt
@@ -1,0 +1,20 @@
+package com.shapeshed.aerial.ui
+
+import androidx.media3.common.Player
+import com.shapeshed.aerial.data.Station
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class PlaylistReorderTest {
+    @Test
+    fun reorderingFavoritesMovesExistingItemsWithoutReplacingPlaylist() {
+        val alpha = Station(id = 1, name = "Alpha", streamUrl = "https://example.test/a")
+        val bravo = Station(id = 2, name = "Bravo", streamUrl = "https://example.test/b")
+        val player = mock<Player>()
+
+        reorderPlayerPlaylist(player, listOf(alpha, bravo), listOf(bravo, alpha))
+
+        verify(player).moveMediaItem(1, 0)
+    }
+}


### PR DESCRIPTION
## Summary
- refresh the active favorites playback queue when the favorites sort changes
- keep Media3 next/previous navigation aligned with the visible favorites order
- preserve the current station and playback position

## Tests
- added a regression test that fails with the old queue behavior
- `./gradlew test lint`

Fixes the favorites mini-player/navigation sort regression.