### PR TITLE
fix(favorites): space list items

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/ui/FavoritesContent.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/FavoritesContent.kt
@@ -120,7 +120,7 @@ internal fun FavoritesTabContent(
             verticalArrangement = if (homeViewMode == HomeViewMode.Cards) {
                 Arrangement.spacedBy(16.dp)
             } else {
-                Arrangement.Top
+                Arrangement.spacedBy(8.dp)
             },
             contentPadding = PaddingValues(
                 start = 16.dp,


### PR DESCRIPTION
## Summary
- add 8dp spacing between Favorites list rows to match Booth
- keep the existing 16dp grid spacing unchanged

## Validation
- ./gradlew compileDebugKotlin
- ./gradlew installDebug