### PR TITLE
fix(ui): improve station grid titles and artwork

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/ui/FavoritesContent.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/FavoritesContent.kt
@@ -40,6 +40,13 @@ internal fun favoritesGridMinimumWidth(maxWidth: Dp): Dp = when {
     else -> 112.dp
 }
 
+internal fun shouldShowStationActivityIndicator(
+    showActivityIndicator: Boolean,
+    isActive: Boolean,
+    isPlaying: Boolean,
+    isBuffering: Boolean,
+): Boolean = showActivityIndicator && isActive && (isPlaying || isBuffering)
+
 @Composable
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 internal fun FavoritesTabContent(
@@ -455,6 +462,12 @@ private fun StationTile(
 ) {
     val haptic = LocalHapticFeedback.current
     val stationOptionsLabel = stringResource(R.string.station_options)
+    val hasActivityIndicator = shouldShowStationActivityIndicator(
+        showActivityIndicator = showActivityIndicator,
+        isActive = isActive,
+        isPlaying = isPlaying,
+        isBuffering = isBuffering,
+    )
     val cardColor = if (isActive) MaterialTheme.colorScheme.surfaceContainerHigh
     else MaterialTheme.colorScheme.surfaceContainerLow
     Surface(
@@ -501,14 +514,16 @@ private fun StationTile(
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier
+                    .weight(1f)
+                    .then(if (isPlaying) Modifier.safeMarquee() else Modifier),
             )
-            Spacer(Modifier.width(8.dp))
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier.size(width = 24.dp, height = 20.dp),
-            ) {
-                if (showActivityIndicator && isActive && (isPlaying || isBuffering)) {
+            if (hasActivityIndicator) {
+                Spacer(Modifier.width(8.dp))
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.size(width = 24.dp, height = 20.dp),
+                ) {
                     if (isBuffering) {
                         CircularWavyProgressIndicator(
                             modifier = Modifier.size(20.dp),

--- a/app/src/main/java/com/shapeshed/aerial/ui/LogoFiles.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/LogoFiles.kt
@@ -399,7 +399,26 @@ private fun Bitmap.hasCircularArtwork(): Boolean {
             averageCorner,
         ) > 0.20f
     }
-    return cornersMatch && contrastingEdges >= 2
+    return looksLikeCircularArtwork(
+        transparentCorners = transparentCorners,
+        cornersMatch = cornersMatch,
+        contrastingEdges = contrastingEdges,
+    )
+}
+
+/**
+ * Opaque circular marks should reach the artwork on all four cardinal edges. Requiring only two
+ * contrasting edges misclassifies full-bleed square artwork with a horizontal or vertical band
+ * as circular, which causes its corners to be clipped in the grid.
+ */
+internal fun looksLikeCircularArtwork(
+    transparentCorners: Int,
+    cornersMatch: Boolean,
+    contrastingEdges: Int,
+): Boolean = if (transparentCorners == 4) {
+    contrastingEdges >= 2
+} else {
+    cornersMatch && contrastingEdges >= 3
 }
 
 private fun colorDistance(first: FloatArray, second: FloatArray): Float =

--- a/app/src/test/java/com/shapeshed/aerial/ui/FavoritesContentTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/ui/FavoritesContentTest.kt
@@ -1,0 +1,44 @@
+package com.shapeshed.aerial.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FavoritesContentTest {
+
+    @Test
+    fun stationActivityIndicatorOnlyReservesSpaceWhenVisible() {
+        assertFalse(
+            shouldShowStationActivityIndicator(
+                showActivityIndicator = true,
+                isActive = false,
+                isPlaying = false,
+                isBuffering = false,
+            ),
+        )
+        assertFalse(
+            shouldShowStationActivityIndicator(
+                showActivityIndicator = true,
+                isActive = true,
+                isPlaying = false,
+                isBuffering = false,
+            ),
+        )
+        assertTrue(
+            shouldShowStationActivityIndicator(
+                showActivityIndicator = true,
+                isActive = true,
+                isPlaying = true,
+                isBuffering = false,
+            ),
+        )
+        assertTrue(
+            shouldShowStationActivityIndicator(
+                showActivityIndicator = true,
+                isActive = true,
+                isPlaying = false,
+                isBuffering = true,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/shapeshed/aerial/ui/LogoFilesTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/ui/LogoFilesTest.kt
@@ -12,4 +12,36 @@ class LogoFilesTest {
             mediaArtworkFileForSystem(File("/tmp/bbc-radio-1.svg")),
         )
     }
+
+    @Test
+    fun opaqueSquareArtworkNeedsThreeContrastingEdgesToBeCircular() {
+        assertEquals(
+            false,
+            looksLikeCircularArtwork(
+                transparentCorners = 0,
+                cornersMatch = true,
+                contrastingEdges = 2,
+            ),
+        )
+        assertEquals(
+            true,
+            looksLikeCircularArtwork(
+                transparentCorners = 0,
+                cornersMatch = true,
+                contrastingEdges = 3,
+            ),
+        )
+    }
+
+    @Test
+    fun transparentCircularArtworkCanUseTwoContrastingEdges() {
+        assertEquals(
+            true,
+            looksLikeCircularArtwork(
+                transparentCorners = 4,
+                cornersMatch = false,
+                contrastingEdges = 2,
+            ),
+        )
+    }
 }


### PR DESCRIPTION
## Summary

- Give idle station titles the full available width.
- Marquee only the currently playing station title.
- Prevent opaque square station artwork from being misclassified as circular and clipped.
- Preserve transparent circular-logo handling.

## Validation

- `./gradlew test compileDebugKotlin`

Closes #204
Closes #224

## Merge order

Merge this PR first, followed by the independent playback synchronization PR for #225.