### PR TITLE
Hide skip controls for single-station queues

### DIFF
--- a/app/src/androidTest/java/com/shapeshed/aerial/MediaSessionQueueExpansionTest.kt
+++ b/app/src/androidTest/java/com/shapeshed/aerial/MediaSessionQueueExpansionTest.kt
@@ -2,13 +2,73 @@ package com.shapeshed.aerial
 
 import androidx.media3.common.MediaItem
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class MediaSessionQueueExpansionTest {
+    @Test
+    fun notificationSkipCommandsAreHiddenForSingleItemQueue() = runBlocking {
+        withContext(Dispatchers.Main) {
+            val context = androidx.test.core.app.ApplicationProvider.getApplicationContext<AerialApp>()
+            val player = androidx.media3.exoplayer.ExoPlayer.Builder(context).build()
+            try {
+                player.repeatMode = androidx.media3.common.Player.REPEAT_MODE_ALL
+                player.setMediaItem(item("station-1"))
+
+                val sessionPlayer = createSessionPlayer(player)
+
+                assertEquals(false, sessionPlayer.isCommandAvailable(
+                    androidx.media3.common.Player.COMMAND_SEEK_TO_PREVIOUS,
+                ))
+                assertEquals(false, sessionPlayer.isCommandAvailable(
+                    androidx.media3.common.Player.COMMAND_SEEK_TO_NEXT,
+                ))
+                assertEquals(false, sessionPlayer.availableCommands.contains(
+                    androidx.media3.common.Player.COMMAND_SEEK_TO_PREVIOUS,
+                ))
+                assertEquals(false, sessionPlayer.availableCommands.contains(
+                    androidx.media3.common.Player.COMMAND_SEEK_TO_NEXT,
+                ))
+            } finally {
+                player.release()
+            }
+        }
+    }
+
+    @Test
+    fun notificationSkipCommandsRemainAvailableForMultiItemQueue() = runBlocking {
+        withContext(Dispatchers.Main) {
+            val context = androidx.test.core.app.ApplicationProvider.getApplicationContext<AerialApp>()
+            val player = androidx.media3.exoplayer.ExoPlayer.Builder(context).build()
+            try {
+                player.repeatMode = androidx.media3.common.Player.REPEAT_MODE_ALL
+                player.setMediaItems(listOf(item("station-1"), item("station-2")))
+
+                val sessionPlayer = createSessionPlayer(player)
+
+                assertEquals(true, sessionPlayer.isCommandAvailable(
+                    androidx.media3.common.Player.COMMAND_SEEK_TO_PREVIOUS,
+                ))
+                assertEquals(true, sessionPlayer.isCommandAvailable(
+                    androidx.media3.common.Player.COMMAND_SEEK_TO_NEXT,
+                ))
+                assertEquals(true, sessionPlayer.availableCommands.contains(
+                    androidx.media3.common.Player.COMMAND_SEEK_TO_PREVIOUS,
+                ))
+                assertEquals(true, sessionPlayer.availableCommands.contains(
+                    androidx.media3.common.Player.COMMAND_SEEK_TO_NEXT,
+                ))
+            } finally {
+                player.release()
+            }
+        }
+    }
+
     @Test
     fun browseControllerGetsFreshSiblingQueueAndTappedIndex() = runBlocking {
         val tapped = item("station-2")
@@ -50,5 +110,8 @@ class MediaSessionQueueExpansionTest {
         assertEquals(-1, result.startIndex)
     }
 
-    private fun item(id: String) = MediaItem.Builder().setMediaId(id).build()
+    private fun item(id: String) = MediaItem.Builder()
+        .setMediaId(id)
+        .setUri("https://example.invalid/$id")
+        .build()
 }

--- a/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
+++ b/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
@@ -763,6 +763,7 @@ internal fun createSessionPlayer(player: Player): Player = object : ForwardingPl
 private fun Int.isSkipCommandAvailableFor(mediaItemCount: Int): Boolean =
     mediaItemCount > 1 || this !in SKIP_COMMANDS
 
+@OptIn(UnstableApi::class)
 private fun Player.Commands.withoutSkipCommandsFor(mediaItemCount: Int): Player.Commands =
     if (mediaItemCount > 1) {
         this

--- a/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
+++ b/app/src/main/java/com/shapeshed/aerial/PlayerService.kt
@@ -183,10 +183,7 @@ class PlayerService : MediaLibraryService() {
         // radio those generic methods can restart the current item instead of moving through the
         // playlist. Expose a forwarding player to the session so those calls always navigate by
         // media item; the service continues to use the ExoPlayer instance directly.
-        sessionPlayer = object : ForwardingPlayer(player) {
-            override fun seekToPrevious() = seekToPreviousMediaItem()
-            override fun seekToNext() = seekToNextMediaItem()
-        }
+        sessionPlayer = createSessionPlayer(player)
         mediaSession = MediaLibrarySession.Builder(this, sessionPlayer, librarySessionCallback)
             .setSessionActivity(pendingIntent())
             .setMediaButtonPreferences(listOf(favoriteButton(null)))
@@ -745,6 +742,40 @@ class PlayerService : MediaLibraryService() {
         const val HTTP_TIMEOUT_MS = 8_000
     }
 }
+
+@OptIn(UnstableApi::class)
+internal fun createSessionPlayer(player: Player): Player = object : ForwardingPlayer(player) {
+    override fun seekToPrevious() = seekToPreviousMediaItem()
+    override fun seekToNext() = seekToNextMediaItem()
+
+    // Repeat-all is intentional for station queues, but it also makes a one-item timeline
+    // report next/previous as available. That causes redundant controls to appear in the
+    // notification and on the lock screen, where both actions would only restart the same
+    // station.
+    override fun isCommandAvailable(command: Int): Boolean =
+        command.isSkipCommandAvailableFor(player.mediaItemCount) &&
+            super.isCommandAvailable(command)
+
+    override fun getAvailableCommands(): Player.Commands =
+        super.getAvailableCommands().withoutSkipCommandsFor(player.mediaItemCount)
+}
+
+private fun Int.isSkipCommandAvailableFor(mediaItemCount: Int): Boolean =
+    mediaItemCount > 1 || this !in SKIP_COMMANDS
+
+private fun Player.Commands.withoutSkipCommandsFor(mediaItemCount: Int): Player.Commands =
+    if (mediaItemCount > 1) {
+        this
+    } else {
+        buildUpon().removeAll(*SKIP_COMMANDS).build()
+    }
+
+private val SKIP_COMMANDS = intArrayOf(
+    Player.COMMAND_SEEK_TO_PREVIOUS,
+    Player.COMMAND_SEEK_TO_NEXT,
+    Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
+    Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
+)
 
 /** Re-prepares a failed item without replacing the player's timeline. */
 @OptIn(UnstableApi::class)


### PR DESCRIPTION
Fixes #212. Hide Previous and Next media-session commands when the active queue contains only one station; keep both controls available for multi-station queues. Tests: ./gradlew connectedDeviceTestAndroidTest