### PR TITLE
fix(playback): sync newly favorited station state

### DIFF
--- a/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
+++ b/app/src/main/java/com/shapeshed/aerial/ui/MainViewModel.kt
@@ -308,8 +308,16 @@ class MainViewModel @Inject constructor(
                     previous.firstOrNull { it.id == id }?.let { removed ->
                         setCurrentStation(removed.copy(id = 0, isFavorite = false))
                     }
-            } else if (id != null) {
+                } else if (id != null) {
                     list.firstOrNull { it.id == id }?.let(::refreshCurrentStation)
+                } else {
+                    // A station started from search or an external media control is ephemeral
+                    // until it is saved. When that save happens in another scope (including the
+                    // media service handling a notification/lock-screen action), promote the
+                    // matching persisted row so Favorites and Now Playing share its identity.
+                    val ephemeral = _ephemeralStation.value
+                    list.firstOrNull { it.isFavorite && ephemeral?.matches(it) == true }
+                        ?.let(::setCurrentStation)
                 }
                 refreshActiveFavoritesQueueForStationUpdate(list)
                 previous = list

--- a/app/src/test/java/com/shapeshed/aerial/ui/MainViewModelStateTest.kt
+++ b/app/src/test/java/com/shapeshed/aerial/ui/MainViewModelStateTest.kt
@@ -620,6 +620,37 @@ class MainViewModelStateTest {
         verify(repository).insertOrGetExisting(argThat { logoPath == "/tmp/aerial-logo.png" })
     }
 
+    @Test
+    fun addingCurrentlyPlayingRegistryStationPromotesEphemeralPlaybackToFavorite() = runTest {
+        val repository = mock<StationRepository>()
+        val registryRepository = mock<RegistryRepository>()
+        val stations = MutableStateFlow<List<Station>>(emptyList())
+        whenever(repository.getAll()).thenReturn(stations)
+        whenever(repository.recentlyPlayedAsFlow(any())).thenReturn(flowOf(emptyList()))
+        val registryStation = registry("Mango Radio")
+        val savedStation = Station(
+            id = 42L,
+            name = registryStation.name,
+            streamUrl = registryStation.streamUrl,
+            isFavorite = true,
+            provider = registryStation.provider,
+            providerId = registryStation.providerId,
+        )
+        whenever(repository.insertOrGetExisting(any())).thenReturn(savedStation.id)
+        whenever(repository.getById(savedStation.id)).thenReturn(savedStation)
+        val viewModel = viewModel(repository, registryRepository)
+
+        viewModel.playFromRegistry(registryStation)
+        assertEquals(0L, viewModel.playbackUiState.value.station?.id)
+
+        viewModel.addFromRegistry(registryStation)
+        viewModel.recentlyAddedStationId.first { it == savedStation.id }
+        stations.value = listOf(savedStation)
+        runCurrent()
+
+        assertEquals(savedStation, viewModel.playbackUiState.value.station)
+    }
+
     private fun viewModel(
         repository: StationRepository,
         registryRepository: RegistryRepository,


### PR DESCRIPTION
## Summary

- Promote an ephemeral currently playing station when it becomes a saved favorite.
- Keep the Favorites grid playing animation synchronized.
- Keep the expanded player favorite heart synchronized.
- Cover favorites added through search, notification, and lock-screen controls.

## Validation

- `./gradlew test compileDebugKotlin`

Closes #225

## Merge order

Merge after PR #227, which addresses the related UI behavior in #204 and #224. The changes are technically independent, but this order keeps the UI and playback fixes grouped logically.