### PR TITLE
fix(i18n): complete translated resource coverage

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -122,4 +122,17 @@
     <string name="recently_played">Zuletzt gespielt</string>
     <string name="favorite_removed_message">%1$s aus Favoriten entfernt</string>
     <string name="undo">Rückgängig</string>
+    <string name="backup_exported">Backup exportiert</string>
+    <string name="backup_export_failed">Backup konnte nicht exportiert werden</string>
+    <string name="backup_import_failed">Backup konnte nicht importiert werden</string>
+    <plurals name="backup_imported">
+        <item quantity="one">%1$d Sender und Einstellungen importiert</item>
+        <item quantity="other">%1$d Sender und Einstellungen importiert</item>
+    </plurals>
+    <string name="next_station">Nächster Sender</string>
+    <string name="playback_connection_failed">Verbindung fehlgeschlagen</string>
+    <string name="playback_failed">Wiedergabe fehlgeschlagen</string>
+    <string name="playback_format_unsupported">Streamformat nicht unterstützt</string>
+    <string name="previous_station">Vorheriger Sender</string>
+    <string name="station_options">Senderoptionen</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -125,4 +125,17 @@
     <string name="recently_played">Reproducidos recientemente</string>
     <string name="favorite_removed_message">%1$s eliminado de favoritos</string>
     <string name="undo">Deshacer</string>
+    <string name="backup_exported">Copia de seguridad exportada</string>
+    <string name="backup_export_failed">No se pudo exportar la copia de seguridad</string>
+    <string name="backup_import_failed">No se pudo importar la copia de seguridad</string>
+    <plurals name="backup_imported">
+        <item quantity="one">Se importó %1$d emisora y la configuración</item>
+        <item quantity="other">Se importaron %1$d emisoras y la configuración</item>
+    </plurals>
+    <string name="next_station">Siguiente emisora</string>
+    <string name="playback_connection_failed">Error de conexión</string>
+    <string name="playback_failed">Error de reproducción</string>
+    <string name="playback_format_unsupported">Formato de emisión no compatible</string>
+    <string name="previous_station">Emisora anterior</string>
+    <string name="station_options">Opciones de la emisora</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -116,4 +116,17 @@
     <string name="recently_played">Hiljuti esitatud</string>
     <string name="favorite_removed_message">%1$s eemaldati lemmikutest</string>
     <string name="undo">Võta tagasi</string>
+    <string name="backup_exported">Varukoopia eksporditud</string>
+    <string name="backup_export_failed">Varukoopia eksportimine ebaõnnestus</string>
+    <string name="backup_import_failed">Varukoopia importimine ebaõnnestus</string>
+    <plurals name="backup_imported">
+        <item quantity="one">Imporditi %1$d jaam ja seaded</item>
+        <item quantity="other">Imporditi %1$d jaama ja seaded</item>
+    </plurals>
+    <string name="next_station">Järgmine jaam</string>
+    <string name="playback_connection_failed">Ühendus ebaõnnestus</string>
+    <string name="playback_failed">Taasesitus ebaõnnestus</string>
+    <string name="playback_format_unsupported">Voo vormingut ei toetata</string>
+    <string name="previous_station">Eelmine jaam</string>
+    <string name="station_options">Jaama valikud</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -125,4 +125,17 @@
     <string name="recently_played">Écouté récemment</string>
     <string name="favorite_removed_message">%1$s retirée des favoris</string>
     <string name="undo">Annuler</string>
+    <string name="backup_exported">Sauvegarde exportée</string>
+    <string name="backup_export_failed">Impossible d’exporter la sauvegarde</string>
+    <string name="backup_import_failed">Impossible d’importer la sauvegarde</string>
+    <plurals name="backup_imported">
+        <item quantity="one">%1$d station et les réglages importés</item>
+        <item quantity="other">%1$d stations et les réglages importés</item>
+    </plurals>
+    <string name="next_station">Station suivante</string>
+    <string name="playback_connection_failed">Échec de la connexion</string>
+    <string name="playback_failed">Échec de la lecture</string>
+    <string name="playback_format_unsupported">Format du flux non compatible</string>
+    <string name="previous_station">Station précédente</string>
+    <string name="station_options">Options de la station</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -114,4 +114,19 @@
     <string name="no_favorites_desc">अपने पसंदीदा स्टेशन जोड़ें ताकि उन्हें यहाँ आसानी से ढूँढा जा सके</string>
     <string name="car_moods">मूडज़</string>
     <string name="recently_played">हाल ही में चलाए गए</string>
