### PR TITLE
chore(i18n): clean up fixed resource overrides

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Aerial</string>
     <!-- Common actions -->
     <string name="action_back">Zurück</string>
     <string name="action_remove">Entfernen</string>
@@ -57,7 +56,6 @@
     <string name="add_to_favorites">Zu Favoriten hinzufügen</string>
     <string name="share_station">Sender teilen</string>
     <string name="copy_track_info">Titelinfo kopieren</string>
-    <string name="stream_bitrate_format">%1$d kbps</string>
     <!-- Settings -->
     <string name="show_stream_bitrate">Stream-Bitrate anzeigen</string>
     <string name="show_stream_bitrate_desc">Zeigt die aktuelle Streamqualität im Player an</string>
@@ -66,7 +64,6 @@
     <string name="export_backup_desc">Speichert Sender, Einstellungen und lokale Logos</string>
     <string name="import_backup">Backup importieren</string>
     <string name="import_backup_desc">Führt Sender zusammen und stellt Einstellungen aus einem Backup wieder her</string>
-    <string name="version_format">Aerial %1$s</string>
     <string name="language">Sprache</string>
     <string name="language_system_default">Systemstandard</string>
     <!-- Station edit -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Aerial</string>
     <!-- Common actions -->
     <string name="action_back">Atrás</string>
     <string name="action_remove">Quitar</string>
@@ -57,7 +56,6 @@
     <string name="add_to_favorites">Añadir a favoritos</string>
     <string name="share_station">Compartir emisora</string>
     <string name="copy_track_info">Copiar info de la pista</string>
-    <string name="stream_bitrate_format">%1$d kbps</string>
     <!-- Settings -->
     <string name="show_stream_bitrate">Mostrar bitrate del stream</string>
     <string name="show_stream_bitrate_desc">Muestra la calidad actual del stream en el reproductor</string>
@@ -66,7 +64,6 @@
     <string name="export_backup_desc">Guarda emisoras, ajustes y logotipos locales</string>
     <string name="import_backup">Importar copia</string>
     <string name="import_backup_desc">Combina emisoras y restaura los ajustes desde una copia</string>
-    <string name="version_format">Aerial %1$s</string>
     <string name="language">Idioma</string>
     <string name="language_system_default">Predeterminado del sistema</string>
     <!-- Station edit -->

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Aerial</string>
     <string name="action_back">Tagasi</string>
     <string name="action_remove">Eemalda</string>
     <string name="action_cancel">Tühista</string>
@@ -62,8 +61,6 @@
     <string name="mood_workout_desc">Energiat jätkub lõpuni</string>
     <string name="close_player">Sulge mängija</string>
     <string name="copy_track_info">Kopeeri loo teave</string>
-    <string name="stream_bitrate_format">%1$d kbit/s</string>
-    <string name="version_format">Aerial %1$s</string>
     <string name="language">Keel</string>
     <string name="language_system_default">Süsteemi vaikeseade</string>
     <string name="edit_station">Muuda jaama</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Aerial</string>
     <!-- Common actions -->
     <string name="action_back">Retour</string>
     <string name="action_remove">Supprimer</string>
@@ -57,7 +56,6 @@
     <string name="add_to_favorites">Ajouter aux favoris</string>
     <string name="share_station">Partager la station</string>
     <string name="copy_track_info">Copier les infos du titre</string>
-    <string name="stream_bitrate_format">%1$d kbps</string>
     <!-- Settings -->
     <string name="show_stream_bitrate">Afficher le débit du flux</string>
     <string name="show_stream_bitrate_desc">Affiche la qualité actuelle du flux dans le lecteur</string>
@@ -66,7 +64,6 @@
     <string name="export_backup_desc">Enregistre les stations, les paramètres et les logos locaux</string>
     <string name="import_backup">Importer la sauvegarde</string>
     <string name="import_backup_desc">Fusionne les stations et restaure les paramètres depuis une sauvegarde</string>
-    <string name="version_format">Aerial %1$s</string>
     <string name="language">Langue</string>
     <string name="language_system_default">Par défaut du système</string>
     <!-- Station edit -->

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Aerial</string>
     <string name="action_back">पीछे जाएं</string>
     <string name="action_remove">हटाएं</string>
     <string name="action_cancel">रद्द करें</string>