+    <string name="favorite_removed_message">%1$s को पसंदीदा से हटा दिया गया</string>
+    <string name="undo">पहले जैसा करें</string>
+    <string name="backup_exported">बैकअप एक्सपोर्ट हो गया</string>
+    <string name="backup_export_failed">बैकअप एक्सपोर्ट नहीं हो सका</string>
+    <string name="backup_import_failed">बैकअप इम्पोर्ट नहीं हो सका</string>
+    <plurals name="backup_imported">
+        <item quantity="one">%1$d स्टेशन और सेटिंग इम्पोर्ट की गईं</item>
+        <item quantity="other">%1$d स्टेशन और सेटिंग इम्पोर्ट की गईं</item>
+    </plurals>
+    <string name="next_station">अगला स्टेशन</string>
+    <string name="playback_connection_failed">कनेक्शन विफल</string>
+    <string name="playback_failed">प्लेबैक विफल</string>
+    <string name="playback_format_unsupported">स्ट्रीम फ़ॉर्मैट समर्थित नहीं है</string>
+    <string name="previous_station">पिछला स्टेशन</string>
+    <string name="station_options">स्टेशन विकल्प</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -125,4 +125,17 @@
     <string name="recently_played">Ascoltati di recente</string>
     <string name="favorite_removed_message">%1$s rimosso dai preferiti</string>
     <string name="undo">Annulla</string>
+    <string name="backup_exported">Backup esportato</string>
+    <string name="backup_export_failed">Impossibile esportare il backup</string>
+    <string name="backup_import_failed">Impossibile importare il backup</string>
+    <plurals name="backup_imported">
+        <item quantity="one">Importata %1$d stazione e le impostazioni</item>
+        <item quantity="other">Importate %1$d stazioni e le impostazioni</item>
+    </plurals>
+    <string name="next_station">Stazione successiva</string>
+    <string name="playback_connection_failed">Connessione non riuscita</string>
+    <string name="playback_failed">Riproduzione non riuscita</string>
+    <string name="playback_format_unsupported">Formato del flusso non supportato</string>
+    <string name="previous_station">Stazione precedente</string>
+    <string name="station_options">Opzioni della stazione</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -119,4 +119,16 @@
     <string name="recently_played">最近再生</string>
     <string name="favorite_removed_message">%1$sをお気に入りから削除しました</string>
     <string name="undo">元に戻す</string>
+    <string name="backup_exported">バックアップをエクスポートしました</string>
+    <string name="backup_export_failed">バックアップをエクスポートできませんでした</string>
+    <string name="backup_import_failed">バックアップをインポートできませんでした</string>
+    <plurals name="backup_imported">
+        <item quantity="other">%1$d局と設定をインポートしました</item>
+    </plurals>
+    <string name="next_station">次の放送局</string>
+    <string name="playback_connection_failed">接続に失敗しました</string>
+    <string name="playback_failed">再生に失敗しました</string>
+    <string name="playback_format_unsupported">ストリーム形式に対応していません</string>
+    <string name="previous_station">前の放送局</string>
+    <string name="station_options">放送局のオプション</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -119,4 +119,16 @@
     <string name="recently_played">최근 재생</string>
     <string name="favorite_removed_message">%1$s을(를) 즐겨찾기에서 삭제했습니다</string>
     <string name="undo">실행 취소</string>
+    <string name="backup_exported">백업을 내보냈습니다</string>
+    <string name="backup_export_failed">백업을 내보낼 수 없습니다</string>
+    <string name="backup_import_failed">백업을 가져올 수 없습니다</string>
+    <plurals name="backup_imported">
+        <item quantity="other">방송국 %1$d개와 설정을 가져왔습니다</item>
+    </plurals>
+    <string name="next_station">다음 방송국</string>
+    <string name="playback_connection_failed">연결 실패</string>
+    <string name="playback_failed">재생 실패</string>
+    <string name="playback_format_unsupported">지원되지 않는 스트림 형식</string>
+    <string name="previous_station">이전 방송국</string>
+    <string name="station_options">방송국 옵션</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -122,4 +122,17 @@
     <string name="recently_played">Laatst afgespeeld</string>
     <string name="favorite_removed_message">%1$s verwijderd uit favorieten</string>
     <string name="undo">Ongedaan maken</string>
+    <string name="backup_exported">Back-up geëxporteerd</string>
+    <string name="backup_export_failed">Back-up exporteren mislukt</string>
+    <string name="backup_import_failed">Back-up importeren mislukt</string>
+    <plurals name="backup_imported">
+        <item quantity="one">%1$d zender en instellingen geïmporteerd</item>
+        <item quantity="other">%1$d zenders en instellingen geïmporteerd</item>
+    </plurals>
+    <string name="next_station">Volgende zender</string>
+    <string name="playback_connection_failed">Verbinding mislukt</string>
+    <string name="playback_failed">Afspelen mislukt</string>
+    <string name="playback_format_unsupported">Streamformaat wordt niet ondersteund</string>
+    <string name="previous_station">Vorige zender</string>
+    <string name="station_options">Zenderopties</string>
 </resources>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -114,4 +114,19 @@
     <string name="no_favorites_desc">ਆਪਣੇ ਮਨਪਸੰਦ ਸਟੇਸ਼ਨਾਂ ਨੂੰ ਇੱਥੇ ਆਸਾਨੀ ਨਾਲ ਲੱਭਣ ਲਈ ਉਹਨਾਂ ਨੂੰ ਸ਼ਾਮਿਲ ਕਰੋ</string>
     <string name="car_moods">ਮੂਡਜ਼</string>
     <string name="recently_played">ਹਾਲ ਹੀ ਵਿੱਚ ਚਲਾਏ ਗਏ</string>
+    <string name="favorite_removed_message">%1$s ਨੂੰ ਮਨਪਸੰਦ ਵਿੱਚੋਂ ਹਟਾ ਦਿੱਤਾ ਗਿਆ</string>
+    <string name="undo">ਵਾਪਸ ਕਰੋ</string>
+    <string name="backup_exported">ਬੈਕਅੱਪ ਐਕਸਪੋਰਟ ਹੋ ਗਿਆ</string>
+    <string name="backup_export_failed">ਬੈਕਅੱਪ ਐਕਸਪੋਰਟ ਨਹੀਂ ਹੋ ਸਕਿਆ</string>
+    <string name="backup_import_failed">ਬੈਕਅੱਪ ਇੰਪੋਰਟ ਨਹੀਂ ਹੋ ਸਕਿਆ</string>
+    <plurals name="backup_imported">
+        <item quantity="one">%1$d ਸਟੇਸ਼ਨ ਅਤੇ ਸੈਟਿੰਗਾਂ ਇੰਪੋਰਟ ਕੀਤੀਆਂ</item>
+        <item quantity="other">%1$d ਸਟੇਸ਼ਨ ਅਤੇ ਸੈਟਿੰਗਾਂ ਇੰਪੋਰਟ ਕੀਤੀਆਂ</item>
+    </plurals>
+    <string name="next_station">ਅਗਲਾ ਸਟੇਸ਼ਨ</string>
+    <string name="playback_connection_failed">ਕਨੈਕਸ਼ਨ ਅਸਫਲ</string>
+    <string name="playback_failed">ਪਲੇਬੈਕ ਅਸਫਲ</string>
+    <string name="playback_format_unsupported">ਸਟ੍ਰੀਮ ਫਾਰਮੈਟ ਸਮਰਥਿਤ ਨਹੀਂ</string>
+    <string name="previous_station">ਪਿਛਲਾ ਸਟੇਸ਼ਨ</string>
+    <string name="station_options">ਸਟੇਸ਼ਨ ਵਿਕਲਪ</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -126,4 +126,17 @@
     <string name="recently_played">Reproduzidos recentemente</string>
     <string name="favorite_removed_message">%1$s removida dos favoritos</string>
     <string name="undo">Desfazer</string>