@@ -55,14 +54,12 @@
     <string name="add_to_favorites">पसंदीदा में जोड़े</string>
     <string name="share_station">स्टेशन शेयर करें</string>
     <string name="copy_track_info">ट्रैक की जानकारी कॉपी करें</string>
-    <string name="stream_bitrate_format">%1$d kbps</string>
     <string name="show_stream_bitrate">स्ट्रीम बिटरेट दिखाएँ</string>
     <string name="show_stream_bitrate_desc">प्लेयर पर मौजूदा स्ट्रीम क्वालिटी दिखाएं</string>
     <string name="section_data">डेटा</string>
     <string name="export_backup">बैकअप एक्सपोर्ट करें</string>
     <string name="import_backup">बैकअप इम्पोर्ट करें</string>
     <string name="import_backup_desc">स्टेशनों को मर्ज करें और बैकअप से सेटिंग रीस्टोर करें</string>
-    <string name="version_format">Aerial %1$s</string>
     <string name="language">भाषा</string>
     <string name="language_system_default">सिस्टम डिफ़ॉल्ट</string>
     <string name="edit_station">स्टेशन एडिट करें</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Aerial</string>
     <!-- Common actions -->
     <string name="action_back">Indietro</string>
     <string name="action_remove">Rimuovi</string>
@@ -57,7 +56,6 @@
     <string name="add_to_favorites">Aggiungi ai preferiti</string>
     <string name="share_station">Condividi stazione</string>
     <string name="copy_track_info">Copia info brano</string>
-    <string name="stream_bitrate_format">%1$d kbps</string>
     <!-- Settings -->
     <string name="show_stream_bitrate">Mostra bitrate dello stream</string>
     <string name="show_stream_bitrate_desc">Mostra la qualità attuale dello stream nel player</string>
@@ -66,7 +64,6 @@
     <string name="export_backup_desc">Salva stazioni, impostazioni e loghi locali</string>
     <string name="import_backup">Importa backup</string>
     <string name="import_backup_desc">Unisce le stazioni e ripristina le impostazioni da un backup</string>
-    <string name="version_format">Aerial %1$s</string>
     <string name="language">Lingua</string>
     <string name="language_system_default">Predefinita di sistema</string>
     <!-- Station edit -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Aerial</string>
     <!-- Common actions -->
     <string name="action_back">戻る</string>
     <string name="action_remove">削除</string>
@@ -57,7 +56,6 @@
     <string name="add_to_favorites">お気に入りに追加</string>
     <string name="share_station">放送局を共有</string>
     <string name="copy_track_info">曲情報をコピー</string>
-    <string name="stream_bitrate_format">%1$d kbps</string>
     <!-- Settings -->
     <string name="show_stream_bitrate">ストリームのビットレートを表示</string>
     <string name="show_stream_bitrate_desc">プレーヤーに現在のストリーム品質を表示</string>
@@ -66,7 +64,6 @@
     <string name="export_backup_desc">放送局、設定、ローカルのロゴを保存</string>
     <string name="import_backup">バックアップを読み込む</string>
     <string name="import_backup_desc">放送局を統合し、バックアップから設定を復元</string>
-    <string name="version_format">Aerial %1$s</string>
     <string name="language">言語</string>
     <string name="language_system_default">システムのデフォルト</string>
     <!-- Station edit -->

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Aerial</string>
     <!-- Common actions -->
     <string name="action_back">뒤로</string>
     <string name="action_remove">삭제</string>
@@ -57,7 +56,6 @@
     <string name="add_to_favorites">즐겨찾기에 추가</string>
     <string name="share_station">방송국 공유</string>
     <string name="copy_track_info">트랙 정보 복사</string>
-    <string name="stream_bitrate_format">%1$d kbps</string>
     <!-- Settings -->
     <string name="show_stream_bitrate">스트림 비트레이트 표시</string>
     <string name="show_stream_bitrate_desc">플레이어에 현재 스트림 품질을 표시</string>
@@ -66,7 +64,6 @@
     <string name="export_backup_desc">방송국, 설정, 로컬 로고 저장</string>
     <string name="import_backup">백업 가져오기</string>
     <string name="import_backup_desc">백업에서 방송국을 병합하고 설정을 복원</string>
-    <string name="version_format">Aerial %1$s</string>
     <string name="language">언어</string>
     <string name="language_system_default">시스템 기본값</string>
     <!-- Station edit -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Aerial</string>
     <!-- Common actions -->
     <string name="action_back">Terug</string>
     <string name="action_remove">Verwijderen</string>