+    <string name="backup_exported">Backup exportado</string>
+    <string name="backup_export_failed">Não foi possível exportar o backup</string>
+    <string name="backup_import_failed">Não foi possível importar o backup</string>
+    <plurals name="backup_imported">
+        <item quantity="one">%1$d estação e definições importadas</item>
+        <item quantity="other">%1$d estações e definições importadas</item>
+    </plurals>
+    <string name="next_station">Estação seguinte</string>
+    <string name="playback_connection_failed">Falha na ligação</string>
+    <string name="playback_failed">Falha na reprodução</string>
+    <string name="playback_format_unsupported">Formato de transmissão não suportado</string>
+    <string name="previous_station">Estação anterior</string>
+    <string name="station_options">Opções da estação</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -122,4 +122,19 @@
     <string name="recently_played">Недавно прослушанные</string>
     <string name="favorite_removed_message">%1$s удалена из избранного</string>
     <string name="undo">Отменить</string>
+    <string name="backup_exported">Резервная копия экспортирована</string>
+    <string name="backup_export_failed">Не удалось экспортировать резервную копию</string>
+    <string name="backup_import_failed">Не удалось импортировать резервную копию</string>
+    <plurals name="backup_imported">
+        <item quantity="one">Импортирована %1$d станция и настройки</item>
+        <item quantity="few">Импортировано %1$d станции и настройки</item>
+        <item quantity="many">Импортировано %1$d станций и настройки</item>
+        <item quantity="other">Импортировано %1$d станции и настройки</item>
+    </plurals>
+    <string name="next_station">Следующая станция</string>
+    <string name="playback_connection_failed">Ошибка подключения</string>
+    <string name="playback_failed">Ошибка воспроизведения</string>
+    <string name="playback_format_unsupported">Формат потока не поддерживается</string>
+    <string name="previous_station">Предыдущая станция</string>
+    <string name="station_options">Параметры станции</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -116,4 +116,17 @@
     <string name="recently_played">Son oynatılanlar</string>
     <string name="favorite_removed_message">%1$s favorilerden kaldırıldı</string>
     <string name="undo">Geri al</string>
+    <string name="backup_exported">Yedek dışa aktarıldı</string>
+    <string name="backup_export_failed">Yedek dışa aktarılamadı</string>
+    <string name="backup_import_failed">Yedek içe aktarılamadı</string>
+    <plurals name="backup_imported">
+        <item quantity="one">%1$d istasyon ve ayar içe aktarıldı</item>
+        <item quantity="other">%1$d istasyon ve ayar içe aktarıldı</item>
+    </plurals>
+    <string name="next_station">Sonraki istasyon</string>
+    <string name="playback_connection_failed">Bağlantı başarısız</string>
+    <string name="playback_failed">Oynatma başarısız</string>
+    <string name="playback_format_unsupported">Akış biçimi desteklenmiyor</string>
+    <string name="previous_station">Önceki istasyon</string>
+    <string name="station_options">İstasyon seçenekleri</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -119,4 +119,16 @@
     <string name="recently_played">最近播放</string>
     <string name="favorite_removed_message">已从收藏中移除 %1$s</string>
     <string name="undo">撤销</string>
+    <string name="backup_exported">备份已导出</string>
+    <string name="backup_export_failed">无法导出备份</string>
+    <string name="backup_import_failed">无法导入备份</string>
+    <plurals name="backup_imported">
+        <item quantity="other">已导入 %1$d 个电台和设置</item>
+    </plurals>
+    <string name="next_station">下一个电台</string>
+    <string name="playback_connection_failed">连接失败</string>
+    <string name="playback_failed">播放失败</string>
+    <string name="playback_format_unsupported">不支持的流格式</string>
+    <string name="previous_station">上一个电台</string>
+    <string name="station_options">电台选项</string>
 </resources>


### PR DESCRIPTION
## Summary
- add translations for all newly introduced settings, playback, and navigation strings
- complete missing Hindi and Punjabi favorite-action strings
- keep the British English resource as an intentional spelling override

## Validation
- `./gradlew lint`
- verified every base resource key exists in each supported locale
- verified no default-locale resources are unused