@@ -57,7 +56,6 @@
     <string name="add_to_favorites">Aan favorieten toevoegen</string>
     <string name="share_station">Zender delen</string>
     <string name="copy_track_info">Nummerinfo kopiëren</string>
-    <string name="stream_bitrate_format">%1$d kbps</string>
     <!-- Settings -->
     <string name="show_stream_bitrate">Stream-bitrate tonen</string>
     <string name="show_stream_bitrate_desc">Toont de huidige streamkwaliteit in de speler</string>
@@ -66,7 +64,6 @@
     <string name="export_backup_desc">Slaat zenders, instellingen en lokale logo\'s op</string>
     <string name="import_backup">Back-up importeren</string>
     <string name="import_backup_desc">Voegt zenders samen en herstelt instellingen uit een back-up</string>
-    <string name="version_format">Aerial %1$s</string>
     <string name="language">Taal</string>
     <string name="language_system_default">Systeemstandaard</string>
     <!-- Station edit -->

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Aerial</string>
     <string name="action_back">ਵਾਪਿਸ</string>
     <string name="action_remove">ਹਟਾਓ</string>
     <string name="action_cancel">ਰੱਦ ਕਰੋ</string>
@@ -54,7 +53,6 @@
     <string name="add_to_favorites">ਮਨਪਸੰਦ ਵਿੱਚ ਜੋੜੋ</string>
     <string name="share_station">ਸਟੇਸ਼ਨ ਸਾਂਝਾ ਕਰੋ</string>
     <string name="copy_track_info">ਟਰੈਕ ਜਾਣਕਾਰੀ ਕਾਪੀ ਕਰੋ</string>
-    <string name="stream_bitrate_format">%1$d kbps</string>
     <string name="show_stream_bitrate">ਸਟ੍ਰੀਮ ਬਿੱਟਰੇਟ ਵਿਖਾਓ</string>
     <string name="show_stream_bitrate_desc">ਪਲੇਅਰ \'ਤੇ ਮੌਜੂਦਾ ਸਟ੍ਰੀਮ ਗੁਣਵੱਤਾ ਪ੍ਰਦਰਸ਼ਿਤ ਕਰੋ</string>
     <string name="section_data">ਡੇਟਾ</string>
@@ -62,7 +60,6 @@
     <string name="export_backup_desc">ਸਟੇਸ਼ਨ, ਸੈਟਿੰਗਾਂ ਅਤੇ ਸਥਾਨਕ ਲੋਗੋ ਸੁਰੱਖਿਅਤ ਕਰੋ</string>
     <string name="import_backup">ਬੈਕਅੱਪ ਇੰਪੋਰਟ ਕਰੋ</string>
     <string name="import_backup_desc">ਸਟੇਸ਼ਨਾਂ ਨੂੰ ਮਿਲਾਓ ਅਤੇ ਬੈਕਅੱਪ ਤੋਂ ਸੈਟਿੰਗਾਂ ਨੂੰ ਰੀਸਟੋਰ ਕਰੋ</string>
-    <string name="version_format">Aerial %1$s</string>
     <string name="language">ਭਾਸ਼ਾ</string>
     <string name="language_system_default">ਸਿਸਟਮ ਡਿਫ਼ਾਲਟ</string>
     <string name="edit_station">ਸਟੇਸ਼ਨ ਸੰਪਾਦਿਤ ਕਰੋ</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Aerial</string>
     <!-- Common actions -->
     <string name="action_back">Voltar</string>
     <string name="action_remove">Remover</string>
@@ -57,7 +56,6 @@
     <string name="add_to_favorites">Adicionar aos favoritos</string>
     <string name="share_station">Compartilhar estação</string>
     <string name="copy_track_info">Copiar info da faixa</string>
-    <string name="stream_bitrate_format">%1$d kbps</string>
     <!-- Settings -->
     <string name="show_stream_bitrate">Mostrar bitrate do stream</string>
     <string name="show_stream_bitrate_desc">Exibe a qualidade atual do stream no player</string>
@@ -66,7 +64,6 @@
     <string name="export_backup_desc">Salva estações, configurações e logotipos locais</string>
     <string name="import_backup">Importar backup</string>
     <string name="import_backup_desc">Mescla estações e restaura configurações de um backup</string>
-    <string name="version_format">Aerial %1$s</string>
     <string name="language">Idioma</string>
     <string name="language_system_default">Padrão do sistema</string>
     <!-- Station edit -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Aerial</string>
     <string name="action_back">Назад</string>
     <string name="action_remove">Удалить</string>
     <string name="action_cancel">Отмена</string>
@@ -62,8 +61,6 @@
     <string name="mood_workout_desc">Энергичная музыка, чтобы не останавливаться</string>
     <string name="close_player">Закрыть плеер</string>
     <string name="copy_track_info">Копировать информацию о треке</string>
-    <string name="stream_bitrate_format">%1$d кбит/с</string>
-    <string name="version_format">Aerial %1$s</string>
     <string name="language">Язык</string>
     <string name="language_system_default">Системный язык</string>
     <string name="edit_station">Редактировать станцию</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Aerial</string>
     <string name="action_back">Geri</string>
     <string name="action_remove">Kaldır</string>
     <string name="action_cancel">İptal</string>
@@ -54,7 +53,6 @@
     <string name="add_to_favorites">Favorilere ekle</string>
     <string name="share_station">İstasyonu paylaş</string>
     <string name="copy_track_info">Parça bilgilerini kopyala</string>
-    <string name="stream_bitrate_format">%1$d kb/sn</string>
     <string name="show_stream_bitrate">Yayın bit hızını göster</string>
     <string name="show_stream_bitrate_desc">Oynatıcıda mevcut yayın kalitesini gösterir</string>
     <string name="section_data">Veri</string>
@@ -62,7 +60,6 @@
     <string name="export_backup_desc">İstasyonları, ayarları ve yerel logoları kaydeder</string>
     <string name="import_backup">Yedeklemeyi içe aktar</string>
     <string name="import_backup_desc">İstasyonları birleştirir ve ayarları yedekten geri yükler</string>
-    <string name="version_format">Aerial %1$s</string>
     <string name="language">Dil</string>
     <string name="language_system_default">Sistem varsayılanı</string>
     <string name="edit_station">İstasyonu düzenle</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Aerial</string>
     <!-- Common actions -->
     <string name="action_back">返回</string>
     <string name="action_remove">移除</string>
@@ -57,7 +56,6 @@
     <string name="add_to_favorites">添加到收藏</string>
     <string name="share_station">分享电台</string>
     <string name="copy_track_info">复制曲目信息</string>
-    <string name="stream_bitrate_format">%1$d kbps</string>
     <!-- Settings -->
     <string name="show_stream_bitrate">显示流比特率</string>
     <string name="show_stream_bitrate_desc">在播放器中显示当前流质量</string>
@@ -66,7 +64,6 @@
     <string name="export_backup_desc">保存电台、设置和本地徽标</string>
     <string name="import_backup">导入备份</string>
     <string name="import_backup_desc">从备份合并电台并恢复设置</string>
-    <string name="version_format">Aerial %1$s</string>
     <string name="language">语言</string>
     <string name="language_system_default">系统默认</string>
     <!-- Station edit -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:locale="en">
-    <string name="app_name">Aerial</string>
+    <string name="app_name" translatable="false">Aerial</string>
     <!-- Common actions -->
     <string name="action_back">Back</string>
     <string name="action_remove">Remove</string>
@@ -59,7 +59,7 @@
     <string name="add_to_favorites">Add to favorites</string>
     <string name="share_station">Share station</string>
     <string name="copy_track_info">Copy track info</string>
-    <string name="stream_bitrate_format">%1$d kbps</string>
+    <string name="stream_bitrate_format" translatable="false">%1$d kbps</string>
     <!-- Settings -->
     <string name="show_stream_bitrate">Show stream bitrate</string>
     <string name="show_stream_bitrate_desc">Display the current stream quality on the player</string>
@@ -75,7 +75,7 @@
         <item quantity="one">Imported %1$d station and settings</item>
         <item quantity="other">Imported %1$d stations and settings</item>
     </plurals>
-    <string name="version_format">Aerial %1$s</string>
+    <string name="version_format" translatable="false">Aerial %1$s</string>
     <string name="language">Language</string>
     <string name="language_system_default">System default</string>
     <!-- Station edit -->


### PR DESCRIPTION
## Summary
- mark the app name, bitrate format, and version format as non-translatable
- remove redundant locale overrides for those fixed resources
- prevent Weblate from counting intentional unchanged values as untranslated

## Validation
- `./gradlew lint`
- all locale XML files parse successfully
